### PR TITLE
feat: support fs access across platforms

### DIFF
--- a/preload.cjs
+++ b/preload.cjs
@@ -1,4 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron');
+const fs = require('fs');
+const path = require('path');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   applySettings: (settings) => ipcRenderer.send('apply-settings', settings),
@@ -10,5 +12,21 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Notificación cuando la ventana principal sale de fullscreen
   onMainLeaveFullscreen: (callback) => ipcRenderer.on('main-leave-fullscreen', callback),
-  removeMainLeaveFullscreenListener: () => ipcRenderer.removeAllListeners('main-leave-fullscreen')
+  removeMainLeaveFullscreenListener: () => ipcRenderer.removeAllListeners('main-leave-fullscreen'),
+
+  // File system helpers
+  readTextFile: (filePath) => fs.promises.readFile(filePath, 'utf-8'),
+  writeTextFile: async (filePath, data) => {
+    const dir = path.dirname(filePath);
+    await fs.promises.mkdir(dir, { recursive: true });
+    await fs.promises.writeFile(filePath, data);
+  },
+  exists: async (filePath) => {
+    try {
+      await fs.promises.access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1298,7 +1298,7 @@ const App: React.FC = () => {
                 if (existing) {
                   applyPresetConfig(engineRef.current, layerId, existing);
                 } else {
-                  const cfg = engineRef.current.getLayerPresetConfig(layerId, presetId);
+                  const cfg = await engineRef.current.getLayerPresetConfig(layerId, presetId);
                   setLayerPresetConfigs(prev => ({
                     ...prev,
                     [layerId]: { ...(prev[layerId] || {}), [presetId]: cfg }
@@ -1329,13 +1329,13 @@ const App: React.FC = () => {
             }
             broadcastRef.current?.postMessage({ type: 'layerConfig', layerId, config });
           }}
-          onPresetSelect={(layerId, presetId) => {
+          onPresetSelect={async (layerId, presetId) => {
             if (presetId) {
               const preset = availablePresets.find(p => p.id === presetId);
               if (preset) {
                 const existing = layerPresetConfigs[layerId]?.[presetId];
                 if (!existing) {
-                  const cfg = engineRef.current?.getLayerPresetConfig(layerId, presetId);
+                  const cfg = await engineRef.current?.getLayerPresetConfig(layerId, presetId);
                   if (cfg) {
                     setLayerPresetConfigs(prev => ({
                       ...prev,

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -22,10 +22,10 @@ interface LayerConfig {
 
 interface LayerGridProps {
   presets: LoadedPreset[];
-  onPresetActivate: (layerId: string, presetId: string, velocity?: number) => void;
+  onPresetActivate: (layerId: string, presetId: string, velocity?: number) => void | Promise<void>;
   onLayerClear: (layerId: string) => void;
   onLayerConfigChange: (layerId: string, config: Partial<LayerConfig>) => void;
-  onPresetSelect: (layerId: string, presetId: string) => void;
+  onPresetSelect: (layerId: string, presetId: string) => void | Promise<void>;
   clearAllSignal: number;
   externalTrigger?: { layerId: string; presetId: string; velocity: number } | null;
   layerChannels: Record<string, number>;

--- a/types/globa.d.ts
+++ b/types/globa.d.ts
@@ -5,6 +5,9 @@ interface Window {
     applySettings: (settings: { maximize?: boolean; monitorId?: number }) => void;
     getDisplays: () => Promise<{ id: number; label: string; bounds: { x: number; y: number; width: number; height: number }; scaleFactor: number; primary: boolean; }[]>;
     toggleFullscreen: (ids: number[]) => Promise<void>;
+    readTextFile: (path: string) => Promise<string>;
+    writeTextFile: (path: string, data: string) => Promise<void>;
+    exists: (path: string) => Promise<boolean>;
   };
 }
 


### PR DESCRIPTION
## Summary
- handle preset config files through Tauri fs API, Electron bridge or localStorage fallback
- expose basic fs helpers in Electron preload and corresponding TypeScript types
- await async preset config methods and allow promise-returning layer callbacks

## Testing
- `npx tsc --noEmit` *(fails: multiple TypeScript errors in unrelated files)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8f4c8bf9c83338b8bc2550c6de259