### PR TITLE
feat: grouped butterflies for analysis preset

### DIFF
--- a/src/presets/analysis/config.json
+++ b/src/presets/analysis/config.json
@@ -9,26 +9,24 @@
   "note": 48,
   "defaultConfig": {
     "radius": 8,
-    "butterflyCount": 12,
+    "butterflyCount": 20,
     "colors": {
-      "low": "#3498db",
-      "mid": "#2ecc71",
-      "high": "#e74c3c",
-      "butterfly": "#ffccff"
+      "low": "#607080",
+      "mid": "#8fa1b3",
+      "high": "#c7d8e8"
     }
   },
   "controls": [
     {"name": "radius", "type": "slider", "label": "Camera Radius", "min": 5, "max": 15, "step": 0.5, "default": 8},
-    {"name": "butterflyCount", "type": "slider", "label": "Butterflies", "min": 0, "max": 50, "step": 1, "default": 12},
-    {"name": "colors.low", "type": "color", "label": "Low Color", "default": "#3498db"},
-    {"name": "colors.mid", "type": "color", "label": "Mid Color", "default": "#2ecc71"},
-    {"name": "colors.high", "type": "color", "label": "High Color", "default": "#e74c3c"},
-    {"name": "colors.butterfly", "type": "color", "label": "Butterfly Color", "default": "#ffccff"}
+    {"name": "butterflyCount", "type": "slider", "label": "Max Butterflies", "min": 5, "max": 50, "step": 1, "default": 20},
+    {"name": "colors.low", "type": "color", "label": "Low Color", "default": "#607080"},
+    {"name": "colors.mid", "type": "color", "label": "Mid Color", "default": "#8fa1b3"},
+    {"name": "colors.high", "type": "color", "label": "High Color", "default": "#c7d8e8"}
   ],
   "audioMapping": {
-    "low": {"description": "Low frequencies", "frequency": "20-250 Hz", "effect": "Low bar height"},
-    "mid": {"description": "Mid frequencies", "frequency": "250-4000 Hz", "effect": "Mid bar height"},
-    "high": {"description": "High frequencies", "frequency": "4000+ Hz", "effect": "High bar height"}
+    "low": {"description": "Low frequencies", "frequency": "20-250 Hz", "effect": "Low band butterfly density"},
+    "mid": {"description": "Mid frequencies", "frequency": "250-4000 Hz", "effect": "Mid band butterfly density"},
+    "high": {"description": "High frequencies", "frequency": "4000+ Hz", "effect": "High band butterfly density"}
   },
   "performance": {"complexity": "low", "recommendedFPS": 60, "gpuIntensive": false}
 }

