### PR TITLE
Refine preset gallery layout

### DIFF
--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -153,7 +153,7 @@
   display: flex;
   flex-direction: row;
   height: calc(100% - 80px);
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 /* Sections */
@@ -313,7 +313,7 @@
 
 /* Overrides for main preset list */
 .preset-gallery-main-grid {
-  width: 115px;
+  width: 100px;
   flex: none;
   display: flex;
   flex-direction: column;
@@ -321,14 +321,16 @@
   gap: 15px;
   overflow-y: auto;
   height: 100%;
-  padding: 10px;
+  max-height: none;
+  padding: 0;
+  box-sizing: border-box;
   background: #0F0F0F;
   border-radius: 8px 0 0 8px;
 }
 
 .preset-gallery-main-grid .preset-gallery-item {
-  width: 80px;
-  height: 80px;
+  width: 100px;
+  height: 100px;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
## Summary
- Narrow preset gallery to 100px and remove padding
- Align gallery to the modal's left and allow full height
- Resize preset cells to 100×100 for consistent grid

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8dc3beb088333aca0023a5e218eac