### PR TITLE
Add oneshot presets and MIDI mappings

### DIFF
--- a/config/midi_mappings.json
+++ b/config/midi_mappings.json
@@ -340,5 +340,41 @@
       "custom_values": ""
     },
     "midi": "note_on_ch0_note64"
+  },
+  "deck_a_preset_15": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Oneshot Character Train",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note47"
+  },
+  "deck_a_preset_16": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Oneshot Boom Explosion",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note75"
+  },
+  "deck_b_preset_15": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Oneshot Character Train",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note76"
+  },
+  "deck_b_preset_16": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Oneshot Boom Explosion",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note77"
   }
 }

--- a/config/settings.json
+++ b/config/settings.json
@@ -1,505 +1,541 @@
 {
-    "last_midi_device": "virtual 2",
-    "control_panel_monitor": 0,
-    "main_window_monitor": 2,
-    "auto_save_settings": true,
-    "window_positions": {
-        "control_panel": {
-            "x": 3814,
-            "y": 85,
-            "width": 1536,
-            "height": 824
-        },
-        "main_window": {
-            "x": 0,
-            "y": 23,
-            "width": 1536,
-            "height": 793
-        }
+  "last_midi_device": "virtual 2",
+  "control_panel_monitor": 0,
+  "main_window_monitor": 2,
+  "auto_save_settings": true,
+  "window_positions": {
+    "control_panel": {
+      "x": 3814,
+      "y": 85,
+      "width": 1536,
+      "height": 824
     },
-    "deck_settings": {
-        "deck_a": {
-            "last_visualizer": "",
-            "last_controls": {}
-        },
-        "deck_b": {
-            "last_visualizer": "",
-            "last_controls": {}
-        }
-    },
-    "mixer_settings": {
-        "last_mix_value": 50,
-        "crossfader_curve": "linear"
-    },
-    "audio_settings": {
-        "input_device": "Line (Reloop RMX-95) (10 ch)",
-        "buffer_size": 1024,
-        "sample_rate": 44100
-    },
-    "visual_settings": {
-        "fps_limit": 60,
-        "vsync": true,
-        "quality": "high"
-    },
-    "midi_mappings": {
-        "deck_a_preset_0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Simple Test",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note36"
-        },
-        "deck_a_preset_1": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Intro Background",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note37"
-        },
-        "deck_a_preset_2": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Intro Text ROBOTICA",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note38"
-        },
-        "deck_a_preset_3": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Wire Terrain",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note39"
-        },
-        "deck_a_preset_4": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Abstract Lines",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note40"
-        },
-        "deck_a_preset_5": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Geometric Particles",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note41"
-        },
-        "deck_a_preset_6": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Evolutive Particles",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note42"
-        },
-        "deck_a_preset_7": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Abstract Shapes",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note43"
-        },
-        "deck_a_preset_8": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Mobius Band",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note44"
-        },
-        "deck_a_preset_9": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Building Madness",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note45"
-        },
-        "deck_a_clear": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": null,
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note46"
-        },
-        "mix_action_0": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "10s",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note48"
-        },
-        "mix_action_1": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "B to A",
-                "duration": "10s",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note49"
-        },
-        "mix_action_2": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "5s",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note50"
-        },
-        "mix_action_3": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "B to A",
-                "duration": "5s",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note51"
-        },
-        "mix_action_4": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "500ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note52"
-        },
-        "mix_action_5": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "B to A",
-                "duration": "500ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note53"
-        },
-        "mix_action_6": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "Instant A",
-                "duration": "50ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note54"
-        },
-        "mix_action_7": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "Instant B",
-                "duration": "50ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note55"
-        },
-        "mix_action_8": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "Cut to Center",
-                "duration": "50ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note56"
-        },
-        "note_60_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Simple Test",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note60"
-        },
-        "note_61_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note61"
-        },
-        "note_62_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Intro Text ROBOTICA",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note62"
-        },
-        "note_63_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Wire Terrain",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note63"
-        },
-        "note_64_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Abstract Lines",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note64"
-        },
-        "note_65_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Geometric Particles",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note65"
-        },
-        "note_66_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Evolutive Particles",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note66"
-        },
-        "note_67_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Abstract Shapes",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note67"
-        },
-        "note_68_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Mobius Band",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note68"
-        },
-        "note_69_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "Building Madness",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note69"
-        },
-        "note_70_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "B",
-                "preset_name": "",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note70"
-        },
-        "note_36_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Simple Test",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note36"
-        },
-        "note_37_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Intro Text ROBOTICA",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note37"
-        },
-        "note_38_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Intro Text ROBOTICA",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note38"
-        },
-        "note_39_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Wire Terrain",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note39"
-        },
-        "note_40_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Abstract Lines",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note40"
-        },
-        "note_41_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Geometric Particles",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note41"
-        },
-        "note_42_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Evolutive Particles",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note42"
-        },
-        "note_43_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Abstract Shapes",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note43"
-        },
-        "note_44_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Mobius Band",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note44"
-        },
-        "note_45_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "Building Madness",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note45"
-        },
-        "note_46_ch0": {
-            "type": "load_preset",
-            "params": {
-                "deck_id": "A",
-                "preset_name": "",
-                "custom_values": ""
-            },
-            "midi": "note_on_ch0_note46"
-        },
-        "note_48_ch0": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "50ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note48"
-        },
-        "note_49_ch0": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "50ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note49"
-        },
-        "note_50_ch0": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "50ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note50"
-        },
-        "note_51_ch0": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "50ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note51"
-        },
-        "note_52_ch0": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "50ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note52"
-        },
-        "note_53_ch0": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "50ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note53"
-        },
-        "note_54_ch0": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "50ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note54"
-        },
-        "note_55_ch0": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "50ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note55"
-        },
-        "note_56_ch0": {
-            "type": "crossfade_action",
-            "params": {
-                "preset": "A to B",
-                "duration": "50ms",
-                "target": "Visual Mix"
-            },
-            "midi": "note_on_ch0_note56"
-        }
+    "main_window": {
+      "x": 0,
+      "y": 23,
+      "width": 1536,
+      "height": 793
     }
