### PR TITLE
Switch UI to PySide6 and fix Taichi gradient preset

### DIFF
--- a/ui/control_panel_window.py
+++ b/ui/control_panel_window.py
@@ -1,13 +1,13 @@
 # ui/control_panel_window.py - ENHANCED WITH IMPROVED UI COMPONENTS
 import logging
-from PyQt6.QtWidgets import (
+from PySide6.QtWidgets import (
     QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QComboBox,
     QGroupBox, QGridLayout, QFrame, QProgressBar, QMenuBar, QMenu, QFormLayout, QApplication,
     QMessageBox, QTextEdit, QScrollArea, QSplitter, QTabWidget, QTableWidget, QTableWidgetItem,
     QHeaderView, QDialog, QDialogButtonBox
 )
-from PyQt6.QtCore import Qt, QTimer, QMutex, QMutexLocker, QSize
-from PyQt6.QtGui import QAction, QFont, QColor
+from PySide6.QtCore import Qt, QTimer, QMutex, QMutexLocker, QSize
+from PySide6.QtGui import QAction, QFont, QColor
 
 from .preferences_dialog import PreferencesDialog
 from .midi_config_widget import MidiConfigWidget

--- a/ui/layout_sections.py
+++ b/ui/layout_sections.py
@@ -1,7 +1,7 @@
-from PyQt6.QtWidgets import (
+from PySide6.QtWidgets import (
     QFrame, QHBoxLayout, QLabel, QWidget, QVBoxLayout, QProgressBar
 )
-from PyQt6.QtCore import QTimer, Qt
+from PySide6.QtCore import QTimer, Qt
 
 
 def create_midi_activity_indicator(self):

--- a/ui/live_control_tab.py
+++ b/ui/live_control_tab.py
@@ -1,5 +1,5 @@
 # ui/live_control_tab.py - cleaned and feature-complete implementation
-from PyQt6.QtWidgets import (
+from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QLabel,
@@ -10,7 +10,7 @@ from PyQt6.QtWidgets import (
     QSpinBox,
     QSlider,
 )
-from PyQt6.QtCore import Qt
+from PySide6.QtCore import Qt
 
 import json
 import logging

--- a/ui/midi_config_tab.py
+++ b/ui/midi_config_tab.py
@@ -1,4 +1,4 @@
-from PyQt6.QtWidgets import QWidget, QVBoxLayout
+from PySide6.QtWidgets import QWidget, QVBoxLayout
 from .midi_config_widget import MidiConfigWidget
 
 

--- a/ui/midi_config_widget.py
+++ b/ui/midi_config_widget.py
@@ -1,20 +1,20 @@
 # ui/midi_config_widget.py - UI MEJORADA PARA CONFIGURACIÓN MIDI
 import logging
-from PyQt6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, QGroupBox, QLabel, 
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, QGroupBox, QLabel,
     QPushButton, QComboBox, QLineEdit, QTableWidget, QTableWidgetItem,
     QHeaderView, QTabWidget, QSpinBox, QCheckBox, QMessageBox, QSplitter,
     QTextEdit, QFrame, QScrollArea, QFormLayout
 )
-from PyQt6.QtCore import Qt, pyqtSignal, QTimer
-from PyQt6.QtGui import QFont, QColor, QBrush
+from PySide6.QtCore import Qt, Signal, QTimer
+from PySide6.QtGui import QFont, QColor, QBrush
 
 class MidiConfigWidget(QWidget):
     """Widget principal para configuración MIDI completa"""
     
     # Señales
-    mapping_changed = pyqtSignal()
-    start_learning = pyqtSignal(str)  # Emite la clave MIDI que está aprendiendo
+    mapping_changed = Signal()
+    start_learning = Signal(str)  # Emite la clave MIDI que está aprendiendo
     
     def __init__(self, midi_engine, visualizer_manager, parent=None):
         super().__init__(parent)
@@ -961,7 +961,7 @@ class MidiConfigWidget(QWidget):
     def export_json(self):
         """Exportar mappings como JSON"""
         try:
-            from PyQt6.QtWidgets import QFileDialog
+            from PySide6.QtWidgets import QFileDialog
             
             filename, _ = QFileDialog.getSaveFileName(
                 self, "Exportar Mappings MIDI", 
@@ -982,7 +982,7 @@ class MidiConfigWidget(QWidget):
     def export_readable(self):
         """Exportar mappings en formato legible"""
         try:
-            from PyQt6.QtWidgets import QFileDialog
+            from PySide6.QtWidgets import QFileDialog
             
             filename, _ = QFileDialog.getSaveFileName(
                 self, "Exportar Mappings Legible", 
@@ -1079,7 +1079,7 @@ class MidiConfigWidget(QWidget):
     def import_json(self):
         """Importar mappings desde JSON"""
         try:
-            from PyQt6.QtWidgets import QFileDialog
+            from PySide6.QtWidgets import QFileDialog
             
             filename, _ = QFileDialog.getOpenFileName(
                 self, "Importar Mappings MIDI", 
@@ -1173,7 +1173,7 @@ class MidiConfigWidget(QWidget):
         """Añadir mapping personalizado"""
         try:
             # Crear diálogo simple para mapping personalizado
-            from PyQt6.QtWidgets import QDialog, QFormLayout
+            from PySide6.QtWidgets import QDialog, QFormLayout
             
             dialog = QDialog(self)
             dialog.setWindowTitle("Añadir Mapping Personalizado")
@@ -1198,7 +1198,7 @@ class MidiConfigWidget(QWidget):
             layout.addRow("Parámetros (JSON):", params_edit)
             
             # Botones
-            from PyQt6.QtWidgets import QDialogButtonBox
+            from PySide6.QtWidgets import QDialogButtonBox
             buttons = QDialogButtonBox(
                 QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
             )
@@ -1479,7 +1479,7 @@ class CompactMidiConfigWidget(QWidget):
             layout.addWidget(config_widget)
             
             # Botón cerrar
-            from PyQt6.QtWidgets import QDialogButtonBox
+            from PySide6.QtWidgets import QDialogButtonBox
             buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
             buttons.rejected.connect(dialog.accept)
             layout.addWidget(buttons)

--- a/ui/midi_mapping_dialog.py
+++ b/ui/midi_mapping_dialog.py
@@ -2,19 +2,19 @@
 
 import json
 import logging
-from PyQt6.QtWidgets import (
+from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QTableWidget,
     QTableWidgetItem, QHeaderView, QDialogButtonBox, QLabel,
     QMessageBox, QGroupBox, QProgressBar, QComboBox, QWidget,
     QLineEdit, QSpinBox, QDoubleSpinBox
 )
-from PyQt6.QtCore import pyqtSignal, Qt, QTimer
-from PyQt6.QtGui import QFont, QColor, QBrush
+from PySide6.QtCore import Signal, Qt, QTimer
+from PySide6.QtGui import QFont, QColor, QBrush
 
 class MidiMappingDialog(QDialog):
     # Señales
-    start_midi_learn = pyqtSignal(int)  # Emite el row index que está aprendiendo
-    mappings_saved = pyqtSignal(dict)
+    start_midi_learn = Signal(int)  # Emite el row index que está aprendiendo
+    mappings_saved = Signal(dict)
 
     def __init__(self, visualizer_presets, midi_engine, deck_id=None, parent=None, as_widget=False):
         """Create the dialog.

--- a/ui/monitor_tab.py
+++ b/ui/monitor_tab.py
@@ -1,8 +1,8 @@
-from PyQt6.QtWidgets import (
+from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QSplitter, QGroupBox, QTableWidget, QHeaderView,
     QPushButton, QHBoxLayout, QLabel, QTextEdit
 )
-from PyQt6.QtCore import Qt
+from PySide6.QtCore import Qt
 
 
 def create_monitor_tab(self):

--- a/ui/preferences_dialog.py
+++ b/ui/preferences_dialog.py
@@ -1,4 +1,4 @@
-from PyQt6.QtWidgets import (
+from PySide6.QtWidgets import (
     QDialog,
     QVBoxLayout,
     QFormLayout,
@@ -11,7 +11,7 @@ from PyQt6.QtWidgets import (
     QListWidget,
     QListWidgetItem,
 )
-from PyQt6.QtCore import Qt
+from PySide6.QtCore import Qt
 import logging
 
 class PreferencesDialog(QDialog):
@@ -242,9 +242,9 @@ class PreferencesDialog(QDialog):
     def _detect_opengl_gpus(self):
         """Detect GPUs using OpenGL context creation"""
         try:
-            from PyQt6.QtOpenGL import QOpenGLContext
-            from PyQt6.QtGui import QOffscreenSurface, QSurfaceFormat
-            from PyQt6.QtCore import QCoreApplication
+            from PySide6.QtOpenGL import QOpenGLContext
+            from PySide6.QtGui import QOffscreenSurface, QSurfaceFormat
+            from PySide6.QtCore import QCoreApplication
             from OpenGL.GL import glGetString, GL_RENDERER, GL_VENDOR, GL_VERSION
 
             # Ensure we have a QApplication instance

--- a/ui/thumbnail_utils.py
+++ b/ui/thumbnail_utils.py
@@ -1,5 +1,5 @@
-from PyQt6.QtGui import QPixmap, QColor, QPainter, QPen, QBrush, QPolygon
-from PyQt6.QtCore import QPoint, Qt
+from PySide6.QtGui import QPixmap, QColor, QPainter, QPen, QBrush, QPolygon
+from PySide6.QtCore import QPoint, Qt
 import math
 from pathlib import Path
 import json
@@ -41,7 +41,7 @@ def set_custom_thumbnail_path(visual_name, path):
 
 
 def _create_wave_path(width, offset=0):
-    from PyQt6.QtGui import QPainterPath
+    from PySide6.QtGui import QPainterPath
     path = QPainterPath()
     path.moveTo(0, width // 2 + offset)
     for x in range(width):

--- a/ui/visual_settings_tab.py
+++ b/ui/visual_settings_tab.py
@@ -1,5 +1,5 @@
 # ui/visual_settings_tab.py - cleaned and feature-complete implementation
-from PyQt6.QtWidgets import (
+from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QLabel,
@@ -17,8 +17,8 @@ from PyQt6.QtWidgets import (
     QFormLayout,
     QSlider,
 )
-from PyQt6.QtCore import Qt
-from PyQt6.QtGui import (
+from PySide6.QtCore import Qt
+from PySide6.QtGui import (
     QIntValidator,
     QFont,
 )

--- a/visuals/presets/gradient.py
+++ b/visuals/presets/gradient.py
@@ -8,5 +8,12 @@ def _gradient(img: ti.template()):
 
 class GradientVisual(TaichiVisual):
     """Simple visual that renders a horizontal gradient."""
+    # Advertise this visual so ``VisualizerManager`` can discover it
+    # just like the other Taichi-based presets.
+    visual_name = "Gradient"
+
     def setup(self):
+        # Register a single rendering pass that fills the framebuffer with
+        # a horizontal gradient.  Without ``visual_name`` the manager skips
+        # this module which caused the runtime warning seen by users.
         self.renderer.add_pass("gradient", _gradient)


### PR DESCRIPTION
## Summary
- migrate UI layer from PyQt6 to PySide6 using Signal/Slot APIs
- expose visual_name in gradient Taichi preset so it's discovered
- clean up lingering compatibility imports

## Testing
- `python -m py_compile visuals/presets/gradient.py ui/mixer_window.py ui/control_panel_window.py ui/midi_mapping_dialog.py ui/midi_config_widget.py ui/midi_config_tab.py ui/live_control_tab.py ui/layout_sections.py ui/thumbnail_utils.py ui/monitor_tab.py ui/visual_settings_tab.py ui/preferences_dialog.py`
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file, ModuleNotFoundError: moderngl)*

------
https://chatgpt.com/codex/tasks/task_e_68a38a92103c8333b92a837fcff8d9a8