### PR TITLE
Refactor startup to avoid splash hang

### DIFF
--- a/audio/audio_analyzer.py
+++ b/audio/audio_analyzer.py
@@ -276,6 +276,31 @@ class AudioAnalyzer(QObject):
         self.cleanup()
 
 
+class DummyAudioAnalyzer(QObject):
+    """Minimal analyzer that emits silence for debugging."""
+
+    audio_data_ready = Signal(np.ndarray)
+    fft_data_ready = Signal(np.ndarray)
+    level_changed = Signal(float)
+
+    def __init__(self, chunk_size=1024):
+        super().__init__()
+        self.chunk_size = chunk_size
+        self._timer = QTimer()
+        self._timer.setInterval(100)
+        self._timer.timeout.connect(self._emit_silence)
+        self._timer.start()
+
+    def _emit_silence(self):
+        audio = np.zeros(self.chunk_size, dtype=np.float32)
+        self.audio_data_ready.emit(audio)
+        self.fft_data_ready.emit(np.zeros(self.chunk_size // 2 + 1, dtype=np.float32))
+        self.level_changed.emit(0.0)
+
+    def cleanup(self):
+        self._timer.stop()
+
+
 # Try to import pyaudio and create full version if available
 try:
     import pyaudio

--- a/midi/midi_engine.py
+++ b/midi/midi_engine.py
@@ -79,9 +79,10 @@ class MidiEngine(QObject):
 
         # Timer para procesar mensajes MIDI en cola
         self._queue_timer = QTimer()
-        self._queue_timer.setInterval(1)
+        self._queue_timer.setInterval(10)
         self._queue_timer.timeout.connect(self._process_midi_queue)
-        self._queue_timer.start()
+        # Iniciar tras un pequeño retraso para no saturar el arranque
+        QTimer.singleShot(100, self._queue_timer.start)
 
         # Configurar mappings por defecto después de inicialización
         QTimer.singleShot(1000, self.setup_default_mappings)
@@ -1311,3 +1312,25 @@ class MidiEngine(QObject):
             self.close_input_port()
         except:
             pass
+
+
+class DummyMidiEngine(QObject):
+    """Simplified engine that bypasses hardware access."""
+
+    midi_message_received = Signal(object)
+    control_changed = Signal(str, int)
+    note_on_received = Signal(int, int)
+    note_off_received = Signal(int)
+    preset_loaded_on_deck = Signal(str, str)
+    midi_message_received_for_learning = Signal(str)
+    bpm_changed = Signal(float)
+    device_connected = Signal(str)
+    device_disconnected = Signal(str)
+    mapped_action_triggered = Signal(str, int)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        logging.info("DummyMidiEngine initialized")
+
+    def cleanup(self):
+        pass


### PR DESCRIPTION
## Summary
- initialize AudioAnalyzer and MidiEngine inside worker thread with optional dummy versions
- delay MIDI queue processing and provide dummy engine to isolate hardware
- centralize cleanup to avoid GUI blocking and allow thread-safe shutdown

## Testing
- `python -m py_compile ui/main_application.py midi/midi_engine.py audio/audio_analyzer.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4bf84ee38833385d71a80f72e08a0