+  },
+  "deck_settings": {
+    "deck_a": {
+      "last_visualizer": "",
+      "last_controls": {}
+    },
+    "deck_b": {
+      "last_visualizer": "",
+      "last_controls": {}
+    }
+  },
+  "mixer_settings": {
+    "last_mix_value": 50,
+    "crossfader_curve": "linear"
+  },
+  "audio_settings": {
+    "input_device": "Line (Reloop RMX-95) (10 ch)",
+    "buffer_size": 1024,
+    "sample_rate": 44100
+  },
+  "visual_settings": {
+    "fps_limit": 60,
+    "vsync": true,
+    "quality": "high"
+  },
+  "midi_mappings": {
+    "deck_a_preset_0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Simple Test",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note36"
+    },
+    "deck_a_preset_1": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Intro Background",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note37"
+    },
+    "deck_a_preset_2": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Intro Text ROBOTICA",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note38"
+    },
+    "deck_a_preset_3": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Wire Terrain",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note39"
+    },
+    "deck_a_preset_4": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Abstract Lines",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note40"
+    },
+    "deck_a_preset_5": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Geometric Particles",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note41"
+    },
+    "deck_a_preset_6": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Evolutive Particles",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note42"
+    },
+    "deck_a_preset_7": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Abstract Shapes",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note43"
+    },
+    "deck_a_preset_8": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Mobius Band",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note44"
+    },
+    "deck_a_preset_9": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Building Madness",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note45"
+    },
+    "deck_a_clear": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": null,
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note46"
+    },
+    "mix_action_0": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "A to B",
+        "duration": "10s",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note48"
+    },
+    "mix_action_1": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "B to A",
+        "duration": "10s",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note49"
+    },
+    "mix_action_2": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "A to B",
+        "duration": "5s",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note50"
+    },
+    "mix_action_3": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "B to A",
+        "duration": "5s",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note51"
+    },
+    "mix_action_4": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "A to B",
+        "duration": "500ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note52"
+    },
+    "mix_action_5": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "B to A",
+        "duration": "500ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note53"
+    },
+    "mix_action_6": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "Instant A",
+        "duration": "50ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note54"
+    },
+    "mix_action_7": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "Instant B",
+        "duration": "50ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note55"
+    },
+    "mix_action_8": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "Cut to Center",
+        "duration": "50ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note56"
+    },
+    "note_60_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "B",
+        "preset_name": "Simple Test",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note60"
+    },
+    "note_61_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "B",
+        "preset_name": "",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note61"
+    },
+    "note_62_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "B",
+        "preset_name": "Intro Text ROBOTICA",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note62"
+    },
+    "note_63_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "B",
+        "preset_name": "Wire Terrain",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note63"
+    },
+    "note_64_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "B",
+        "preset_name": "Abstract Lines",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note64"
+    },
+    "note_65_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "B",
+        "preset_name": "Geometric Particles",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note65"
+    },
+    "note_66_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "B",
+        "preset_name": "Evolutive Particles",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note66"
+    },
+    "note_67_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "B",
+        "preset_name": "Abstract Shapes",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note67"
+    },
+    "note_68_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "B",
+        "preset_name": "Mobius Band",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note68"
+    },
+    "note_69_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "B",
+        "preset_name": "Building Madness",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note69"
+    },
+    "note_70_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "B",
+        "preset_name": "",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note70"
+    },
+    "note_36_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Simple Test",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note36"
+    },
+    "note_37_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Intro Text ROBOTICA",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note37"
+    },
+    "note_38_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Intro Text ROBOTICA",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note38"
+    },
+    "note_39_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Wire Terrain",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note39"
+    },
+    "note_40_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Abstract Lines",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note40"
+    },
+    "note_41_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Geometric Particles",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note41"
+    },
+    "note_42_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Evolutive Particles",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note42"
+    },
+    "note_43_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Abstract Shapes",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note43"
+    },
+    "note_44_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Mobius Band",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note44"
+    },
+    "note_45_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Building Madness",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note45"
+    },
+    "note_46_ch0": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note46"
+    },
+    "note_48_ch0": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "A to B",
+        "duration": "50ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note48"
+    },
+    "note_49_ch0": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "A to B",
+        "duration": "50ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note49"
+    },
+    "note_50_ch0": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "A to B",
+        "duration": "50ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note50"
+    },
+    "note_51_ch0": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "A to B",
+        "duration": "50ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note51"
+    },
+    "note_52_ch0": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "A to B",
+        "duration": "50ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note52"
+    },
+    "note_53_ch0": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "A to B",
+        "duration": "50ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note53"
+    },
+    "note_54_ch0": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "A to B",
+        "duration": "50ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note54"
+    },
+    "note_55_ch0": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "A to B",
+        "duration": "50ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note55"
+    },
+    "note_56_ch0": {
+      "type": "crossfade_action",
+      "params": {
+        "preset": "A to B",
+        "duration": "50ms",
+        "target": "Visual Mix"
+      },
+      "midi": "note_on_ch0_note56"
+    },
+    "deck_a_preset_15": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Oneshot Character Train",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note47"
+    },
+    "deck_a_preset_16": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "A",
+        "preset_name": "Oneshot Boom Explosion",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note75"
+    },
+    "deck_b_preset_15": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "B",
+        "preset_name": "Oneshot Character Train",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note76"
+    },
+    "deck_b_preset_16": {
+      "type": "load_preset",
+      "params": {
+        "deck_id": "B",
+        "preset_name": "Oneshot Boom Explosion",
+        "custom_values": ""
+      },
+      "midi": "note_on_ch0_note77"
+    }
+  }
 }

