### PR TITLE
Fix missing imports for AudioVisualizer engine

### DIFF
--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -1,5 +1,7 @@
 import * as THREE from 'three';
 import { PresetLoader, LoadedPreset, AudioData } from './PresetLoader';
+import { LayerManager } from './LayerManager';
+import { Compositor } from './Compositor';
 // Using simple path helpers instead of Node's `path` module which is not
 // available in the browser runtime. Node's `path.join` was causing errors
 // after bundling (e.g. `TypeError: Bi.join is not a function`).


### PR DESCRIPTION
## Summary
- Import LayerManager and Compositor in AudioVisualizerEngine to avoid ReferenceError during initialization

## Testing
- `npm run electron -- --no-sandbox` *(fails: Missing X server or DBus)*

------
https://chatgpt.com/codex/tasks/task_e_68a97c4bc05483339a9311522d925727