### PR TITLE
feat: scaffold live control and preview UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,28 @@
 import React, { useState } from 'react';
 import LayerGrid from './components/LayerGrid';
+import PreviewControls from './components/PreviewControls';
 
 export default function App() {
   const [tab, setTab] = useState<'live' | 'settings'>('live');
 
   return (
-    <div>
-      <nav>
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <nav style={{ padding: 5 }}>
         <button onClick={() => setTab('live')}>Live Control</button>
         <button onClick={() => setTab('settings')}>Visual Settings</button>
       </nav>
-      {tab === 'live' ? <LayerGrid /> : <div>Settings coming soon...</div>}
+      {tab === 'live' ? (
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          <div style={{ flex: 1, overflow: 'auto' }}>
+            <LayerGrid />
+          </div>
+          <div style={{ flex: 1, borderTop: '1px solid #ccc' }}>
+            <PreviewControls />
+          </div>
+        </div>
+      ) : (
+        <div style={{ padding: 20 }}>Settings coming soon...</div>
+      )}
     </div>
   );
 }

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -2,39 +2,119 @@ import React, { useState } from 'react';
 import GridLayout from 'react-grid-layout';
 import { invoke } from '@tauri-apps/api';
 
+// Basic layer metadata used to render controls
 const layers = [
   { id: 'A', midi: 14 },
   { id: 'B', midi: 15 },
   { id: 'C', midi: 16 },
 ];
 
+// Pre-build a simple 4-pad layout (2x2) for each layer
+const padLayout = [
+  { i: '0', x: 0, y: 0, w: 1, h: 1 },
+  { i: '1', x: 1, y: 0, w: 1, h: 1 },
+  { i: '2', x: 0, y: 1, w: 1, h: 1 },
+  { i: '3', x: 1, y: 1, w: 1, h: 1 },
+];
+
+type LayerId = 'A' | 'B' | 'C';
+
+interface LayerState {
+  opacity: number;
+  fade: number;
+  midi: number;
+}
+
 export default function LayerGrid() {
-  const [opacities, setOpacities] = useState({ A: 1, B: 1, C: 1 });
+  const [state, setState] = useState<Record<LayerId, LayerState>>({
+    A: { opacity: 1, fade: 0, midi: 14 },
+    B: { opacity: 1, fade: 0, midi: 15 },
+    C: { opacity: 1, fade: 0, midi: 16 },
+  });
 
-  const layout = layers.map((l, i) => ({ i: l.id, x: 0, y: i, w: 1, h: 1 }));
-
-  const handleChange = (layer: 'A' | 'B' | 'C', value: number) => {
-    setOpacities({ ...opacities, [layer]: value });
-    invoke('set_layer_opacity', { layer, opacity: value });
+  const updateLayer = (layer: LayerId, values: Partial<LayerState>) => {
+    const next = { ...state[layer], ...values };
+    setState({ ...state, [layer]: next });
+    if (values.opacity !== undefined) {
+      invoke('set_layer_opacity', { layer, opacity: values.opacity });
+    }
   };
 
   return (
-    <GridLayout className="layout" layout={layout} cols={1} rowHeight={100} width={300}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
       {layers.map((layer) => (
-        <div key={layer.id} style={{ padding: 10 }}>
-          <h3>Layer {layer.id} (MIDI {layer.midi})</h3>
-          <input
-            type="range"
-            min={0}
-            max={1}
-            step={0.01}
-            value={opacities[layer.id as 'A' | 'B' | 'C']}
-            onChange={(e) =>
-              handleChange(layer.id as 'A' | 'B' | 'C', parseFloat(e.target.value))
-            }
-          />
+        <div
+          key={layer.id}
+          style={{ border: '1px solid #ccc', padding: 10, background: '#111', color: '#fff' }}
+        >
+          <h3 style={{ marginTop: 0 }}>Layer {layer.id}</h3>
+          <GridLayout
+            className="pads"
+            layout={padLayout}
+            cols={2}
+            rowHeight={100}
+            width={200}
+            isDraggable={false}
+            isResizable={false}
+          >
+            {padLayout.map((pad) => (
+              <div
+                key={pad.i}
+                style={{
+                  border: '1px solid #555',
+                  background: '#333',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 12,
+                }}
+              >
+                Pad {pad.i}
+              </div>
+            ))}
+          </GridLayout>
+          <div style={{ marginTop: 10, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+            <label>
+              Opacity
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.01}
+                value={state[layer.id as LayerId].opacity}
+                onChange={(e) =>
+                  updateLayer(layer.id as LayerId, { opacity: parseFloat(e.target.value) })
+                }
+              />
+            </label>
+            <label>
+              Fade (ms)
+              <input
+                type="number"
+                min={0}
+                value={state[layer.id as LayerId].fade}
+                onChange={(e) =>
+                  updateLayer(layer.id as LayerId, { fade: parseInt(e.target.value, 10) })
+                }
+                style={{ width: 80 }}
+              />
+            </label>
+            <label>
+              MIDI Ch
+              <input
+                type="number"
+                min={0}
+                max={127}
+                value={state[layer.id as LayerId].midi}
+                onChange={(e) =>
+                  updateLayer(layer.id as LayerId, { midi: parseInt(e.target.value, 10) })
+                }
+                style={{ width: 60 }}
+              />
+            </label>
+          </div>
         </div>
       ))}
-    </GridLayout>
+    </div>
   );
 }

--- a/src/components/PreviewControls.tsx
+++ b/src/components/PreviewControls.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { invoke } from '@tauri-apps/api';
+
+export default function PreviewControls() {
+  const [sensitivity, setSensitivity] = useState(0.5);
+  const [smoothness, setSmoothness] = useState(0.5);
+
+  const fullscreenAll = () => {
+    invoke('fullscreen_all').catch(() => {});
+  };
+
+  return (
+    <div style={{ display: 'flex', height: '100%' }}>
+      <div
+        style={{
+          flex: 1,
+          border: '1px solid #ccc',
+          marginRight: 10,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#000',
+          color: '#fff',
+        }}
+      >
+        Preview Output
+      </div>
+      <div style={{ width: 250, display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <h3>Audio FFT</h3>
+        <label>
+          Sensitivity
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={sensitivity}
+            onChange={(e) => setSensitivity(parseFloat(e.target.value))}
+          />
+        </label>
+        <label>
+          Smoothness
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={smoothness}
+            onChange={(e) => setSmoothness(parseFloat(e.target.value))}
+          />
+        </label>
+        <button onClick={fullscreenAll}>Fullscreen All Monitors</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- split live interface into layer grid and preview sections
- add opacity, fade and MIDI controls for three layers with pad grid
- create preview panel with audio FFT controls and fullscreen button

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a4dab784d0833396eca642b590d373