--- a/midi_mappings.json
+++ b/midi_mappings.json
@@ -340,5 +340,41 @@
       "custom_values": ""
     },
     "midi": "note_on_ch0_note64"
+  },
+  "deck_a_preset_15": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Oneshot Character Train",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note47"
+  },
+  "deck_a_preset_16": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Oneshot Boom Explosion",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note75"
+  },
+  "deck_b_preset_15": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Oneshot Character Train",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note76"
+  },
+  "deck_b_preset_16": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Oneshot Boom Explosion",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note77"
   }
 }

--- a/midi_mappings.txt
+++ b/midi_mappings.txt
@@ -1,7 +1,7 @@
 === CONFIGURACIÓN MIDI MAPPINGS ===
 
-Total mappings: 38
-Fecha: 2025-08-16 13:08:36
+Total mappings: 42
+Fecha: 2025-08-16 13:45:50
 
 === PRESET MAPPINGS ===
   note_on_ch0_note36 -> Deck A: Simple Test
@@ -36,6 +36,10 @@ Fecha: 2025-08-16 13:08:36
   note_on_ch0_note73 -> Deck B: Kaleido Tunnel
   note_on_ch0_note74 -> Deck B: Scientific Analyzer
   note_on_ch0_note64 -> Deck B: None
+  note_on_ch0_note47 -> Deck A: Oneshot Character Train
+  note_on_ch0_note75 -> Deck A: Oneshot Boom Explosion
+  note_on_ch0_note76 -> Deck B: Oneshot Character Train
+  note_on_ch0_note77 -> Deck B: Oneshot Boom Explosion
 
 === MIX ACTIONS ===
   note_on_ch0_note48 -> A to B (10s)

