### PR TITLE
feat: add canvas visual settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,6 +98,9 @@ const App: React.FC = () => {
   const [fullscreenByDefault, setFullscreenByDefault] = useState(() => localStorage.getItem('fullscreenByDefault') !== 'false');
   const [startMaximized, setStartMaximized] = useState(() => localStorage.getItem('startMaximized') !== 'false');
   const [startMonitor, setStartMonitor] = useState<string | null>(() => localStorage.getItem('startMonitor'));
+  const [canvasBrightness, setCanvasBrightness] = useState(() => parseFloat(localStorage.getItem('canvasBrightness') || '1'));
+  const [canvasVibrance, setCanvasVibrance] = useState(() => parseFloat(localStorage.getItem('canvasVibrance') || '1'));
+  const [canvasBackground, setCanvasBackground] = useState(() => localStorage.getItem('canvasBackground') || '#000000');
 
   useEffect(() => {
     const channel = new BroadcastChannel('av-sync');
@@ -142,6 +145,18 @@ const App: React.FC = () => {
   useEffect(() => {
     localStorage.setItem('fullscreenByDefault', fullscreenByDefault.toString());
   }, [fullscreenByDefault]);
+
+  useEffect(() => {
+    localStorage.setItem('canvasBrightness', canvasBrightness.toString());
+  }, [canvasBrightness]);
+
+  useEffect(() => {
+    localStorage.setItem('canvasVibrance', canvasVibrance.toString());
+  }, [canvasVibrance]);
+
+  useEffect(() => {
+    localStorage.setItem('canvasBackground', canvasBackground);
+  }, [canvasBackground]);
 
   useEffect(() => {
     if (!isFullscreenMode && midiTrigger) {
@@ -955,7 +970,14 @@ const App: React.FC = () => {
 
       {/* Sección inferior con visuales y controles */}
       <div className="bottom-section">
-        <canvas ref={canvasRef} className="main-canvas" />
+        <canvas
+          ref={canvasRef}
+          className="main-canvas"
+          style={{
+            filter: `brightness(${canvasBrightness}) saturate(${canvasVibrance})`,
+            background: canvasBackground
+          }}
+        />
         <div className={`controls-panel ${isControlsOpen ? '' : 'collapsed'}`}>
           <button
             className="toggle-sidebar"
@@ -1077,6 +1099,12 @@ const App: React.FC = () => {
           setFullscreenByDefault(value);
           localStorage.setItem('fullscreenByDefault', value.toString());
         }}
+        canvasBrightness={canvasBrightness}
+        onCanvasBrightnessChange={setCanvasBrightness}
+        canvasVibrance={canvasVibrance}
+        onCanvasVibranceChange={setCanvasVibrance}
+        canvasBackground={canvasBackground}
+        onCanvasBackgroundChange={setCanvasBackground}
       />
 
       {/* Modal de galería de presets */}

--- a/src/components/GlobalSettingsModal.css
+++ b/src/components/GlobalSettingsModal.css
@@ -212,6 +212,15 @@
   transition: all 0.2s ease;
 }
 
+.setting-color {
+  background: transparent;
+  border: none;
+  width: 50px;
+  height: 30px;
+  padding: 0;
+  cursor: pointer;
+}
+
 .layer-channel-settings {
   display: flex;
   flex-direction: column;

--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -53,6 +53,12 @@ interface GlobalSettingsModalProps {
   onStartMaximizedChange: (value: boolean) => void;
   sidebarCollapsed: boolean;
   onSidebarCollapsedChange: (value: boolean) => void;
+  canvasBrightness: number;
+  onCanvasBrightnessChange: (value: number) => void;
+  canvasVibrance: number;
+  onCanvasVibranceChange: (value: number) => void;
+  canvasBackground: string;
+  onCanvasBackgroundChange: (value: string) => void;
 }
 
 export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
@@ -90,7 +96,13 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
   startMaximized,
   onStartMaximizedChange,
   sidebarCollapsed,
-  onSidebarCollapsedChange
+  onSidebarCollapsedChange,
+  canvasBrightness,
+  onCanvasBrightnessChange,
+  canvasVibrance,
+  onCanvasVibranceChange,
+  canvasBackground,
+  onCanvasBackgroundChange
 }) => {
   const [activeTab, setActiveTab] = useState('audio');
   
@@ -606,6 +618,51 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
                   />
                   <span>Ventanas en fullscreen por defecto</span>
                 </label>
+              </div>
+
+              <div className="setting-group">
+                <label className="setting-label">
+                  <span>Brillo: {canvasBrightness.toFixed(2)}</span>
+                  <input
+                    type="range"
+                    min={0.5}
+                    max={2}
+                    step={0.1}
+                    value={canvasBrightness}
+                    onChange={(e) => onCanvasBrightnessChange(parseFloat(e.target.value))}
+                    className="setting-slider"
+                  />
+                </label>
+                <small className="setting-hint">Ajusta el brillo global del canvas</small>
+              </div>
+
+              <div className="setting-group">
+                <label className="setting-label">
+                  <span>Viveza: {canvasVibrance.toFixed(2)}</span>
+                  <input
+                    type="range"
+                    min={0}
+                    max={2}
+                    step={0.1}
+                    value={canvasVibrance}
+                    onChange={(e) => onCanvasVibranceChange(parseFloat(e.target.value))}
+                    className="setting-slider"
+                  />
+                </label>
+                <small className="setting-hint">Acentúa los valores de brillo</small>
+              </div>
+
+              <div className="setting-group">
+                <label className="setting-label">
+                  <span>Color de fondo del canvas</span>
+                  <input
+                    type="color"
+                    value={canvasBackground}
+                    onChange={(e) => onCanvasBackgroundChange(e.target.value)}
+                    className="setting-color"
+                  />
+                </label>
+                <small className="setting-hint">Elige un color de fondo para el canvas</small>
               </div>
 
               <div className="setting-group">


### PR DESCRIPTION
## Summary
- add global settings for canvas brightness, vibrance and background color
- persist canvas visual settings in localStorage and apply to canvas
- style color picker for new setting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unable to find your web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a8bafa4483338cb62111b6e3319e