### PR TITLE
Display preset note numbers on pads

### DIFF
--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -225,9 +225,15 @@
   color: #aaa;
 }
 
-.preset-note {
-  color: #aaa;
-}
+.preset-note-badge {
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    font-size: 8px;
+    color: #aaa;
+    pointer-events: none;
+  }
+
 
 
 .active-indicator {

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -146,6 +146,9 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
                     '--layer-color-alpha': layer.color + '20'
                   } as React.CSSProperties}
                 >
+                    {preset.config.note !== undefined && (
+                      <div className="preset-note-badge">{preset.config.note}</div>
+                    )}
                   <div className="preset-thumbnail">
                     {getPresetThumbnail(preset)}
                   </div>
@@ -153,9 +156,6 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
                     <div className="preset-name">{preset.config.name}</div>
                     <div className="preset-details">
                       <span className="preset-category">{preset.config.category}</span>
-                      {preset.config.note !== undefined && (
-                        <span className="preset-note">note:{preset.config.note}</span>
-                      )}
                     </div>
                   </div>
                   

--- a/src/presets/abstract-lines/config.json
+++ b/src/presets/abstract-lines/config.json
@@ -6,7 +6,7 @@
   "category": "abstract",
   "tags": ["abstract", "lines", "organic", "fluid", "minimal", "geometric"],
   "thumbnail": "abstract_lines_thumb.png",
-  "note": 51,
+  "note": 55,
   "defaultConfig": {
     "width": 1920,
     "height": 1080,

--- a/src/presets/boom-wave/config.json
+++ b/src/presets/boom-wave/config.json
@@ -6,6 +6,7 @@
   "category": "one-shot",
   "tags": ["wave", "bass", "one-shot"],
   "thumbnail": "boom_wave_thumb.png",
+  "note": 58,
   "defaultConfig": {
     "opacity": 1.0,
     "fadeMs": 200,

--- a/src/presets/custom-glitch-text/config.json
+++ b/src/presets/custom-glitch-text/config.json
@@ -6,6 +6,7 @@
   "category": "text",
   "tags": ["text", "glitch", "one-shot"],
   "thumbnail": "custom_glitch_text_thumb.png",
+  "note": 59,
   "defaultConfig": {
     "opacity": 1.0,
     "fadeMs": 200,

--- a/src/presets/evolutive-particles/config.json
+++ b/src/presets/evolutive-particles/config.json
@@ -6,7 +6,7 @@
   "category": "particles",
   "tags": ["particles", "evolution", "organic", "complex", "adaptive", "swarm"],
   "thumbnail": "evolutive_particles_thumb.png",
-  "note": 52,
+  "note": 56,
   "defaultConfig": {
     "width": 1920,
     "height": 1080,

--- a/src/presets/neural_network/config.json
+++ b/src/presets/neural_network/config.json
@@ -6,7 +6,7 @@
   "category": "abstract",
   "tags": ["neural", "network", "infinite", "starfield"],
   "thumbnail": "neural_network_thumb.png",
-  "note": 50,
+  "note": 54,
   "defaultConfig": {
     "width": 1920,
     "height": 1080,

--- a/src/presets/plasma-ray/config.json
+++ b/src/presets/plasma-ray/config.json
@@ -6,7 +6,7 @@
   "category": "energy",
   "tags": ["plasma", "energy", "electric", "lightning", "rays", "power"],
   "thumbnail": "plasma_ray_thumb.png",
-  "note": 54,
+  "note": 57,
   "defaultConfig": {
     "width": 1920,
     "height": 1080,

--- a/src/presets/shot-text/config.json
+++ b/src/presets/shot-text/config.json
@@ -6,7 +6,7 @@
   "category": "text",
   "tags": ["text", "intro", "robotica", "cinematic", "glow", "animation"],
   "thumbnail": "robotica_intro_thumb.png",
-  "note": 53,
+  "note": 60,
   "defaultConfig": {
     "width": 1920,
     "height": 1080,

--- a/src/presets/text-glitch/config.json
+++ b/src/presets/text-glitch/config.json
@@ -6,7 +6,7 @@
   "category": "text",
   "tags": ["text", "glitch", "animated", "cyberpunk", "digital"],
   "thumbnail": "text_glitch_thumb.png",
-  "note": 55,
+  "note": 61,
   "defaultConfig": {
     "width": 1920,
     "height": 1080,


### PR DESCRIPTION
## Summary
- Assign sequential MIDI note numbers to all visuals
- Show each preset's note number in the pad's top-left corner

## Testing
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_68a61e5c4f50833394f5aed239c6ff28