--- a/visuals/presets/oneshot_boomexplosion.py
+++ b/visuals/presets/oneshot_boomexplosion.py
@@ -1,4 +1,4 @@
-# visuals/presets/boom_explosion.py
+# visuals/presets/oneshot_boomexplosion.py
 import logging
 import numpy as np
 import ctypes
@@ -8,10 +8,10 @@ import random
 from OpenGL.GL import *
 from ..base_visualizer import BaseVisualizer
 
-class BoomExplosionVisualizer(BaseVisualizer):
+class OneshotBoomExplosionVisualizer(BaseVisualizer):
     """One-shot explosion visual for dramatic booms and bass drops"""
     
-    visual_name = "Boom Explosion"
+    visual_name = "Oneshot Boom Explosion"
     
     def __init__(self):
         super().__init__()
@@ -34,12 +34,12 @@ class BoomExplosionVisualizer(BaseVisualizer):
         self.size_multiplier = 1.0
         self.color_mode = 0  # 0=fire, 1=electric, 2=rainbow
         
-        logging.info("BoomExplosionVisualizer created")
+        logging.info("OneshotBoomExplosionVisualizer created")
 
     def initializeGL(self):
         """Initialize OpenGL resources"""
         try:
-            logging.debug("BoomExplosionVisualizer.initializeGL called")
+            logging.debug("OneshotBoomExplosionVisualizer.initializeGL called")
             
             # Clear GL errors
             while glGetError() != GL_NO_ERROR:
@@ -63,10 +63,10 @@ class BoomExplosionVisualizer(BaseVisualizer):
                 return
             
             self.initialized = True
-            logging.info("✅ BoomExplosionVisualizer initialized successfully")
+            logging.info("✅ OneshotBoomExplosionVisualizer initialized successfully")
             
         except Exception as e:
-            logging.error(f"Error in BoomExplosionVisualizer.initializeGL: {e}")
+            logging.error(f"Error in OneshotBoomExplosionVisualizer.initializeGL: {e}")
             import traceback
             traceback.print_exc()
 
@@ -197,7 +197,7 @@ class BoomExplosionVisualizer(BaseVisualizer):
             glDeleteShader(vertex_shader)
             glDeleteShader(fragment_shader)
             
-            logging.debug("BoomExplosionVisualizer shaders compiled successfully")
+            logging.debug("OneshotBoomExplosionVisualizer shaders compiled successfully")
             return True
             
         except Exception as e:
