### PR TITLE
Add Gen Lab preset template with editable presets

### DIFF
--- a/src/components/GenLabPresetModal.css
+++ b/src/components/GenLabPresetModal.css
@@ -1,0 +1,29 @@
+.genlab-modal-content {
+  padding: 20px;
+  height: 100%;
+  overflow: auto;
+}
+
+.genlab-name-input {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 10px;
+  border: 1px solid #555;
+  border-radius: 4px;
+  background: #111;
+  color: #fff;
+}
+
+.genlab-modal-actions {
+  text-align: right;
+  margin-top: 10px;
+}
+
+.genlab-modal-actions button {
+  background: #64B5F6;
+  border: none;
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/src/components/GenLabPresetModal.tsx
+++ b/src/components/GenLabPresetModal.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { LoadedPreset } from '../core/PresetLoader';
+import { PresetControls } from './PresetControls';
+import { setNestedValue } from '../utils/objectPath';
+import './GenLabPresetModal.css';
+
+interface GenLabPresetModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  basePreset: LoadedPreset;
+  initial?: { name: string; config: any };
+  onSave: (preset: { name: string; config: any }) => void;
+}
+
+export const GenLabPresetModal: React.FC<GenLabPresetModalProps> = ({
+  isOpen,
+  onClose,
+  basePreset,
+  initial,
+  onSave,
+}) => {
+  const [name, setName] = useState(initial?.name || '');
+  const [config, setConfig] = useState<any>(() => {
+    return initial?.config
+      ? JSON.parse(JSON.stringify(initial.config))
+      : JSON.parse(JSON.stringify(basePreset.config.defaultConfig || {}));
+  });
+
+  const handleControlChange = (path: string, value: any) => {
+    setConfig((prev: any) => {
+      const clone = JSON.parse(JSON.stringify(prev));
+      setNestedValue(clone, path, value);
+      return clone;
+    });
+  };
+
+  const handleSave = () => {
+    if (!name.trim()) return;
+    onSave({ name: name.trim(), config });
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="preset-gallery-overlay" onClick={onClose}>
+      <div className="preset-gallery-modal small" onClick={e => e.stopPropagation()}>
+        <div className="preset-gallery-header">
+          <h2>{initial ? 'Edit Gen Lab Preset' : 'New Gen Lab Preset'}</h2>
+          <button className="close-button" onClick={onClose}>✕</button>
+        </div>
+        <div className="genlab-modal-content">
+          <input
+            type="text"
+            className="genlab-name-input"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="Preset name"
+          />
+          <PresetControls preset={basePreset} config={config} onChange={handleControlChange} />
+          <div className="genlab-modal-actions">
+            <button onClick={handleSave}>Save</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -33,6 +33,11 @@
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
 }
 
+.preset-gallery-modal.small {
+  width: 60%;
+  height: 60%;
+}
+
 /* Header */
 .preset-gallery-header {
   display: flex;
@@ -216,6 +221,48 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.genlab-config {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.genlab-add-button {
+  align-self: flex-start;
+  background: #333;
+  border: 1px solid #555;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.genlab-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.genlab-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #2a2a2a;
+  padding: 6px 8px;
+  border-radius: 4px;
+  margin-bottom: 4px;
+}
+
+.genlab-list li button {
+  margin-left: 5px;
+  background: #333;
+  border: 1px solid #555;
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
 .custom-text-inputs {

--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -452,6 +452,16 @@ export class AudioVisualizerEngine {
     return this.presetLoader.getLoadedPresets();
   }
 
+  public async updateGenLabPresets(presets: { name: string; config: any }[]): Promise<LoadedPreset[]> {
+    this.presetLoader.setGenLabPresets(presets);
+    await this.presetLoader.loadAllPresets();
+    return this.presetLoader.getLoadedPresets();
+  }
+
+  public getGenLabBasePreset(): LoadedPreset | null {
+    return this.presetLoader.getGenLabBasePreset();
+  }
+
   public updateAudioData(audioData: AudioData): void {
     this.presetLoader.updateAudioData(audioData);
   }


### PR DESCRIPTION
## Summary
- Enable custom Gen Lab presets persisted in local storage and loaded as separate visuals
- Add engine and app wiring to manage Gen Lab templates and expose them in the presets gallery
- Provide UI modal to add, edit, or delete Gen Lab presets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unable to find web assets)*
- `npx tsc --noEmit` *(fails: Cannot find module 'fs' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c019174c8333a34e87b33d9a4c23