### PR TITLE
Allow AJV validation under CSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" />
     <title>AudioVisualizer</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- permit 'unsafe-eval' in CSP so Ajv schema compilation succeeds in Electron renderer

## Testing
- `npm run electron` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a97b4907d48333bc7d36570f2c276a