### PR TITLE
Ensure all visuals have default MIDI mappings

### DIFF
--- a/config/midi_mappings.json
+++ b/config/midi_mappings.json
@@ -89,6 +89,51 @@
     },
     "midi": "note_on_ch0_note45"
   },
+  "deck_a_preset_10": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Intro Background",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note65"
+  },
+  "deck_a_preset_11": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Intro Text ROBOTICA",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note66"
+  },
+  "deck_a_preset_12": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Vortex Particles",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note67"
+  },
+  "deck_a_preset_13": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Kaleido Tunnel",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note68"
+  },
+  "deck_a_preset_14": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Scientific Analyzer",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note69"
+  },
   "deck_a_clear": {
     "type": "load_preset",
     "params": {
@@ -241,6 +286,51 @@
       "custom_values": ""
     },
     "midi": "note_on_ch0_note63"
+  },
+  "deck_b_preset_10": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Intro Background",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note70"
+  },
+  "deck_b_preset_11": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Intro Text ROBOTICA",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note71"
+  },
+  "deck_b_preset_12": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Vortex Particles",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note72"
+  },
+  "deck_b_preset_13": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Kaleido Tunnel",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note73"
+  },
+  "deck_b_preset_14": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Scientific Analyzer",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note74"
   },
   "deck_b_clear": {
     "type": "load_preset",

--- a/create_correct_mappings.py
+++ b/create_correct_mappings.py
@@ -9,285 +9,28 @@ import os
 
 def create_correct_midi_mappings():
     """Crear mapeos MIDI correctos basados en los documentos proporcionados"""
-    
+
     print("🔧 CREANDO MAPPINGS MIDI CORRECTOS...")
-    
-    # Definir los mappings exactos según el documento midi_mappings.json
-    mappings = {
-        # DECK A PRESETS (36-45)
-        "deck_a_preset_0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Simple Test",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note36"
-        },
-        "deck_a_preset_1": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Wire Terrain",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note37"
-        },
-        "deck_a_preset_2": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Abstract Lines",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note38"
-        },
-        "deck_a_preset_3": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Geometric Particles",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note39"
-        },
-        "deck_a_preset_4": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Evolutive Particles",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note40"
-        },
-        "deck_a_preset_5": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Abstract Shapes",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note41"
-        },
-        "deck_a_preset_6": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Mobius Band",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note42"
-        },
-        "deck_a_preset_7": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Building Madness",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note43"
-        },
-        "deck_a_preset_8": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Cosmic Flow",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note44"
-        },
-        "deck_a_preset_9": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Fluid Particles",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note45"
-        },
-        "deck_a_clear": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": None,
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note46"
-        },
-        
-        # MIX ACTIONS (48-53)
-        "mix_action_0": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "10s",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note48"
-        },
-        "mix_action_1": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "B to A",
-                "duration": "10s",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note49"
-        },
-        "mix_action_2": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "5s",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note50"
-        },
-        "mix_action_3": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "B to A",
-                "duration": "5s",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note51"
-        },
-        "mix_action_4": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "500ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note52"
-        },
-        "mix_action_5": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "B to A",
-                "duration": "500ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note53"
-        },
-        
-        # DECK B PRESETS (54-63)
-        "deck_b_preset_0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Simple Test",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note54"
-        },
-        "deck_b_preset_1": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Wire Terrain",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note55"
-        },
-        "deck_b_preset_2": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Abstract Lines",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note56"
-        },
-        "deck_b_preset_3": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Geometric Particles",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note57"
-        },
-        "deck_b_preset_4": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Evolutive Particles",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note58"
-        },
-        "deck_b_preset_5": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Abstract Shapes",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note59"
-        },
-        "deck_b_preset_6": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Mobius Band",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note60"
-        },
-        "deck_b_preset_7": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Building Madness",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note61"
-        },
-        "deck_b_preset_8": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Cosmic Flow",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note62"
-        },
-        "deck_b_preset_9": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Fluid Particles",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note63"
-        },
-        "deck_b_clear": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": None,
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note64"
-        }
-    }
-    
+
+    # Cargar los mappings desde el archivo raíz
+    with open('midi_mappings.json', 'r', encoding='utf-8') as f:
+        mappings = json.load(f)
+
     # Crear directorio config si no existe
     config_dir = 'config'
     if not os.path.exists(config_dir):
         os.makedirs(config_dir)
         print(f"✅ Directorio '{config_dir}/' creado")
-    
+
     # Guardar archivo
     output_file = 'config/midi_mappings.json'
     try:
         with open(output_file, 'w', encoding='utf-8') as f:
             json.dump(mappings, f, indent=2, ensure_ascii=False)
