### PR TITLE
Limit preset gallery width and align left

### DIFF
--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -153,7 +153,7 @@
   display: flex;
   flex-direction: row;
   height: calc(100% - 80px);
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 /* Sections */
@@ -313,7 +313,7 @@
 
 /* Overrides for main preset list */
 .preset-gallery-main-grid {
-  width: 115px;
+  width: 100px;
   flex: none;
   display: flex;
   flex-direction: column;
@@ -321,7 +321,9 @@
   gap: 15px;
   overflow-y: auto;
   height: 100%;
-  padding: 10px;
+  max-height: none;
+  padding: 0;
+  box-sizing: border-box;
   background: #0F0F0F;
   border-radius: 8px 0 0 8px;
 }


### PR DESCRIPTION
## Summary
- Align preset gallery list to the left edge of the modal
- Restrict vertical preset list width to 100px and allow full height

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8dc36cab48333be96cb6fd2149310