### PR TITLE
feat: configurable fullscreen monitors

### DIFF
--- a/electron.cjs
+++ b/electron.cjs
@@ -43,6 +43,14 @@ function createWindow() {
   mainWindow.webContents.on('console-message', (event, level, message, line, sourceId) => {
     console.log(`Console [${level}]:`, message);
   });
+
+  // Si el usuario sale del modo fullscreen manualmente, cerrar las ventanas
+  // secundarias y notificar al renderer para que actualice su estado
+  mainWindow.on('leave-full-screen', () => {
+    fullscreenWindows.forEach(win => win.close());
+    fullscreenWindows = [];
+    mainWindow.webContents.send('main-leave-fullscreen');
+  });
 }
 
 ipcMain.on('apply-settings', (event, settings) => {

--- a/preload.cjs
+++ b/preload.cjs
@@ -10,5 +10,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Recepción de frames en ventanas clon
   onReceiveFrame: (callback) => ipcRenderer.on('receive-frame', callback),
-  removeFrameListener: () => ipcRenderer.removeAllListeners('receive-frame')
+  removeFrameListener: () => ipcRenderer.removeAllListeners('receive-frame'),
+
+  // Notificación cuando la ventana principal sale de fullscreen
+  onMainLeaveFullscreen: (callback) => ipcRenderer.on('main-leave-fullscreen', callback),
+  removeMainLeaveFullscreenListener: () => ipcRenderer.removeAllListeners('main-leave-fullscreen')
 });

--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -36,6 +36,8 @@ interface GlobalSettingsModalProps {
   onLayerChannelChange: (layerId: string, channel: number) => void;
   monitors: MonitorInfo[];
   selectedMonitors: string[];
+  fullscreenMainMonitor: string | null;
+  onFullscreenMainMonitorChange: (id: string | null) => void;
   onToggleMonitor: (id: string) => void;
   startMonitor: string | null;
   onStartMonitorChange: (id: string | null) => void;
@@ -74,6 +76,8 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
   onLayerChannelChange,
   monitors,
   selectedMonitors,
+  fullscreenMainMonitor,
+  onFullscreenMainMonitorChange,
   onToggleMonitor,
   startMonitor,
   onStartMonitorChange,
@@ -511,6 +515,28 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
               <div className="monitors-summary">
                 <strong>Monitores seleccionados: {selectedMonitors.length}</strong>
                 <p>Se abrirá una ventana fullscreen en cada monitor seleccionado</p>
+              </div>
+
+              <div className="setting-group">
+                <label className="setting-label">
+                  <span>Monitor principal en fullscreen</span>
+                  <select
+                    value={fullscreenMainMonitor || ''}
+                    onChange={(e) => onFullscreenMainMonitorChange(e.target.value || null)}
+                    className="setting-select"
+                  >
+                    <option value="">Primero de la lista</option>
+                    {selectedMonitors.map(id => {
+                      const m = monitors.find(mon => mon.id === id);
+                      return (
+                        <option key={id} value={id}>
+                          {m?.label || id}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </label>
+                <small className="setting-hint">La ventana principal permanecerá en este monitor</small>
               </div>
             </div>
           )}

--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -48,7 +48,11 @@ export class AudioVisualizerEngine {
       antialias: true,
       alpha: true,
       powerPreference: 'high-performance',
-      preserveDrawingBuffer: false // Mejor rendimiento
+      // Necesario para capturar frames y replicar la vista en monitores secundarios
+      // cuando el modo multi-monitor está activo. Puede tener un ligero impacto en
+      // el rendimiento, pero garantiza que el contenido del canvas esté disponible
+      // para toBlob()/toDataURL.
+      preserveDrawingBuffer: true
     });
     
     // Configuración optimizada del renderer


### PR DESCRIPTION
## Summary
- allow selecting a primary monitor for fullscreen mode from Settings
- close secondary windows when leaving fullscreen and expose renderer event
- ensure cloned windows mirror main view by preserving WebGL buffer

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc --noEmit` (fails: Cannot find type definition file for 'vite/client')


------
https://chatgpt.com/codex/tasks/task_e_68a734d9dba48333b6d1492859876493