### PR TITLE
Improve Launchpad device detection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { GlobalSettingsModal } from './components/GlobalSettingsModal';
 import { LoadedPreset, AudioData } from './core/PresetLoader';
 import { setNestedValue } from './utils/objectPath';
 import { AVAILABLE_EFFECTS } from './utils/effects';
-import { buildLaunchpadFrame, LaunchpadPreset } from './utils/launchpad';
+import { buildLaunchpadFrame, LaunchpadPreset, isLaunchpadDevice } from './utils/launchpad';
 import './App.css';
 import './components/LayerGrid.css';
 
@@ -508,7 +508,7 @@ const App: React.FC = () => {
           const inputs = Array.from(access.inputs.values());
           setMidiDevices(inputs);
           const outputs = Array.from(access.outputs.values());
-          const lps = outputs.filter((out: any) => (out.name || '').toLowerCase().includes('launchpad'));
+          const lps = outputs.filter(isLaunchpadDevice);
           setLaunchpadOutputs(lps);
           const lp = lps.find((out: any) => out.id === launchpadId) || lps[0] || null;
           setLaunchpadOutput(lp);
@@ -529,7 +529,7 @@ const App: React.FC = () => {
             const ins = Array.from(access.inputs.values());
             setMidiDevices(ins);
             const outs = Array.from(access.outputs.values());
-            const lps2 = outs.filter((out: any) => (out.name || '').toLowerCase().includes('launchpad'));
+            const lps2 = outs.filter(isLaunchpadDevice);
             setLaunchpadOutputs(lps2);
             const lp2 = lps2.find((out: any) => out.id === launchpadId) || lps2[0] || null;
             setLaunchpadOutput(lp2);

--- a/src/utils/launchpad.ts
+++ b/src/utils/launchpad.ts
@@ -8,6 +8,21 @@ export const LAUNCHPAD_PRESETS: { id: LaunchpadPreset; label: string }[] = [
 ];
 
 /**
+ * Determine whether a given MIDI port belongs to a Novation Launchpad.
+ * Some Launchpad models expose names like "LPPRO MIDI" or "LPX Standalone Port",
+ * so we check both the manufacturer and common LP prefixes.
+ */
+export function isLaunchpadDevice(device: any): boolean {
+  const name = (device?.name || '').toLowerCase();
+  const manufacturer = (device?.manufacturer || '').toLowerCase();
+
+  if (name.includes('launchpad')) return true;
+
+  const fromNovation = manufacturer.includes('novation');
+  return fromNovation && /^lp/.test(name);
+}
+
+/**
  * Build a frame of 64 color values for the Launchpad grid based on audio data.
  * Colors use the built-in palette (0-127).
  */


### PR DESCRIPTION
## Summary
- detect Novation Launchpads by manufacturer and LP prefix or name
- filter MIDI outputs using shared helper so Launchpad appears in UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unable to find your web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d8cd6dc08333b0eec6cfae673d16