### PR TITLE
Use PySide6 with dark theme and fix Taichi clear

### DIFF
--- a/ui/main_application.py
+++ b/ui/main_application.py
@@ -2,9 +2,9 @@
 import sys
 import os
 import logging
-from PyQt6.QtWidgets import QApplication, QMessageBox, QSplashScreen
-from PyQt6.QtGui import QSurfaceFormat, QPixmap
-from PyQt6.QtCore import QTimer, Qt
+from PySide6.QtWidgets import QApplication, QMessageBox, QSplashScreen
+from PySide6.QtGui import QSurfaceFormat, QPixmap, QPalette, QColor
+from PySide6.QtCore import QTimer, Qt
 
 from utils.settings_manager import SettingsManager
 from midi.midi_engine import MidiEngine
@@ -50,9 +50,29 @@ class MainApplication:
             QSurfaceFormat.setDefaultFormat(format)
             logging.debug("✅ OpenGL format configured")
 
+            # High DPI support and modern dark theme
+            QApplication.setAttribute(Qt.ApplicationAttribute.AA_EnableHighDpiScaling)
+            QApplication.setAttribute(Qt.ApplicationAttribute.AA_UseHighDpiPixmaps)
+
             self.app = QApplication(sys.argv)
             self.app.setApplicationName("Audio Visualizer Pro")
             self.app.setApplicationVersion("1.0")
+            self.app.setStyle("Fusion")
+
+            # Apply a dark palette for a more modern appearance
+            palette = QPalette()
+            palette.setColor(QPalette.ColorRole.Window, QColor(30, 30, 30))
+            palette.setColor(QPalette.ColorRole.WindowText, QColor(220, 220, 220))
+            palette.setColor(QPalette.ColorRole.Base, QColor(45, 45, 45))
+            palette.setColor(QPalette.ColorRole.AlternateBase, QColor(53, 53, 53))
+            palette.setColor(QPalette.ColorRole.ToolTipBase, QColor(255, 255, 255))
+            palette.setColor(QPalette.ColorRole.ToolTipText, QColor(220, 220, 220))
+            palette.setColor(QPalette.ColorRole.Text, QColor(220, 220, 220))
+            palette.setColor(QPalette.ColorRole.Button, QColor(53, 53, 53))
+            palette.setColor(QPalette.ColorRole.ButtonText, QColor(220, 220, 220))
+            palette.setColor(QPalette.ColorRole.Highlight, QColor(42, 130, 218))
+            palette.setColor(QPalette.ColorRole.HighlightedText, QColor(0, 0, 0))
+            self.app.setPalette(palette)
 
             # Simple loading splash while initializing components
             pixmap = QPixmap(400, 300)


### PR DESCRIPTION
## Summary
- replace PyQt6 imports with PySide6 and apply Fusion dark theme with high-DPI support
- fix Taichi render backend clear pass to avoid invalid kernel argument

## Testing
- `python - <<'PY' from visuals.render_backend import TaichiBackend;b=TaichiBackend();b.begin_frame((16,16));b.clear(0.1,0.2,0.3,1.0);img=b.end_frame();print(img.shape, img[0,0]);PY`
- `pytest` *(fails: ImportError: libGL.so.1 missing; ModuleNotFoundError: moderngl)*

------
https://chatgpt.com/codex/tasks/task_e_68a38844afa08333a8c9eab57b8edca6