### PR TITLE
Handle PyQt6 context sharing in mixer window

### DIFF
--- a/visuals/render_backend.py
+++ b/visuals/render_backend.py
@@ -323,13 +323,27 @@ class ModernGLBackend(RenderBackend):
             self.mgl = moderngl
 
             if self.share_context:
-                logging.debug("🔧 Creating ModernGL context by sharing existing GL context")
+                logging.debug(
+                    "🔧 Creating ModernGL context by sharing existing GL context"
+                )
+                share_obj = self.share_context
+                # Some platforms return a wrapper object for the native
+                # handle (such as sip.voidptr).  Attempt to convert it to an
+                # int, but ignore failures so we can still pass the original
+                # object to moderngl.
+                try:  # pragma: no cover - defensive programming
+                    share_obj = int(share_obj)
+                except Exception:
+                    pass
                 try:
-                    self.ctx = moderngl.create_context(share=self.share_context)
+                    self.ctx = moderngl.create_context(share=share_obj)
                     logging.info("✅ ModernGL context created by sharing")
                 except Exception as exc:
-                    logging.error(f"❌ Failed to create ModernGL context by sharing: {exc}")
-                    raise
+                    logging.error(
+                        f"❌ Failed to create ModernGL context by sharing: {exc}"
+                    )
+                    # Fallback: create a fresh context instead of aborting
+                    self.ctx = moderngl.create_context(require=330)
             else:
                 logging.debug(
                     f"🔧 Creating ModernGL context for device {self.device_index}"


### PR DESCRIPTION
## Summary
- Support PyQt6 `nativeInterface()` fallback when obtaining OpenGL context handles in mixer and control panel windows
- Guard ModernGL backend against non-integer share handles and gracefully fall back to standalone context

## Testing
- `pip install -r requirements.txt` *(fails: build wheel for pyaudio)*
- `pip install pygame-ce python-rtmidi PyOpenGL PyOpenGL_accelerate PyBullet PyQt6 numpy scipy moderngl gputil mido`
- `apt-get install -y libgl1`
- `apt-get install -y libxkbcommon0`
- `apt-get install -y libegl1`
- `apt-get install -y libasound2t64`
- `QT_QPA_PLATFORM=offscreen pytest` *(aborted: Fatal Python error: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a3643a853c83339d1b2de53a3b207f