### PR TITLE
Fix sidebar controls and per-layer preset configuration

### DIFF
--- a/src/components/PresetControls.tsx
+++ b/src/components/PresetControls.tsx
@@ -64,14 +64,14 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
         return (
           <div key={control.name} className="control-group">
             <label className="control-label">
-              {control.label || control.name}: {currentValue?.toFixed?.(2) || currentValue}
+              {control.label || control.name}: {currentValue?.toFixed?.(2) ?? currentValue}
             </label>
             <input
               type="range"
               min={control.min || 0}
               max={control.max || 1}
               step={control.step || 0.01}
-              value={currentValue || control.default || 0}
+              value={currentValue ?? control.default ?? 0}
               onChange={(e) => handleControlChange(control.name, e.target.value, 'slider')}
               className="control-slider"
             />
@@ -91,7 +91,7 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
               min={control.min}
               max={control.max}
               step={control.step || 1}
-              value={currentValue || control.default || 0}
+              value={currentValue ?? control.default ?? 0}
               onChange={(e) => handleControlChange(control.name, e.target.value, 'number')}
               className="control-number"
             />
@@ -101,7 +101,7 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
       case 'color':
         const colorHex = Array.isArray(currentValue) 
           ? `#${Math.round(currentValue[0] * 255).toString(16).padStart(2, '0')}${Math.round(currentValue[1] * 255).toString(16).padStart(2, '0')}${Math.round(currentValue[2] * 255).toString(16).padStart(2, '0')}`
-          : currentValue || control.default || '#ffffff';
+          : currentValue ?? control.default ?? '#ffffff';
         
         return (
           <div key={control.name} className="control-group">
@@ -124,7 +124,7 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
             <label className="control-label checkbox-label">
               <input
                 type="checkbox"
-                checked={currentValue || control.default || false}
+                checked={currentValue ?? control.default ?? false}
                 onChange={(e) => handleControlChange(control.name, e.target.checked, 'boolean')}
                 className="control-checkbox"
               />
@@ -138,7 +138,7 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
           <div key={control.name} className="control-group">
             <label className="control-label">{control.label || control.name}</label>
             <select
-              value={currentValue || control.default || ''}
+              value={currentValue ?? control.default ?? ''}
               onChange={(e) => handleControlChange(control.name, e.target.value, 'select')}
               className="control-select"
             >
@@ -157,7 +157,7 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
             <label className="control-label">{control.label || control.name}</label>
             <input
               type="text"
-              value={currentValue?.toString() || control.default?.toString() || ''}
+              value={currentValue?.toString() ?? control.default?.toString() ?? ''}
               onChange={(e) => handleControlChange(control.name, e.target.value, 'text')}
               className="control-text"
               placeholder={control.placeholder}
@@ -171,7 +171,7 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
             <label className="control-label">{control.label || control.name}</label>
             <input
               type="text"
-              value={currentValue?.toString() || control.default?.toString() || ''}
+              value={currentValue?.toString() ?? control.default?.toString() ?? ''}
               onChange={(e) => handleControlChange(control.name, e.target.value, 'text')}
               className="control-text"
             />

--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -282,11 +282,19 @@ export class AudioVisualizerEngine {
         layer.scene.clear();
       }
 
-      // Cargar configuración guardada específica para el layer
+      // Buscar preset cargado
+      const loadedPreset = this.presetLoader.getLoadedPresets().find(p => p.id === presetId);
+      if (!loadedPreset) {
+        console.error(`Loaded preset ${presetId} no encontrado`);
+        return false;
+      }
+
+      // Cargar configuración guardada específica para el layer y clonar config base
       const savedConfig = this.loadLayerPresetConfig(presetId, layerId);
-      const loadedPresetConfig = {
-        ...loadedPreset.config,
-        defaultConfig: { ...loadedPreset.config.defaultConfig, ...savedConfig }
+      const loadedPresetConfig = JSON.parse(JSON.stringify(loadedPreset.config));
+      loadedPresetConfig.defaultConfig = {
+        ...loadedPresetConfig.defaultConfig,
+        ...savedConfig
       };
 
       // Activar nuevo preset con config específica del layer
@@ -298,13 +306,6 @@ export class AudioVisualizerEngine {
       );
       if (!presetInstance) {
         console.error(`No se pudo activar preset ${presetId}`);
-        return false;
-      }
-
-      // Encontrar el preset loaded para guardarlo
-      const loadedPreset = this.presetLoader.getLoadedPresets().find(p => p.id === presetId);
-      if (!loadedPreset) {
-        console.error(`Loaded preset ${presetId} no encontrado`);
         return false;
       }
 


### PR DESCRIPTION
## Summary
- Fix preset activation to clone per-layer config and load saved layer settings
- Use nullish coalescing in PresetControls to allow sliders, checkboxes, and other inputs to update values (including 0/false)

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unable to find web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68a636839aa88333b4142bd85399d3ad