### PR TITLE
Ensure fullscreen windows wait for OpenGL before applying visualizers

### DIFF
--- a/ui/control_panel_window.py
+++ b/ui/control_panel_window.py
@@ -829,11 +829,17 @@ class ControlPanelWindow(QMainWindow):
                 self.mixer_window.signal_set_deck_opacity.connect(window.set_deck_opacity)
                 self.mixer_window.signal_trigger_deck_action.connect(window.trigger_deck_action)
 
-                window.set_mix_value(int(self.mixer_window.mix_value * 100))
+            # Apply current mixer state once the window's GL context is ready
+            def init_state(win=window):
+                win.set_mix_value(int(self.mixer_window.mix_value * 100))
                 if self.mixer_window.deck_a and self.mixer_window.deck_a.current_visualizer_name:
-                    window.set_deck_visualizer('A', self.mixer_window.deck_a.current_visualizer_name)
+                    win.set_deck_visualizer('A', self.mixer_window.deck_a.current_visualizer_name)
                 if self.mixer_window.deck_b and self.mixer_window.deck_b.current_visualizer_name:
-                    window.set_deck_visualizer('B', self.mixer_window.deck_b.current_visualizer_name)
+                    win.set_deck_visualizer('B', self.mixer_window.deck_b.current_visualizer_name)
+
+            window.gl_ready.connect(init_state)
+            if window.gl_initialized:
+                init_state()
 
             window.exit_fullscreen.connect(self.exit_fullscreen_mode)
             handle = window.windowHandle()

--- a/ui/mixer_window.py
+++ b/ui/mixer_window.py
@@ -21,6 +21,8 @@ class MixerWindow(QMainWindow):
     signal_set_deck_opacity = pyqtSignal(str, float)
     signal_trigger_deck_action = pyqtSignal(str, str)
     exit_fullscreen = pyqtSignal()
+    # Signal emitted after the OpenGL context is fully initialized
+    gl_ready = pyqtSignal()
 
     def __init__(self, visualizer_manager, settings_manager=None, audio_analyzer=None):
         super().__init__()
@@ -166,10 +168,12 @@ class MixerWindow(QMainWindow):
                     logging.warning("⚠️ Deck A not ready after initialization")
                 if not self.deck_b.is_ready():
                     logging.warning("⚠️ Deck B not ready after initialization")
-                
+
                 self.gl_initialized = True
                 logging.info("✅ MixerWindow OpenGL initialized successfully")
-                
+                # Notify listeners that the GL context is ready
+                self.gl_ready.emit()
+
                 # Force initial render
                 QTimer.singleShot(100, self.force_initial_render)
                 


### PR DESCRIPTION
## Summary
- Emit `gl_ready` once a MixerWindow's OpenGL context is ready
- Wait for `gl_ready` before applying mix state and visualizers to fullscreen windows

## Testing
- `python -m py_compile ui/control_panel_window.py ui/mixer_window.py`
- `pytest` *(fails: Fatal Python error: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b78e7bc883338b4f31d94f934fc1