### PR TITLE
fix(tsconfig): remove visuals directory from include list

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "types": ["vite/client"],
     "resolveJsonModule": true
   },
-  "include": ["src", "visuals", "types"]
+  "include": ["src", "types"]
 }


### PR DESCRIPTION
## Summary
- remove non-existent `visuals` directory from TypeScript `include`

## Testing
- `npx tsc --noEmit` *(fails: src/core/AudioVisualizerEngine.ts:168:18 - error TS1109: Expression expected)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a96e2cbab88333a659279e249ff2c9