### PR TITLE
Handle framebuffer binding errors safely

### DIFF
--- a/opengl_fixes.py
+++ b/opengl_fixes.py
@@ -34,7 +34,7 @@ class OpenGLSafety:
     
     @staticmethod
     def safe_point_size(size):
-        """Set point size safely, checking GL limits"""
+        """Set point size safely, checking GL limits""" 
         try:
             # Get the supported point size range
             range_info = glGetFloatv(GL_POINT_SIZE_RANGE)
@@ -59,6 +59,29 @@ class OpenGLSafety:
                     glPointSize(1.0)
                 except:
                     pass
+
+    @staticmethod
+    def safe_bind_framebuffer(target, framebuffer):
+        """Safely bind a framebuffer and log errors"""
+        try:
+            glBindFramebuffer(target, int(framebuffer))
+            error = glGetError()
+            if error != GL_NO_ERROR:
+                error_msg = {
+                    GL_INVALID_ENUM: "GL_INVALID_ENUM",
+                    GL_INVALID_VALUE: "GL_INVALID_VALUE",
+                    GL_INVALID_OPERATION: "GL_INVALID_OPERATION",
+                    GL_OUT_OF_MEMORY: "GL_OUT_OF_MEMORY",
+                    GL_INVALID_FRAMEBUFFER_OPERATION: "GL_INVALID_FRAMEBUFFER_OPERATION",
+                }.get(error, f"Unknown error {error}")
+                logging.warning(
+                    f"OpenGL error binding framebuffer {framebuffer}: {error_msg}"
+                )
+                return False
+            return True
+        except Exception as e:
+            logging.error(f"Error binding framebuffer {framebuffer}: {e}")
+            return False
 
     @staticmethod
     def check_gl_errors(context="OpenGL operation"):

--- a/ui/mixer_window.py
+++ b/ui/mixer_window.py
@@ -368,7 +368,9 @@ class MixerWindow(QMainWindow):
                     logging.error(f"❌ Error painting deck B: {e}")
             
             # Now composite them in the main framebuffer
-            glBindFramebuffer(GL_FRAMEBUFFER, self.gl_widget.defaultFramebufferObject())
+            OpenGLSafety.safe_bind_framebuffer(
+                GL_FRAMEBUFFER, self.gl_widget.defaultFramebufferObject()
+            )
             pixel_ratio = self.gl_widget.devicePixelRatio()
             glViewport(0, 0, int(self.gl_widget.width() * pixel_ratio), int(self.gl_widget.height() * pixel_ratio))
 

--- a/visuals/deck.py
+++ b/visuals/deck.py
@@ -521,8 +521,8 @@ class Deck:
                         if not self._initialize_visualizer_in_fbo():
                             self._render_fallback()
                             self.fbo.release()
-                            # Restore previous FBO
-                            glBindFramebuffer(GL_FRAMEBUFFER, previous_fbo)
+                            # Restore previous FBO safely
+                            OpenGLSafety.safe_bind_framebuffer(GL_FRAMEBUFFER, previous_fbo)
                             return False
                     
                     # Render the visualizer
@@ -602,8 +602,8 @@ class Deck:
                 # Release our FBO
                 self.fbo.release()
 
-                # Restore previous FBO binding
-                glBindFramebuffer(GL_FRAMEBUFFER, previous_fbo)
+                # Restore previous FBO binding safely
+                OpenGLSafety.safe_bind_framebuffer(GL_FRAMEBUFFER, previous_fbo)
                 
                 self._fbo_dirty = False
                 return True


### PR DESCRIPTION
## Summary
- add `OpenGLSafety.safe_bind_framebuffer` utility to handle GL errors when binding FBOs
- use safe framebuffer binding in deck rendering and mixer window compositing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_68a32fecdc58833396850b93f6b02a07