### PR TITLE
Fix splash screen not closing after initialization

### DIFF
--- a/ui/main_application.py
+++ b/ui/main_application.py
@@ -323,7 +323,10 @@ class MainApplication:
         try:
             # Close splash screen
             if self.splash:
-                self.splash.finish(None)
+                # Close and delete the splash screen explicitly to avoid it
+                # hanging around if initialization completes successfully
+                self.splash.close()
+                self.splash.deleteLater()
                 self.splash = None
                 
             # Create main windows
@@ -343,7 +346,9 @@ class MainApplication:
     def _on_initialization_error(self, error_message: str):
         """Handle initialization error."""
         if self.splash:
-            self.splash.finish(None)
+            # Ensure the splash is closed even when initialization fails
+            self.splash.close()
+            self.splash.deleteLater()
             self.splash = None
             
         self._show_error_dialog("Initialization Failed", error_message)


### PR DESCRIPTION
## Summary
- Ensure splash screen closes by using `close()` and `deleteLater()`
- Prevent splash screen from hanging when initialization fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68a4918cf6908333add23701b763d427