### PR TITLE
Handle missing Tauri event API for Electron build

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { listen } from '@tauri-apps/api/event';
 import { AudioVisualizerEngine } from './core/AudioVisualizerEngine';
 import { LayerGrid } from './components/LayerGrid';
 import { StatusBar } from './components/StatusBar';
@@ -62,16 +61,21 @@ const App: React.FC = () => {
   useEffect(() => {
     const setupAudioListener = async () => {
       try {
+        // Intenta importar dinámicamente la API de eventos de Tauri.
+        const { listen } = await import('@tauri-apps/api/event');
+
         await listen('audio_data', (event) => {
           const data = event.payload as AudioData;
           setAudioData(data);
-          
+
           if (engineRef.current) {
             engineRef.current.updateAudioData(data);
           }
         });
       } catch (error) {
-        console.error('Failed to setup audio listener:', error);
+        // Si la API no está disponible (por ejemplo, en entorno Electron puro),
+        // simplemente registra un aviso en consola sin interrumpir la ejecución.
+        console.warn('Audio listener unavailable:', error);
       }
     };
 


### PR DESCRIPTION
## Summary
- Avoid static import of `@tauri-apps/api/event`
- Dynamically import Tauri event API and warn when unavailable

## Testing
- `npm run electron` *(fails: /workspace/AudioVisualizer/node_modules/electron/dist/electron: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fd80e0c48333a6ba37bdbba6ddd5