### PR TITLE
Update deck MIDI channels to 13-16

### DIFF
--- a/debug_midi_mappings.py
+++ b/debug_midi_mappings.py
@@ -38,7 +38,7 @@ def debug_midi_mappings():
             if sample_visual:
                 note = mappings[sample_visual]
                 print(f"\n   🎛️ MAPPING POR CANAL PARA '{sample_visual}':")
-                for deck, channel in zip(['A', 'B', 'C', 'D'], range(4)):
+                for deck, channel in zip(['A', 'B', 'C', 'D'], range(12, 16)):
                     midi_key = f"note_on_ch{channel}_note{note}"
                     print(f"      Deck {deck} -> {midi_key}")
         except Exception as e:

--- a/midi/midi_visual_mapper.py
+++ b/midi/midi_visual_mapper.py
@@ -30,7 +30,7 @@ class MidiVisualMapper:
 
     def create_default_visual_config(self):
         self.config = {
-            "deck_channels": {"A": 0, "B": 1, "C": 2, "D": 3},
+            "deck_channels": {"A": 12, "B": 13, "C": 14, "D": 15},
             "start_note": 56,
             "visual_priority_order": []
         }

--- a/midi/visual_mappings_config.json
+++ b/midi/visual_mappings_config.json
@@ -1,9 +1,9 @@
 {
   "deck_channels": {
-    "A": 0,
-    "B": 1,
-    "C": 2,
-    "D": 3
+    "A": 12,
+    "B": 13,
+    "C": 14,
+    "D": 15
   },
   "start_note": 56,
   "visual_priority_order": [

--- a/midi_diagnostic.py
+++ b/midi_diagnostic.py
@@ -26,7 +26,7 @@ def diagnose_midi():
         # Mostrar algunos mappings de ejemplo usando canales
         test_notes = [56, 57]
         for note in test_notes:
-            for channel in range(4):
+            for channel in range(12, 16):
                 key = f"note_on_ch{channel}_note{note}"
                 found = False
                 for action_id, mapping_data in mappings.items():
@@ -45,7 +45,7 @@ def diagnose_midi():
     print("\n" + "="*60)
 
 # Simular una nota MIDI para probar
-def test_note(note_number, channel=0, velocity=127):
+def test_note(note_number, channel=12, velocity=127):
     print(f"\n🧪 Probando nota {note_number} en canal {channel+1} con velocity {velocity}")
 
     if app.midi_engine:
@@ -73,4 +73,4 @@ diagnose_midi()
 check_visualizers()
 
 # Prueba directa - descomenta para probar
-# test_note(56, channel=0)  # Abstract Lines en Deck A
+# test_note(56, channel=12)  # Abstract Lines en Deck A

--- a/test_midi_mappings.py
+++ b/test_midi_mappings.py
@@ -27,7 +27,7 @@ def test_midi_mappings():
     assert mappings, "No MIDI mappings loaded"
     sample_visual, sample_note = next(iter(mappings.items()))
 
-    for channel in range(4):
+    for channel in range(12, 16):
         logging.info(
             f"\n🎵 Testing {sample_visual} on channel {channel+1}: note {sample_note}"
         )

--- a/ui/live_control_tab.py
+++ b/ui/live_control_tab.py
@@ -90,10 +90,10 @@ def create_improved_deck_grid(self, container):
         visuals = sorted(visuals, key=lambda v: midi_info.get(v, 9999))
 
         deck_config = {
-            "A": {"channel": 1, "color": "#ff6b6b", "name": "DECK A"},
-            "B": {"channel": 2, "color": "#4ecdc4", "name": "DECK B"},
-            "C": {"channel": 3, "color": "#45b7d1", "name": "DECK C"},
-            "D": {"channel": 4, "color": "#96ceb4", "name": "DECK D"},
+            "A": {"channel": 13, "color": "#ff6b6b", "name": "DECK A"},
+            "B": {"channel": 14, "color": "#4ecdc4", "name": "DECK B"},
+            "C": {"channel": 15, "color": "#45b7d1", "name": "DECK C"},
+            "D": {"channel": 16, "color": "#96ceb4", "name": "DECK D"},
         }
 
         # Store grid info for interactions

--- a/ui/midi_config_widget.py
+++ b/ui/midi_config_widget.py
@@ -1188,7 +1188,7 @@ class MidiConfigWidget(QWidget):
             
             # MIDI Key
             midi_key_edit = QLineEdit()
-            midi_key_edit.setPlaceholderText("ej: note_on_ch0_note60 (Deck A)")
+            midi_key_edit.setPlaceholderText("ej: note_on_ch12_note60 (Deck A)")
             layout.addRow("MIDI Key:", midi_key_edit)
             
             # Parámetros (JSON)


### PR DESCRIPTION
## Summary
- configure decks A–D to use MIDI channels 13–16
- adjust MIDI mapping tools, UI, and tests for the new channels

## Testing
- `pytest -q` *(fails: Fatal Python error: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a221b0a23083338f4092db4b21e15a