### PR TITLE
Fix initialization worker signal mismatch and add test

### DIFF
--- a/tests/test_initialization_worker.py
+++ b/tests/test_initialization_worker.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import sys
+import types
+
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(repo_root))
+
+# Stub out heavy dependencies before importing the module under test
+stub_modules = {
+    'midi': types.ModuleType('midi'),
+    'midi.midi_engine': types.ModuleType('midi.midi_engine'),
+    'visuals': types.ModuleType('visuals'),
+    'visuals.visualizer_manager': types.ModuleType('visuals.visualizer_manager'),
+    'audio': types.ModuleType('audio'),
+    'audio.audio_analyzer': types.ModuleType('audio.audio_analyzer'),
+    'utils': types.ModuleType('utils'),
+    'utils.settings_manager': types.ModuleType('utils.settings_manager'),
+    'ui.mixer_window': types.ModuleType('ui.mixer_window'),
+    'ui.control_panel_window': types.ModuleType('ui.control_panel_window'),
+}
+
+stub_modules['midi.midi_engine'].MidiEngine = object
+stub_modules['midi.midi_engine'].DummyMidiEngine = object
+stub_modules['visuals.visualizer_manager'].VisualizerManager = object
+stub_modules['audio.audio_analyzer'].AudioAnalyzer = object
+stub_modules['audio.audio_analyzer'].DummyAudioAnalyzer = object
+stub_modules['utils.settings_manager'].SettingsManager = object
+stub_modules['ui.mixer_window'].MixerWindow = object
+stub_modules['ui.control_panel_window'].ControlPanelWindow = object
+
+for name, module in stub_modules.items():
+    sys.modules[name] = module
+
+from ui.main_application import InitializationWorker
+
+
+class DummySettings:
+    pass
+
+
+def test_initialization_complete_emits_visualizer_manager():
+    worker = InitializationWorker(DummySettings())
+    received = []
+    worker.initialization_complete.connect(lambda vm: received.append(vm))
+    sentinel = object()
+    worker.initialization_complete.emit(sentinel)
+    assert received == [sentinel]

--- a/ui/main_application.py
+++ b/ui/main_application.py
@@ -50,8 +50,8 @@ class InitializationWorker(QObject):
     """Worker thread for heavy initialization tasks."""
     
     progress_updated = Signal(int, str)  # progress percentage, status message
-    # Emit visualizer manager and hardware components
-    initialization_complete = Signal(object, object, object)
+    # Emit visualizer manager; hardware components are created on the main thread
+    initialization_complete = Signal(object)
     error_occurred = Signal(str)
 
     def __init__(self, settings_manager):
@@ -308,7 +308,7 @@ class MainApplication:
             # Connect signals
             self.worker.progress_updated.connect(self._update_splash_progress)
             self.worker.initialization_complete.connect(
-                lambda vm, aa, me: QTimer.singleShot(0, lambda: self._on_initialization_complete(vm, aa, me))
+                lambda vm: QTimer.singleShot(0, lambda: self._on_initialization_complete(vm))
             )
             self.worker.error_occurred.connect(self._on_initialization_error)
             self.worker_thread.started.connect(self.worker.run)
@@ -330,7 +330,7 @@ class MainApplication:
                                   QColor(255, 255, 255))
             self.app.processEvents()
 
-    def _on_initialization_complete(self, visualizer_manager, audio_analyzer, midi_engine):
+    def _on_initialization_complete(self, visualizer_manager):
         """Handle successful initialization."""
         try:
             logging.info("Initialization worker signaled completion")


### PR DESCRIPTION
## Summary
- ensure `InitializationWorker.initialization_complete` only emits the visualizer manager
- adjust main application connection and handler for single-argument signal
- add unit test for `InitializationWorker` signal emission

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4c5ec970883338d561fffc0aae200