### PR TITLE
Add always-on layer effects with MIDI note mapping

### DIFF
--- a/src/components/GlobalSettingsModal.css
+++ b/src/components/GlobalSettingsModal.css
@@ -235,14 +235,14 @@
   font-weight: 500;
 }
 
-.layer-effect-settings {
+.effect-note-settings {
   display: flex;
   flex-direction: column;
   gap: 8px;
   margin-top: 8px;
 }
 
-.layer-effect-settings h5 {
+.effect-note-settings h5 {
   margin: 0;
   font-size: 14px;
   color: #ccc;

--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -35,9 +35,8 @@ interface GlobalSettingsModalProps {
   onMidiClockTypeChange: (value: string) => void;
   layerChannels: Record<string, number>;
   onLayerChannelChange: (layerId: string, channel: number) => void;
-  layerEffects: Record<string, { effect: string; midiNote: number }>;
-  onLayerEffectChange: (layerId: string, effect: string) => void;
-  onLayerEffectNoteChange: (layerId: string, note: number) => void;
+  effectMidiNotes: Record<string, number>;
+  onEffectMidiNoteChange: (effect: string, note: number) => void;
   monitors: MonitorInfo[];
   monitorRoles: Record<string, 'main' | 'secondary' | 'none'>;
   onMonitorRoleChange: (id: string, role: 'main' | 'secondary' | 'none') => void;
@@ -82,9 +81,8 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
   onMidiClockTypeChange,
   layerChannels,
   onLayerChannelChange,
-  layerEffects,
-  onLayerEffectChange,
-  onLayerEffectNoteChange,
+  effectMidiNotes,
+  onEffectMidiNoteChange,
   monitors,
   monitorRoles,
   onMonitorRoleChange,
@@ -398,26 +396,17 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
                     </label>
                   ))}
                 </div>
-                <div className="layer-effect-settings">
-                  <h5>Efectos por Layer</h5>
-                  {['A','B','C'].map(id => (
-                    <label key={id} className="setting-label effect-setting">
-                      <span>Layer {id}</span>
-                      <select
-                        value={layerEffects[id].effect}
-                        onChange={(e) => onLayerEffectChange(id, e.target.value)}
-                        className="setting-select"
-                      >
-                        {AVAILABLE_EFFECTS.map(eff => (
-                          <option key={eff} value={eff}>{eff}</option>
-                        ))}
-                      </select>
+                <div className="effect-note-settings">
+                  <h5>Notas MIDI por Efecto</h5>
+                  {AVAILABLE_EFFECTS.filter(eff => eff !== 'none').map(eff => (
+                    <label key={eff} className="setting-label effect-setting">
+                      <span>{eff}</span>
                       <input
                         type="number"
                         min={0}
                         max={127}
-                        value={layerEffects[id].midiNote}
-                        onChange={(e) => onLayerEffectNoteChange(id, parseInt(e.target.value) || 0)}
+                        value={effectMidiNotes[eff] ?? 0}
+                        onChange={(e) => onEffectMidiNoteChange(eff, parseInt(e.target.value) || 0)}
                         className="setting-number"
                       />
                     </label>

--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -142,6 +142,18 @@
   height: 16px;
 }
 
+.effect-always {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 10px;
+  margin-left: 4px;
+}
+
+.effect-always input {
+  margin: 0;
+}
+
 /* Effect styles */
 .layer-section.effect-blur { filter: blur(3px); }
 .layer-section.effect-distortion { transform: skewX(5deg); }

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -22,8 +22,9 @@ interface LayerGridProps {
   externalTrigger?: { layerId: string; presetId: string; velocity: number } | null;
   layerChannels: Record<string, number>;
   onOpenPresetGallery: () => void;
-  layerEffects: Record<string, { effect: string; midiNote: number; active: boolean }>;
+  layerEffects: Record<string, { effect: string; alwaysOn: boolean; active: boolean }>;
   onLayerEffectChange: (layerId: string, effect: string) => void;
+  onLayerEffectToggle: (layerId: string, alwaysOn: boolean) => void;
 }
 
 export const LayerGrid: React.FC<LayerGridProps> = ({
@@ -37,7 +38,8 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
   layerChannels,
   onOpenPresetGallery,
   layerEffects,
-  onLayerEffectChange
+  onLayerEffectChange,
+  onLayerEffectToggle
 }) => {
   const [layers, setLayers] = useState<LayerConfig[]>([
     { id: 'A', name: 'Layer A', color: '#FF6B6B', midiChannel: layerChannels.A || 14, fadeTime: 200, opacity: 100, activePreset: null },
@@ -424,6 +426,14 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
                 </option>
               ))}
             </select>
+            <label className="effect-always">
+              <input
+                type="checkbox"
+                checked={layerEffects[layer.id]?.alwaysOn}
+                onChange={(e) => onLayerEffectToggle(layer.id, e.target.checked)}
+              />
+              Always
+            </label>
           </div>
 
           {/* Layer Controls - 100x100 square */}


### PR DESCRIPTION
## Summary
- Add "Always" toggle next to layer effect selector
- Allow configuring MIDI note per effect in settings
- Reactivate and deactivate effects on MIDI Note On/Off events

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'fs'; multiple TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ad4a89908333824784dc234c0e43