### PR TITLE
Add Plasma Clouds preset to visualizer and MIDI mappings

### DIFF
--- a/midi_mappings.json
+++ b/midi_mappings.json
@@ -412,5 +412,23 @@
       "custom_values": ""
     },
     "midi": "note_on_ch0_note81"
+  },
+  "deck_a_preset_19": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Plasma Clouds",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note82"
+  },
+  "deck_b_preset_19": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Plasma Clouds",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note83"
   }
 }

--- a/midi_mappings.txt
+++ b/midi_mappings.txt
@@ -1,7 +1,7 @@
 === CONFIGURACIÓN MIDI MAPPINGS ===
 
-Total mappings: 46
-Fecha: 2025-08-16 13:45:50
+Total mappings: 48
+Fecha: 2025-08-16 18:11:46
 
 === PRESET MAPPINGS ===
   note_on_ch0_note36 -> Deck A: Simple Test
@@ -44,6 +44,8 @@ Fecha: 2025-08-16 13:45:50
   note_on_ch0_note79 -> Deck A: Oneshot Electric Boom
   note_on_ch0_note80 -> Deck B: Oneshot Circuit Signal
   note_on_ch0_note81 -> Deck B: Oneshot Electric Boom
+  note_on_ch0_note82 -> Deck A: Plasma Clouds
+  note_on_ch0_note83 -> Deck B: Plasma Clouds
 
 === MIX ACTIONS ===
   note_on_ch0_note48 -> A to B (10s)

--- a/visuals/visualizer_manager.py
+++ b/visuals/visualizer_manager.py
@@ -35,6 +35,7 @@ class VisualizerManager:
                 'vortex_particles',
                 'kaleido_tunney',
                 'science_analyzer',
+                'plasma_clouds',
                 'oneshot_charactertrain',
                 'oneshot_boomexplosion',
                 'oneshot_circuit_signal',


### PR DESCRIPTION
## Summary
- register new Plasma Clouds visualizer
- map Plasma Clouds preset to MIDI notes for decks A and B
- update MIDI mapping summary text

## Testing
- `python -m py_compile visuals/presets/plasma_clouds.py`
- `python -m py_compile visuals/visualizer_manager.py`
- `python -m json.tool midi_mappings.json`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*
- `pip install PyQt6 numpy PyOpenGL moderngl` *(fails: Could not find a version that satisfies the requirement PyQt6)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c89000288333a1b1023b29bac681