@@ -429,7 +429,7 @@ class BoomExplosionVisualizer(BaseVisualizer):
     def cleanup(self):
         """Clean up OpenGL resources"""
         try:
-            logging.debug("Cleaning up BoomExplosionVisualizer")
+            logging.debug("Cleaning up OneshotBoomExplosionVisualizer")
             
             if self.shader_program:
                 try:

--- a/visuals/presets/oneshot_charactertrain.py
+++ b/visuals/presets/oneshot_charactertrain.py
@@ -1,4 +1,4 @@
-# visuals/presets/character_train.py
+# visuals/presets/oneshot_charactertrain.py
 import logging
 import numpy as np
 import ctypes
@@ -9,10 +9,10 @@ import string
 from OpenGL.GL import *
 from ..base_visualizer import BaseVisualizer
 
-class CharacterTrainVisualizer(BaseVisualizer):
+class OneshotCharacterTrainVisualizer(BaseVisualizer):
     """One-shot character train visual - lines of characters crossing the screen"""
     
-    visual_name = "Character Train"
+    visual_name = "Oneshot Character Train"
     
     def __init__(self):
         super().__init__()
@@ -39,12 +39,12 @@ class CharacterTrainVisualizer(BaseVisualizer):
         # Character set (same as intro_background)
         self.charset = string.ascii_letters + string.digits + "!@#$%^&*()_+-=[]{}|;:,.<>?"
         
-        logging.info("CharacterTrainVisualizer created")
+        logging.info("OneshotCharacterTrainVisualizer created")
 
     def initializeGL(self):
         """Initialize OpenGL resources"""
         try:
-            logging.debug("CharacterTrainVisualizer.initializeGL called")
+            logging.debug("OneshotCharacterTrainVisualizer.initializeGL called")
             
             # Clear GL errors
             while glGetError() != GL_NO_ERROR:
@@ -67,10 +67,10 @@ class CharacterTrainVisualizer(BaseVisualizer):
                 return
             
             self.initialized = True
-            logging.info("✅ CharacterTrainVisualizer initialized successfully")
+            logging.info("✅ OneshotCharacterTrainVisualizer initialized successfully")
             
         except Exception as e:
-            logging.error(f"Error in CharacterTrainVisualizer.initializeGL: {e}")
+            logging.error(f"Error in OneshotCharacterTrainVisualizer.initializeGL: {e}")
             import traceback
             traceback.print_exc()
 
@@ -263,7 +263,7 @@ class CharacterTrainVisualizer(BaseVisualizer):
             glDeleteShader(vertex_shader)
             glDeleteShader(fragment_shader)
             
-            logging.debug("CharacterTrainVisualizer shaders compiled successfully")
+            logging.debug("OneshotCharacterTrainVisualizer shaders compiled successfully")
             return True
             
         except Exception as e:
@@ -496,7 +496,7 @@ class CharacterTrainVisualizer(BaseVisualizer):
     def cleanup(self):
         """Clean up OpenGL resources"""
         try:
-            logging.debug("Cleaning up CharacterTrainVisualizer")
+            logging.debug("Cleaning up OneshotCharacterTrainVisualizer")
             
             if self.shader_program:
                 try:

--- a/visuals/visualizer_manager.py
+++ b/visuals/visualizer_manager.py
@@ -35,6 +35,8 @@ class VisualizerManager:
                 'vortex_particles',
                 'kaleido_tunney',
                 'science_analyzer',
+                'oneshot_charactertrain',
+                'oneshot_boomexplosion',
             ]
             
             loaded_count = 0


### PR DESCRIPTION
## Summary
- rename boom_explosion and character_train presets to oneshot variants
- register new oneshot visualizers and MIDI mappings
- document new mappings in configuration files

## Testing
- `python -m py_compile visuals/presets/oneshot_charactertrain.py visuals/presets/oneshot_boomexplosion.py visuals/visualizer_manager.py`
- `pytest` *(fails: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_68a088ebbe8483338a611a7b9077630f