### PR TITLE
Fix fullscreen crash on multi-monitor and ESC key handling

### DIFF
--- a/ui/control_panel_window.py
+++ b/ui/control_panel_window.py
@@ -847,11 +847,15 @@ class ControlPanelWindow(QMainWindow):
                 # Ensure the window handle exists before assigning the screen
                 handle = window.windowHandle()
                 if handle is None:
-                    window.show()
+                    window.winId()  # Force creation of the window handle without showing
                     handle = window.windowHandle()
                 if handle:
-                    handle.setScreen(screen)
-                    window.setGeometry(screen.geometry())
+                    try:
+                        handle.setScreen(screen)
+                        window.setGeometry(screen.geometry())
+                    except Exception as e:
+                        logging.warning(f"Could not set screen geometry: {e}")
+                        window.move(screen.geometry().topLeft())
                 else:
                     window.move(screen.geometry().topLeft())
 

--- a/ui/mixer_window.py
+++ b/ui/mixer_window.py
@@ -805,7 +805,7 @@ class MixerWindow(QMainWindow):
 
     def keyPressEvent(self, event):
         """Handle key presses for fullscreen exit"""
-        if event.key() == Qt.Key_Escape and self.isFullScreen():
+        if event.key() == Qt.Key.Key_Escape and self.isFullScreen():
             self.exit_fullscreen.emit()
         else:
             super().keyPressEvent(event)


### PR DESCRIPTION
## Summary
- prevent AttributeError for ESC key by using Qt6 Key enum
- improve multi-monitor fullscreen assignment by creating window handle before showing and safely setting screen geometry

## Testing
- `pytest` *(fails: Aborted in ui/main_application; requires GUI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a3286bdb0483339a5d2acdd46bffbf