### PR TITLE
Make OpenGL optional for Taichi visuals and rebuild Abstract Lines spacing

### DIFF
--- a/visuals/base.py
+++ b/visuals/base.py
@@ -5,13 +5,29 @@ from __future__ import annotations
 from typing import Tuple
 
 import numpy as np
-from OpenGL.GL import (
-    GL_FLOAT,
-    GL_LUMINANCE,
-    GL_UNPACK_ALIGNMENT,
-    glDrawPixels,
-    glPixelStorei,
-)
+
+# ``PyOpenGL`` is an optional dependency.  Importing it eagerly makes any
+# module that pulls in :mod:`visuals.base` require a working OpenGL runtime
+# which is not available in the headless test environment.  Instead we try to
+# import the symbols lazily and fall back to no-op stubs when OpenGL cannot be
+# loaded.  This allows the render logic to be exercised without an actual GL
+# context (the tests only invoke :meth:`render` and never :meth:`paintGL`).
+try:  # pragma: no cover - exercised indirectly in tests
+    from OpenGL.GL import (
+        GL_FLOAT,
+        GL_LUMINANCE,
+        GL_UNPACK_ALIGNMENT,
+        glDrawPixels,
+        glPixelStorei,
+    )
+except Exception:  # pragma: no cover - gracefully handle missing OpenGL
+    GL_FLOAT = GL_LUMINANCE = GL_UNPACK_ALIGNMENT = 0
+
+    def glDrawPixels(*_args, **_kwargs):
+        return None
+
+    def glPixelStorei(*_args, **_kwargs):
+        return None
 
 from render.taichi_renderer import TaichiRenderer
 from .base_visualizer import BaseVisualizer

--- a/visuals/presets/abstract_lines.py
+++ b/visuals/presets/abstract_lines.py
@@ -13,10 +13,14 @@ class AbstractLinesVisualizer(TaichiVisual):
     def __init__(self, *args, **kwargs):
         self.offset = 0
         self.num_lines = 20
+        # ``TaichiVisual`` will call ``setup`` which computes the initial spacing
+        # based on the renderer's resolution.
         super().__init__(*args, **kwargs)
-        self.spacing = max(1, self.renderer.resolution[0] // self.num_lines)
 
     def setup(self):
+        # Derive the spacing from the current renderer resolution so that a
+        # resize triggers an updated line layout when ``setup`` is invoked again.
+        self.spacing = max(1, self.renderer.resolution[0] // self.num_lines)
         self.renderer.add_pass("lines", lambda img: _lines(img, self.offset, self.spacing))
 
     def render(self):


### PR DESCRIPTION
## Summary
- allow Taichi visuals to work without a GL runtime by lazily importing PyOpenGL and providing no-op stubs
- recompute Abstract Lines spacing during setup so resizing and initialization work correctly

## Testing
- `pytest -q test_abstract_lines_visual.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68a41850fa3883339ade3d73a6a0f35b