### PR TITLE
Ensure Qt context current after ModernGL renders

### DIFF
--- a/ui/mixer_window.py
+++ b/ui/mixer_window.py
@@ -359,13 +359,20 @@ class MixerWindow(QMainWindow):
                     deck_a_rendered = True
                 except Exception as e:
                     logging.error(f"❌ Error painting deck A: {e}")
-                    
+                finally:
+                    # ModernGL renders can change the current context; make sure
+                    # our Qt context is current again before continuing
+                    self.gl_widget.makeCurrent()
+
             if self.deck_b:
                 try:
                     self.deck_b.paint()
                     deck_b_rendered = True
                 except Exception as e:
                     logging.error(f"❌ Error painting deck B: {e}")
+                finally:
+                    # Ensure Qt's GL context remains current after ModernGL calls
+                    self.gl_widget.makeCurrent()
             
             # Now composite them in the main framebuffer
             OpenGLSafety.safe_bind_framebuffer(


### PR DESCRIPTION
## Summary
- Rebind the Qt OpenGL context after each deck render to avoid invalid GL operations when using the ModernGL backend.

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a33340d108833383b49210e345f2ed