### PR TITLE
Integrate preset controls into gallery modal

### DIFF
--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -719,14 +719,63 @@
   .preset-gallery-content {
     flex-direction: column;
   }
-  
+
   .preset-gallery-grid {
     height: 60%;
   }
-  
+
   .preset-gallery-controls {
     width: 100%;
     height: 40%;
+    border-left: none;
+    border-top: 1px solid #444;
+  }
+}
+
+/* Integrated controls layout - vertical preset list with right panel */
+.preset-gallery-content {
+  flex-direction: row;
+}
+
+.preset-gallery-section {
+  flex: none;
+  width: 140px;
+  padding: 20px 10px;
+  border-right: 1px solid #333;
+  border-bottom: none;
+  overflow-y: auto;
+}
+
+.preset-gallery-grid {
+  grid-template-columns: 1fr;
+  grid-auto-rows: 140px;
+  gap: 10px;
+  max-height: none;
+  height: 100%;
+}
+
+.preset-gallery-controls {
+  flex: 1;
+  width: auto;
+  max-width: none;
+  min-height: auto;
+  border-left: 1px solid #444;
+  border-top: none;
+}
+
+@media (max-width: 768px) {
+  .preset-gallery-content {
+    flex-direction: column;
+  }
+
+  .preset-gallery-section {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid #333;
+    height: auto;
+  }
+
+  .preset-gallery-controls {
     border-left: none;
     border-top: 1px solid #444;
   }


### PR DESCRIPTION
## Summary
- Rework preset gallery layout to keep default controls inside the modal
- Display presets as a vertical single-column list
- Show selected preset controls in a dedicated right-hand panel

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8ac12399c8333a1ee6cb1db5763e4