### PR TITLE
Add missing QtOpenGL proxy for PyQt6 compatibility

### DIFF
--- a/PyQt6/QtOpenGL.py
+++ b/PyQt6/QtOpenGL.py
@@ -1,0 +1,6 @@
+"""Proxy module mapping PyQt6.QtOpenGL to PySide6.QtOpenGL."""
+
+from PySide6.QtOpenGL import *  # type: ignore  # noqa: F401,F403
+
+__all__ = [name for name in globals().keys() if not name.startswith('_')]
+

--- a/PyQt6/__init__.py
+++ b/PyQt6/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     'QtWidgets',
     'QtCore',
     'QtGui',
+    'QtOpenGL',
     'QtOpenGLWidgets',
 ]
 


### PR DESCRIPTION
## Summary
- expose QtOpenGL through the PyQt6 compatibility package
- provide proxy module forwarding PyQt6.QtOpenGL to PySide6.QtOpenGL

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a38296613c8333bf6b0bcca68d8fea