### PR TITLE
Handle missing OpenGL context when binding framebuffers

### DIFF
--- a/opengl_fixes.py
+++ b/opengl_fixes.py
@@ -88,6 +88,16 @@ class OpenGLSafety:
             # optimistically continue and rely on the GL error check below.
             pass
 
+        # Extra safety: try a cheap GL query to ensure a context is active.
+        # If this raises, we skip the bind to avoid noisy GL errors.
+        try:
+            glGetIntegerv(GL_FRAMEBUFFER_BINDING)
+        except Exception:
+            logging.warning(
+                f"OpenGL error binding framebuffer {framebuffer}: no active context"
+            )
+            return False
+
         try:
             glBindFramebuffer(target, int(framebuffer))
             error = glGetError()
@@ -105,7 +115,9 @@ class OpenGLSafety:
                 return False
             return True
         except Exception as e:
-            logging.error(f"Error binding framebuffer {framebuffer}: {e}")
+            logging.warning(
+                f"OpenGL error binding framebuffer {framebuffer}: {e}"
+            )
             return False
 
     @staticmethod

--- a/ui/mixer_window.py
+++ b/ui/mixer_window.py
@@ -450,9 +450,11 @@ class MixerWindow(QMainWindow):
             
             # Now composite them in the main framebuffer
             self.gl_widget.makeCurrent() # Ensure context is current before binding framebuffer
-            OpenGLSafety.safe_bind_framebuffer(
+            if not OpenGLSafety.safe_bind_framebuffer(
                 GL_FRAMEBUFFER, self.gl_widget.defaultFramebufferObject()
-            )
+            ):
+                logging.warning("⚠️ MixerWindow: Unable to bind default framebuffer")
+                return
             pixel_ratio = self.gl_widget.devicePixelRatio()
             glViewport(0, 0, int(self.gl_widget.width() * pixel_ratio), int(self.gl_widget.height() * pixel_ratio))
 


### PR DESCRIPTION
## Summary
- Guard framebuffer binding with an extra GL query to avoid invalid operation errors
- Skip rendering when default framebuffer cannot be bound

## Testing
- `pytest -q` *(fails: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_68a36b52b3508333a1e33414ba04d717