### PR TITLE
Improve MIDI metronome visuals and BPM sync

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -574,15 +574,23 @@ body {
 }
 
 .metronome {
+  display: flex;
+  gap: 4px;
+}
+
+.metronome-led {
   width: 10px;
   height: 10px;
   border-radius: 50%;
   background: #555;
-  transition: background 0.05s;
+  opacity: 0.3;
+  transition: opacity 0.3s, background 0.3s;
 }
 
-.metronome.active {
+.metronome-led.active {
   background: #f00;
+  opacity: 1;
+  box-shadow: 0 0 6px #f00;
 }
 
 .separator {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,8 +23,8 @@ interface MonitorInfo {
 const App: React.FC = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const engineRef = useRef<AudioVisualizerEngine | null>(null);
-  const clockTimesRef = useRef<number[]>([]);
-  const clockCountRef = useRef(0);
+  const tickCountRef = useRef(0);
+  const lastBeatRef = useRef<number | null>(null);
   
   const [isInitialized, setIsInitialized] = useState(false);
   const [availablePresets, setAvailablePresets] = useState<LoadedPreset[]>([]);
@@ -226,25 +226,24 @@ const App: React.FC = () => {
       // MIDI Clock handling
       if (statusByte === 0xf8) {
         const now = performance.now();
-        const times = clockTimesRef.current;
-        times.push(now);
-        if (times.length > 24) times.shift();
+        tickCountRef.current++;
 
-        clockCountRef.current++;
-        if (clockCountRef.current % 24 === 0) {
+        if (tickCountRef.current >= 24) {
+          const lastBeat = lastBeatRef.current;
+          if (lastBeat !== null) {
+            const diff = now - lastBeat;
+            const bpmVal = 60000 / diff;
+            setBpm(bpmVal);
+            if (engineRef.current) {
+              engineRef.current.updateBpm(bpmVal);
+            }
+          }
+          lastBeatRef.current = now;
+          tickCountRef.current = 0;
           setBeatActive(true);
           setTimeout(() => setBeatActive(false), 100);
           if (engineRef.current) {
             engineRef.current.triggerBeat();
-          }
-        }
-
-        if (times.length >= 2) {
-          const diff = (times[times.length - 1] - times[0]) / (times.length - 1);
-          const bpmVal = 60000 / (diff * 24);
-          setBpm(bpmVal);
-          if (engineRef.current) {
-            engineRef.current.updateBpm(bpmVal);
           }
         }
         return;

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface TopBarProps {
   midiActive: boolean;
@@ -31,6 +31,14 @@ export const TopBar: React.FC<TopBarProps> = ({
   onClearAll,
   onOpenSettings
 }) => {
+  const [activeLed, setActiveLed] = useState(0);
+
+  useEffect(() => {
+    if (beatActive) {
+      setActiveLed(prev => (prev === 0 ? 1 : 0));
+    }
+  }, [beatActive]);
+
   return (
     <div className="top-bar">
       <div className="midi-section">
@@ -44,7 +52,10 @@ export const TopBar: React.FC<TopBarProps> = ({
 
       <div className="bpm-section">
         <span>BPM: {bpm ? bpm.toFixed(1) : '--'}</span>
-        <div className={`metronome ${beatActive ? 'active' : ''}`}></div>
+        <div className="metronome">
+          <div className={`metronome-led ${activeLed === 0 ? 'active' : ''}`}></div>
+          <div className={`metronome-led ${activeLed === 1 ? 'active' : ''}`}></div>
+        </div>
       </div>
 
       <div className="separator" />


### PR DESCRIPTION
## Summary
- Replace single beat LED with two alternating LEDs for a fading metronome animation
- Derive BPM directly from MIDI clock pulses to avoid doubled tempo

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*
- `npm run build` *(fails: Unable to find web assets for Tauri build)*

------
https://chatgpt.com/codex/tasks/task_e_68a634ec0a388333823fef0b87219f8b