### PR TITLE
Fix missing QOpenGLContext import in MixerWindow

### DIFF
--- a/ui/mixer_window.py
+++ b/ui/mixer_window.py
@@ -6,6 +6,7 @@ import ctypes
 import time
 from PyQt6.QtWidgets import QMainWindow
 from PyQt6.QtCore import Qt, QSize, QTimer, pyqtSlot, pyqtSignal, QMutex, QMutexLocker
+from PyQt6.QtGui import QOpenGLContext
 from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 from OpenGL.GL import *
 


### PR DESCRIPTION
## Summary
- Import `QOpenGLContext` in `MixerWindow` to prevent `NameError` during OpenGL initialization.

## Testing
- `pytest -q` *(fails: Fatal Python error: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a361a56dfc8333a0a294cc5028d5bc