### PR TITLE
Fix fullscreen resize and resolve preset gallery duplicates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -351,10 +351,15 @@ const App: React.FC = () => {
     const handler = () => {
       const param = new URLSearchParams(window.location.search).get('fullscreen') === 'true';
       setIsFullscreenMode(param || !!document.fullscreenElement);
+      window.dispatchEvent(new Event('resize'));
     };
     document.addEventListener('fullscreenchange', handler);
     return () => document.removeEventListener('fullscreenchange', handler);
   }, []);
+
+  useEffect(() => {
+    window.dispatchEvent(new Event('resize'));
+  }, [isFullscreenMode]);
 
   useEffect(() => {
     const api = (window as any).electronAPI;

--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -127,14 +127,8 @@
 /* Sections */
 .preset-gallery-section {
   flex: none;
-<<<<<<< HEAD
-  width: 140px;
-  padding: 10px 10px;
-  padding-lefT: 20px;
-=======
   width: 120px;
   padding: 15px 8px;
->>>>>>> 1a3ccc80086c67e24bb65521152b8798d5b7d7a2
   border-right: 1px solid #333;
   border-bottom: none;
   overflow-y: auto;

--- a/src/components/PresetGalleryModal.tsx
+++ b/src/components/PresetGalleryModal.tsx
@@ -234,10 +234,6 @@ export const PresetGalleryModal: React.FC<PresetGalleryModalProps> = ({
     setSelected({ ...selected });
   };
 
-  const handleDefaultControlChange = (path: string, value: any) => {
-    void persistDefaultConfig(path, value);
-  };
-
   if (!isOpen) return null;
 
   return (


### PR DESCRIPTION
## Summary
- ensure fullscreen mode resizes canvas correctly by dispatching resize events
- remove duplicate `handleDefaultControlChange` implementation
- resolve leftover merge conflict in preset gallery styles

## Testing
- `npx vite build`

------
https://chatgpt.com/codex/tasks/task_e_68a97a29a4c8833387e1bb15beec9469