### PR TITLE
Expose Taichi-compatible GL backend stubs

### DIFF
--- a/visuals/render_backend.py
+++ b/visuals/render_backend.py
@@ -8,7 +8,7 @@ Pythonic API that existing visualizers can gradually migrate to.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, List, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 import numpy as np
 import taichi as ti
@@ -82,24 +82,87 @@ class TaichiBackend(RenderBackend):
             p.compute(self.canvas)
         return self.canvas.to_numpy()
 
+    # ------------------------------------------------------------------
+    # Compatibility helpers
+    # ------------------------------------------------------------------
+    def begin_target(self, size: Tuple[int, int]) -> None:
+        """Alias of :meth:`begin_frame` for legacy callers."""
+        self.begin_frame(size)
+
+    def end_target(self) -> np.ndarray:
+        """Alias of :meth:`end_frame` for legacy callers."""
+        return self.end_frame()
+
     # Compatibility stubs ------------------------------------------------
-    def program(self, *args, **kwargs) -> Any:  # pragma: no cover - stub
-        raise NotImplementedError("Shader programs are not supported in TaichiBackend")
+    # Simple data containers used by legacy presets expecting an OpenGL style API
+    @dataclass
+    class _DummyProgram:
+        vertex_shader: str = ""
+        fragment_shader: str = ""
+        uniforms: Dict[str, Any] = None
 
-    def buffer(self, *args, **kwargs) -> Any:  # pragma: no cover - stub
-        raise NotImplementedError("Buffer objects are not supported in TaichiBackend")
+        def __post_init__(self) -> None:  # pragma: no cover - simple container
+            if self.uniforms is None:
+                self.uniforms = {}
 
-    def vertex_array(self, *args, **kwargs) -> Any:  # pragma: no cover - stub
-        raise NotImplementedError("Vertex arrays are not supported in TaichiBackend")
+    class _DummyBuffer:
+        def __init__(self, data: bytes | None = None) -> None:  # pragma: no cover - simple container
+            self.data = data
+
+        def release(self) -> None:  # pragma: no cover - simple container
+            self.data = None
+
+    class _DummyVertexArray:
+        def __init__(self, program: "TaichiBackend._DummyProgram", buffers: Tuple[Any, ...]):  # pragma: no cover - simple container
+            self.program = program
+            self.buffers = buffers
+
+        def render(self) -> None:  # pragma: no cover - no-op
+            return None
+
+        def release(self) -> None:  # pragma: no cover - simple container
+            self.program = None
+            self.buffers = ()
+
+    def program(self, vertex_shader: str = "", fragment_shader: str = "", *_, **__) -> Any:
+        """Return a minimal shader program container."""
+        return TaichiBackend._DummyProgram(vertex_shader, fragment_shader)
+
+    def buffer(self, data: bytes) -> Any:
+        """Return a minimal buffer container."""
+        return TaichiBackend._DummyBuffer(data)
+
+    def vertex_array(self, program: Any, buffers: Tuple[Any, ...] = tuple()) -> Any:
+        """Return a minimal vertex array container."""
+        return TaichiBackend._DummyVertexArray(program, buffers)
 
     def set_viewport(self, *args, **kwargs) -> None:  # pragma: no cover - stub
         return None
 
-    def uniform(self, *args, **kwargs) -> None:  # pragma: no cover - stub
-        return None
+    def uniform(self, program: Any, name: str, value: Any) -> None:  # pragma: no cover - simple setter
+        if isinstance(program, TaichiBackend._DummyProgram):
+            program.uniforms[name] = value
 
     def create_framebuffer(self, *args, **kwargs) -> Any:  # pragma: no cover - stub
         raise NotImplementedError("Framebuffers are not supported in TaichiBackend")
+
+
+# Legacy compatibility wrappers -------------------------------------------------
+
+class GLBackend(TaichiBackend):
+    """Alias of :class:`TaichiBackend` for legacy OpenGL code."""
+
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - simple wrapper
+        super().__init__()
+
+
+class ModernGLBackend(GLBackend):
+    """Alias of :class:`TaichiBackend` representing a ModernGL backend."""
+
+    def __init__(self, device_index: int = 0, share_context: Any = None, *args, **kwargs) -> None:  # pragma: no cover - simple wrapper
+        super().__init__(*args, **kwargs)
+        self.device_index = device_index
+        self.share_context = share_context
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add compatibility helpers so `GLBackend` and `ModernGLBackend` resolve to the Taichi backend
- implement dummy program/buffer/vertex array and uniform handling for legacy code paths
- add frame alias methods to ease migration from OpenGL APIs

## Testing
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a384a44d788333add1134d2e76bf3c