### PR TITLE
feat: improve audio and device handling

### DIFF
--- a/src/presets/evolutive-particles/preset.ts
+++ b/src/presets/evolutive-particles/preset.ts
@@ -344,9 +344,10 @@ class EvolutiveParticle {
     }
     
     if (this.trailPositions.length > 1) {
-      this.trailMesh.geometry.setFromPoints(this.trailPositions);
-      this.trailMesh.geometry.attributes.position.needsUpdate = true;
-      
+      const newGeometry = new THREE.BufferGeometry().setFromPoints(this.trailPositions);
+      this.trailMesh.geometry.dispose();
+      this.trailMesh.geometry = newGeometry;
+
       const trailMaterial = this.trailMesh.material as THREE.LineBasicMaterial;
       trailMaterial.opacity = this.energyLevel * 0.3;
       trailMaterial.color.copy(this.getStateColor());


### PR DESCRIPTION
## Summary
- persist selected audio and MIDI devices in local storage
- use Web Audio API for audio input when Tauri is unavailable
- rebuild particle trail geometry to avoid buffer size errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unable to find web assets)*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*


------
https://chatgpt.com/codex/tasks/task_e_68a5f1f179848333984f1854777819a3