### PR TITLE
Improve preset layout and transparency handling

### DIFF
--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -102,7 +102,7 @@
 
 /* CORRECCIÓN 1: Preset Grid - altura correcta */
 .preset-grid {
-  height: 98px; /* Ajustado para caber en el contenedor de 100px */
+  height: 96px; /* Más espacio para contenido interno */
   display: flex;
   gap: 1px;
   padding: 1px;
@@ -134,9 +134,9 @@
 /* CORRECCIÓN 2: Preset Cell - tamaño correcto */
 .preset-cell {
   position: relative;
-  width: 98px;
-  height: 98px;
-  min-width: 98px;
+  width: 96px;
+  height: 96px;
+  min-width: 96px;
   background: linear-gradient(135deg, #1E1E1E, #181818);
   border: 1px solid #333;
   border-radius: 4px; /* Añadir bordes redondeados sutiles */
@@ -148,7 +148,7 @@
   justify-content: space-between; /* Distribuir contenido */
   overflow: hidden;
   user-select: none;
-  padding: 4px; /* Añadir padding interno */
+  padding: 2px; /* Padding más pequeño */
 }
 
 .preset-cell:hover {
@@ -172,34 +172,35 @@
 /* CORRECCIÓN 3: Thumbnail mejorado */
 .preset-thumbnail {
   width: 100%;
-  height: 70px; /* Reducir altura para hacer espacio al texto */
+  height: 60px; /* Más espacio para texto abajo */
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 36px; /* Reducir tamaño del emoji */
+  font-size: 32px; /* Tamaño del emoji ajustado */
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
-  margin-bottom: 2px;
 }
 
 /* CORRECCIÓN 4: Info del preset más visible */
 .preset-info {
   width: 100%;
-  height: 20px; /* Aumentar altura */
+  height: 32px; /* Más altura para textos */
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
-  background: rgba(0, 0, 0, 0.3); /* Fondo semi-transparente */
+  background: rgba(0, 0, 0, 0.5); /* Fondo más oscuro */
   border-radius: 2px;
-  padding: 2px;
+  padding: 1px 2px;
+  gap: 1px;
 }
 
 .preset-name {
-  font-size: 8px;
+  font-size: 10px; /* Más grande */
   font-weight: 600;
   color: #FFF;
-  line-height: 10px;
+  line-height: 11px;
+  height: 12px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -207,13 +208,21 @@
 }
 
 .preset-details {
-  font-size: 6px;
+  font-size: 7px; /* Más grande */
   color: #888;
   font-weight: 400;
   text-transform: uppercase;
   letter-spacing: 0.3px;
   line-height: 8px;
-  margin-top: 1px;
+  height: 8px;
+  display: flex;
+  gap: 6px;
+  justify-content: center;
+  align-items: center;
+}
+
+.preset-category {
+  color: #aaa;
 }
 
 .preset-note {

--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -147,7 +147,8 @@ export class AudioVisualizerEngine {
       generateMipmaps: false,
       stencilBuffer: false,
       depthBuffer: true,
-      alpha: true // IMPORTANTE: Habilitar canal alpha
+      alpha: true, // IMPORTANTE: Habilitar canal alpha
+      premultiplyAlpha: false // Evitar pre-multiplicación de alpha
     });
 
     const layerState: LayerState = {
@@ -223,6 +224,10 @@ export class AudioVisualizerEngine {
     this.layers.forEach((layer, layerId) => {
       if (!layer.isActive || !layer.preset || !layer.renderTarget) return;
 
+      // CORRECCIÓN: Asegurar clear correcto antes de renderizar layer
+      this.renderer.setClearColor(0x000000, 0); // Transparente
+      this.renderer.setRenderTarget(layer.renderTarget);
+      this.renderer.clear(true, true, false); // Clear color y depth, no stencil
       // Renderizar layer a su render target
       this.renderer.setRenderTarget(layer.renderTarget);
       this.renderer.clear();

--- a/src/presets/neural_network/preset.ts
+++ b/src/presets/neural_network/preset.ts
@@ -133,10 +133,12 @@ export class InfiniteNeuralNetwork extends BasePreset {
   }
 
   init(): void {
-    // Crear scene background transparente
+    // CRÍTICO: Asegurar scene transparente
     this.scene.background = null;
-
-    // Configurar posición inicial de nodos
+    this.scene.overrideMaterial = null;
+    
+    // NO modificar la cámara global aquí - usar posición relativa
+    const initialCameraX = this.camera.position.x;
     this.camera.position.set(0, 0, 0);
     this.camera.lookAt(1, 0, 0);
 
@@ -175,12 +177,12 @@ export class InfiniteNeuralNetwork extends BasePreset {
     this.nextSpawnX = x;
   }
 
-  // CORRECCIÓN 1: Asegurar que el material sea transparente y use blending correcto
+  // CORRECCIÓN: Métodos para crear materiales con configuración correcta
   private createNodeMaterial(): THREE.MeshBasicMaterial {
     return new THREE.MeshBasicMaterial({
       color: new THREE.Color(this.currentConfig.colors.node),
       transparent: true,
-      opacity: 0.8, // No completamente opaco
+      opacity: 0.9, // Casi opaco pero con algo de transparencia
       blending: THREE.NormalBlending, // Cambiar de AdditiveBlending a NormalBlending
       depthWrite: false, // Importante para transparencia
       depthTest: true
@@ -191,7 +193,7 @@ export class InfiniteNeuralNetwork extends BasePreset {
     return new THREE.LineBasicMaterial({
       color: new THREE.Color(this.currentConfig.colors.connection),
       transparent: true,
-      opacity: 0.6,
+      opacity: 0.7,
       blending: THREE.NormalBlending, // Cambiar de AdditiveBlending
       linewidth: 1
     });
@@ -234,6 +236,10 @@ export class InfiniteNeuralNetwork extends BasePreset {
 
   updateConfig(newConfig: any): void {
     this.currentConfig = this.deepMerge(this.currentConfig, newConfig);
+    
+    // Recrear materiales con nueva configuración
+    const nodeMaterial = this.createNodeMaterial();
+    const connMaterial = this.createConnectionMaterial();
     const nodeColor = new THREE.Color(this.currentConfig.colors.node);
     const connColor = new THREE.Color(this.currentConfig.colors.connection);
     this.nodes.forEach(n => n.setColor(nodeColor));


### PR DESCRIPTION
## Summary
- shrink preset grid and cells for tighter layout and clearer info text
- refine neural network preset materials and initialization for proper transparency
- ensure engine layers clear with alpha and support transparent render targets

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a61a7aba908333a4fd4a1040e9ae74