-        
+
         print(f"✅ Archivo creado: {output_file}")
         print(f"📊 Total mappings: {len(mappings)}")
-        
+
         # Verificar algunos mappings críticos
         print(f"\n🔍 VERIFICANDO MAPPINGS CRÍTICOS:")
         critical_tests = [
@@ -297,14 +40,14 @@ def create_correct_midi_mappings():
             ("note_on_ch0_note38", "Abstract Lines", "A"),
             ("note_on_ch0_note50", "A to B", "Mix")
         ]
-        
+
         for midi_key, expected_preset, expected_deck in critical_tests:
             found = False
             for action_id, mapping_data in mappings.items():
                 if mapping_data.get('midi') == midi_key:
                     action_type = mapping_data.get('type')
                     params = mapping_data.get('params', {})
-                    
+
                     if action_type == 'load_preset':
                         deck_id = params.get('deck_id')
                         preset_name = params.get('preset_name')
@@ -320,28 +63,28 @@ def create_correct_midi_mappings():
                             print(f"   ❌ {midi_key}: Expected Mix -> {expected_preset}, got Mix -> {preset}")
                     found = True
                     break
-            
+
             if not found:
                 print(f"   ❌ {midi_key}: NOT FOUND")
-        
+
         # Mostrar resumen por deck
-        print(f"\n📋 RESUMEN POR DECK:")
-        
+        print(f"\n📋 RESUMEN POR DECK:\n")
+
         deck_a_count = len([m for m in mappings.values() if m.get('params', {}).get('deck_id') == 'A'])
         deck_b_count = len([m for m in mappings.values() if m.get('params', {}).get('deck_id') == 'B'])
         mix_count = len([m for m in mappings.values() if m.get('type') == 'crossfade_action'])
-        
+
         print(f"   🔴 Deck A: {deck_a_count} mappings")
         print(f"   🟢 Deck B: {deck_b_count} mappings")
         print(f"   🟡 Mix: {mix_count} mappings")
-        
+
         print(f"\n💡 SIGUIENTE PASO:")
         print("   1. Ejecuta debug_midi_mappings.py para verificar que todo está correcto")
         print("   2. Reinicia la aplicación")
         print("   3. Los mappings deberían funcionar correctamente ahora")
-        
+
         return True
-        
+
     except Exception as e:
         print(f"❌ Error creando archivo: {e}")
         return False

--- a/midi_mappings.json
+++ b/midi_mappings.json
@@ -89,6 +89,51 @@
     },
     "midi": "note_on_ch0_note45"
   },