--- a/src/presets/analysis/preset.ts
+++ b/src/presets/analysis/preset.ts
@@ -3,7 +3,7 @@ import { BasePreset, PresetConfig } from '../../core/PresetLoader';
 
 export const config: PresetConfig = {
   name: 'ANALYSIS',
-  description: '3D audio spectrum analyzer with butterflies and rotating camera.',
+  description: '3D audio spectrum analyzer with grouped butterflies and rotating camera.',
   author: 'AudioVisualizer',
   version: '1.0.0',
   category: 'analysis',
@@ -12,41 +12,27 @@ export const config: PresetConfig = {
   note: 48,
   defaultConfig: {
     radius: 8,
-    butterflyCount: 12,
+    butterflyCount: 20,
     colors: {
-      low: '#3498db',
-      mid: '#2ecc71',
-      high: '#e74c3c',
-      butterfly: '#ffccff'
+      low: '#607080',
+      mid: '#8fa1b3',
+      high: '#c7d8e8'
     }
   },
   controls: [
     { name: 'radius', type: 'slider', label: 'Camera Radius', min: 5, max: 15, step: 0.5, default: 8 },
-    { name: 'butterflyCount', type: 'slider', label: 'Butterflies', min: 0, max: 50, step: 1, default: 12 },
-    { name: 'colors.low', type: 'color', label: 'Low Color', default: '#3498db' },
-    { name: 'colors.mid', type: 'color', label: 'Mid Color', default: '#2ecc71' },
-    { name: 'colors.high', type: 'color', label: 'High Color', default: '#e74c3c' },
-    { name: 'colors.butterfly', type: 'color', label: 'Butterfly Color', default: '#ffccff' }
+    { name: 'butterflyCount', type: 'slider', label: 'Max Butterflies', min: 5, max: 50, step: 1, default: 20 },
+    { name: 'colors.low', type: 'color', label: 'Low Color', default: '#607080' },
+    { name: 'colors.mid', type: 'color', label: 'Mid Color', default: '#8fa1b3' },
+    { name: 'colors.high', type: 'color', label: 'High Color', default: '#c7d8e8' }
   ],
   audioMapping: {
-    low: { description: 'Low frequencies', frequency: '20-250 Hz', effect: 'Low bar height' },
-    mid: { description: 'Mid frequencies', frequency: '250-4000 Hz', effect: 'Mid bar height' },
-    high: { description: 'High frequencies', frequency: '4000+ Hz', effect: 'High bar height' }
+    low: { description: 'Low frequencies', frequency: '20-250 Hz', effect: 'Low band butterfly density' },
+    mid: { description: 'Mid frequencies', frequency: '250-4000 Hz', effect: 'Mid band butterfly density' },
+    high: { description: 'High frequencies', frequency: '4000+ Hz', effect: 'High band butterfly density' }
   },
   performance: { complexity: 'low', recommendedFPS: 60, gpuIntensive: false }
 };
-
-interface LabelData {
-  sprite: THREE.Sprite;
-  canvas: HTMLCanvasElement;
-  ctx: CanvasRenderingContext2D;
-  texture: THREE.Texture;
-}
-
-interface Bar {
-  mesh: THREE.Mesh;
-  label: LabelData;
-}
 
 interface Butterfly {
   group: THREE.Group;
@@ -55,10 +41,15 @@ interface Butterfly {
   offset: number;
 }
 
+interface ButterflyRange {
+  butterflies: Butterfly[];
+  color: string;
+  centerX: number;
+}
+
 class AnalysisSpectrum extends BasePreset {
   private group!: THREE.Group;
-  private bars: Bar[] = [];
-  private butterflies: Butterfly[] = [];
+  private butterflyGroups!: Record<'low' | 'mid' | 'high', ButterflyRange>;
   private grid?: THREE.GridHelper;
   private ambient?: THREE.AmbientLight;
   private pointLight?: THREE.PointLight;
@@ -86,96 +77,72 @@ class AnalysisSpectrum extends BasePreset {
     this.scene.add(this.ambient);
     this.scene.add(this.pointLight);
 
-    // Bars for low, mid, high
+    // Butterfly groups for low, mid and high bands
     const colors = this.currentConfig.colors;
-    this.bars.push(this.createBar(colors.low, -2));
-    this.bars.push(this.createBar(colors.mid, 0));
-    this.bars.push(this.createBar(colors.high, 2));
+    this.butterflyGroups = {
+      low: { butterflies: [], color: colors.low, centerX: -2 },
+      mid: { butterflies: [], color: colors.mid, centerX: 0 },
+      high: { butterflies: [], color: colors.high, centerX: 2 }
+    };
 
-    // Butterflies
-    for (let i = 0; i < this.currentConfig.butterflyCount; i++) {
-      this.butterflies.push(this.createButterfly());
-    }
+    Object.values(this.butterflyGroups).forEach(range => {
+      for (let i = 0; i < 2; i++) {
+        range.butterflies.push(this.createButterfly(range.color, range.centerX));
+      }
+    });
   }
 
-  private createBar(color: string, x: number): Bar {
-    const geometry = new THREE.BoxGeometry(0.5, 1, 0.5);
-    const material = new THREE.MeshStandardMaterial({ color, emissive: color, emissiveIntensity: 0.3 });
-    const mesh = new THREE.Mesh(geometry, material);
-    mesh.position.set(x, 0.5, 0);
-    const label = this.createLabel('0 dB');
-    label.sprite.position.set(x, 1.2, 0);
-    this.group.add(mesh);
-    this.group.add(label.sprite);
-    return { mesh, label };
-  }
-
-  private createLabel(text: string): LabelData {
-    const canvas = document.createElement('canvas');
-    canvas.width = 128;
-    canvas.height = 64;
-    const ctx = canvas.getContext('2d')!;
-    const texture = new THREE.CanvasTexture(canvas);
-    const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
-    const sprite = new THREE.Sprite(material);
-    sprite.scale.set(1, 0.5, 1);
-    const label = { sprite, canvas, ctx, texture };
-    this.updateLabel(label, text);
-    return label;
-  }
-
-  private updateLabel(label: LabelData, text: string): void {
-    const { canvas, ctx, texture } = label;
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.fillStyle = '#ffffff';
-    ctx.font = '28px Arial';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText(text, canvas.width / 2, canvas.height / 2);
-    texture.needsUpdate = true;
-  }
-
-  private createButterfly(): Butterfly {
+  private createButterfly(color: string, centerX: number): Butterfly {
     const group = new THREE.Group();
-    const geom = new THREE.PlaneGeometry(0.3, 0.2);
-    const mat = new THREE.MeshBasicMaterial({ color: this.currentConfig.colors.butterfly, side: THREE.DoubleSide });
+    const geom = new THREE.PlaneGeometry(0.2, 0.15);
+    const mat = new THREE.MeshBasicMaterial({ color, side: THREE.DoubleSide });
     const left = new THREE.Mesh(geom, mat);
     const right = new THREE.Mesh(geom, mat);
-    left.position.x = -0.15;
-    right.position.x = 0.15;
+    left.position.x = -0.1;
+    right.position.x = 0.1;
     group.add(left);
     group.add(right);
-    const radius = 2 + Math.random() * 3;
+    const radius = 0.5 + Math.random();
     const speed = 0.5 + Math.random();
     const offset = Math.random() * Math.PI * 2;
-    group.position.set(Math.cos(offset) * radius, 1 + Math.random() * 2, Math.sin(offset) * radius);
+    group.position.set(centerX + Math.cos(offset) * radius, 1 + Math.random() * 2, Math.sin(offset) * radius);
     this.group.add(group);
     return { group, speed, radius, offset };
   }
 
+  private adjustButterflies(range: ButterflyRange, target: number): void {
+    while (range.butterflies.length < target) {
+      range.butterflies.push(this.createButterfly(range.color, range.centerX));
+    }
+    while (range.butterflies.length > target) {
+      const b = range.butterflies.pop()!;
+      this.group.remove(b.group);
+    }
+  }
+
   update(): void {
     const time = this.clock.getElapsedTime();
-    const bands = [this.audioData.low, this.audioData.mid, this.audioData.high];
+    const bands = {
+      low: this.audioData.low,
+      mid: this.audioData.mid,
+      high: this.audioData.high
+    };
 
-    this.bars.forEach((bar, i) => {
-      const amp = Math.max(bands[i], 0.0001);
-      const target = 0.5 + amp * 5;
-      bar.mesh.scale.y = THREE.MathUtils.lerp(bar.mesh.scale.y, target, 0.2);
-      bar.mesh.position.y = bar.mesh.scale.y / 2;
-      bar.label.sprite.position.y = bar.mesh.scale.y + 0.1;
-      const db = 20 * Math.log10(amp);
-      this.updateLabel(bar.label, `${db.toFixed(1)} dB`);
-    });
-
-    this.butterflies.forEach(b => {
-      const angle = time * b.speed + b.offset;
-      b.group.position.x = Math.cos(angle) * b.radius;
-      b.group.position.z = Math.sin(angle) * b.radius;
-      const flap = Math.sin(time * 4 + b.offset) * 0.5;
-      if (b.group.children[0] && b.group.children[1]) {
-        b.group.children[0].rotation.z = flap;
-        b.group.children[1].rotation.z = -flap;
-      }
+    (Object.keys(this.butterflyGroups) as Array<'low' | 'mid' | 'high'>).forEach(key => {
+      const range = this.butterflyGroups[key];
+      const amp = Math.max(bands[key], 0);
+      const target = Math.max(2, Math.floor(amp * this.currentConfig.butterflyCount));
+      this.adjustButterflies(range, target);
+      range.butterflies.forEach(b => {
+        const angle = time * b.speed + b.offset;
+        b.group.position.x = range.centerX + Math.cos(angle) * b.radius;
+        b.group.position.z = Math.sin(angle) * b.radius;
+        const flap = Math.sin(time * 4 + b.offset) * 0.5;
+        if (b.group.children[0] && b.group.children[1]) {
+          b.group.children[0].rotation.z = flap;
+          b.group.children[1].rotation.z = -flap;
+        }
+      });
     });
 
     const radius = this.currentConfig.radius;
@@ -195,18 +162,15 @@ class AnalysisSpectrum extends BasePreset {
     this.scene.remove(this.ambient!);
     this.scene.remove(this.pointLight!);
 
-    this.bars.forEach(bar => {
-      bar.mesh.geometry.dispose();
-      (bar.mesh.material as THREE.Material).dispose();
-      bar.label.texture.dispose();
-    });
-
     this.camera.position.copy(this.initialCameraPosition);
     this.camera.quaternion.copy(this.initialCameraQuaternion);
 
     this.group.clear();
-    this.butterflies = [];
-    this.bars = [];
+    this.butterflyGroups = {
+      low: { butterflies: [], color: '', centerX: -2 },
+      mid: { butterflies: [], color: '', centerX: 0 },
+      high: { butterflies: [], color: '', centerX: 2 }
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- replace spectrum bars with low/mid/high butterfly groups
- pastel grey-blue palette per frequency band
- density of small butterflies reacts to dB levels

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a7043eb6ac83339149b50f39cbf2c0