### PR TITLE
Fix MIDI action dispatch and correct Möbius preset name

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -100,7 +100,7 @@
             "type": "load_preset",
             "params": {
                 "deck_id": "A",
-                "preset_name": "Mobius Band",
+                "preset_name": "Möbius Band",
                 "custom_values": ""
             },
             "midi": "note_on_ch0_note42"
@@ -253,7 +253,7 @@
             "type": "load_preset",
             "params": {
                 "deck_id": "B",
-                "preset_name": "Mobius Band",
+                "preset_name": "Möbius Band",
                 "custom_values": ""
             },
             "midi": "note_on_ch0_note60"


### PR DESCRIPTION
## Summary
- route MIDI mapped actions through Qt signal for thread-safe execution
- remove QTimer usage in MIDI callbacks to restore real-time mapping
- fix Möbius Band preset name in default settings

## Testing
- `python -m py_compile midi/midi_engine.py`
- `python test_midi_mappings.py` *(fails: ModuleNotFoundError: No module named 'PyQt6')*
- `python test_fixed_system.py` *(fails: ModuleNotFoundError: No module named 'PyQt6')*
- `python test_visual_system.py` *(fails: ModuleNotFoundError: No module named 'PyQt6')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pygame-ce; Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f4364808c8333be6572970de3c7d8