+  "deck_a_preset_10": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Intro Background",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note65"
+  },
+  "deck_a_preset_11": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Intro Text ROBOTICA",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note66"
+  },
+  "deck_a_preset_12": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Vortex Particles",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note67"
+  },
+  "deck_a_preset_13": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Kaleido Tunnel",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note68"
+  },
+  "deck_a_preset_14": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Scientific Analyzer",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note69"
+  },
   "deck_a_clear": {
     "type": "load_preset",
     "params": {
@@ -241,6 +286,51 @@
       "custom_values": ""
     },
     "midi": "note_on_ch0_note63"
+  },
+  "deck_b_preset_10": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Intro Background",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note70"
+  },
+  "deck_b_preset_11": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Intro Text ROBOTICA",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note71"
+  },
+  "deck_b_preset_12": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Vortex Particles",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note72"
+  },
+  "deck_b_preset_13": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Kaleido Tunnel",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note73"
+  },
+  "deck_b_preset_14": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Scientific Analyzer",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note74"
   },
   "deck_b_clear": {
     "type": "load_preset",

--- a/midi_mappings.txt
+++ b/midi_mappings.txt
@@ -1,31 +1,41 @@
 === CONFIGURACIÓN MIDI MAPPINGS ===
 
-Total mappings: 28
+Total mappings: 38
 Fecha: 2025-08-16 13:08:36
 
 === PRESET MAPPINGS ===
-  _on_ch0_ -> Deck A: Simple Test
-  _on_ch0_ -> Deck A: Wire Terrain
-  _on_ch0_ -> Deck A: Abstract Lines
-  _on_ch0_ -> Deck A: Geometric Particles
-  _on_ch0_ -> Deck A: Evolutive Particles
-  _on_ch0_ -> Deck A: Abstract Shapes
-  _on_ch0_ -> Deck A: Mobius Band
-  _on_ch0_ -> Deck A: Building Madness
-  _on_ch0_ -> Deck A: Cosmic Flow
-  _on_ch0_ -> Deck A: Fluid Particles
-  _on_ch0_ -> Deck A: None
-  _on_ch0_ -> Deck B: Simple Test
-  _on_ch0_ -> Deck B: Wire Terrain
-  _on_ch0_ -> Deck B: Abstract Lines
-  _on_ch0_ -> Deck B: Geometric Particles
-  _on_ch0_ -> Deck B: Evolutive Particles
-  _on_ch0_ -> Deck B: Abstract Shapes
-  _on_ch0_ -> Deck B: Mobius Band
-  _on_ch0_ -> Deck B: Building Madness
-  _on_ch0_ -> Deck B: Cosmic Flow
-  _on_ch0_ -> Deck B: Fluid Particles
-  _on_ch0_ -> Deck B: None
+  note_on_ch0_note36 -> Deck A: Simple Test
+  note_on_ch0_note37 -> Deck A: Wire Terrain
+  note_on_ch0_note38 -> Deck A: Abstract Lines
+  note_on_ch0_note39 -> Deck A: Geometric Particles
+  note_on_ch0_note40 -> Deck A: Evolutive Particles
+  note_on_ch0_note41 -> Deck A: Abstract Shapes
+  note_on_ch0_note42 -> Deck A: Mobius Band
+  note_on_ch0_note43 -> Deck A: Building Madness
+  note_on_ch0_note44 -> Deck A: Cosmic Flow
+  note_on_ch0_note45 -> Deck A: Fluid Particles
+  note_on_ch0_note65 -> Deck A: Intro Background
+  note_on_ch0_note66 -> Deck A: Intro Text ROBOTICA
+  note_on_ch0_note67 -> Deck A: Vortex Particles
+  note_on_ch0_note68 -> Deck A: Kaleido Tunnel
+  note_on_ch0_note69 -> Deck A: Scientific Analyzer
+  note_on_ch0_note46 -> Deck A: None
+  note_on_ch0_note54 -> Deck B: Simple Test
+  note_on_ch0_note55 -> Deck B: Wire Terrain
+  note_on_ch0_note56 -> Deck B: Abstract Lines
+  note_on_ch0_note57 -> Deck B: Geometric Particles
+  note_on_ch0_note58 -> Deck B: Evolutive Particles
+  note_on_ch0_note59 -> Deck B: Abstract Shapes
+  note_on_ch0_note60 -> Deck B: Mobius Band
+  note_on_ch0_note61 -> Deck B: Building Madness
+  note_on_ch0_note62 -> Deck B: Cosmic Flow
+  note_on_ch0_note63 -> Deck B: Fluid Particles
+  note_on_ch0_note70 -> Deck B: Intro Background
+  note_on_ch0_note71 -> Deck B: Intro Text ROBOTICA
+  note_on_ch0_note72 -> Deck B: Vortex Particles
+  note_on_ch0_note73 -> Deck B: Kaleido Tunnel
+  note_on_ch0_note74 -> Deck B: Scientific Analyzer
+  note_on_ch0_note64 -> Deck B: None
 
 === MIX ACTIONS ===
   note_on_ch0_note48 -> A to B (10s)
@@ -34,4 +44,3 @@ Fecha: 2025-08-16 13:08:36
   note_on_ch0_note51 -> B to A (5s)
   note_on_ch0_note52 -> A to B (500ms)
   note_on_ch0_note53 -> B to A (500ms)
-

--- a/test_midi_mappings.py
+++ b/test_midi_mappings.py
@@ -94,17 +94,17 @@ def test_preset_names():
     # Check matches
     missing_presets = mapping_presets - set(available_presets)
     extra_presets = set(available_presets) - mapping_presets
-    
+
     if missing_presets:
         print(f"❌ Missing presets in visualizer_manager: {missing_presets}")
-    
+
     if extra_presets:
-        print(f"ℹ️  Extra presets in visualizer_manager: {extra_presets}")
-    
-    if not missing_presets:
-        print("✅ All mapping presets found in visualizer_manager!")
-    
-    return len(missing_presets) == 0
+        print(f"❌ Presets without MIDI mapping: {extra_presets}")
+
+    if not missing_presets and not extra_presets:
+        print("✅ All mapping presets match visualizer_manager!")
+
+    return len(missing_presets) == 0 and len(extra_presets) == 0
 
 def main():
     """Main test function"""


### PR DESCRIPTION
## Summary
- Add missing MIDI mappings for Intro Background, Intro Text ROBOTICA, and other visuals on both decks
- Load mappings from the root file when generating config to keep presets in sync
- Fail tests if any visual lacks a MIDI mapping

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pygame-ce)*
- `python create_correct_mappings.py`
- `python test_midi_mappings.py` *(fails: ModuleNotFoundError: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_68a06746544c8333bc8f695ec2d9ce6b