### PR TITLE
Fix Electron build asset paths for AudioVisualizer

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  base: mode === 'development' ? '/' : './',
   plugins: [react()],
   build: {
     target: 'esnext'
   }
-});
+}));


### PR DESCRIPTION
## Summary
- Use relative asset paths when bundling with Vite so Electron's file-based load works

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_68a4dc135d3c83339a76825699bcdf39