### PR TITLE
fix: reference layers from manager

### DIFF
--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -25,6 +25,7 @@ export class AudioVisualizerEngine {
   private renderer: THREE.WebGLRenderer;
   private presetLoader: PresetLoader;
   private layerManager: LayerManager;
+  private layers: Map<string, LayerState>;
   private compositor: Compositor;
   private animationId: number | null = null;
   private isRunning = false;
@@ -47,6 +48,7 @@ export class AudioVisualizerEngine {
 
     this.presetLoader = new PresetLoader(this.camera, this.renderer, options.glitchTextPads ?? 1);
     this.layerManager = new LayerManager(this.renderer, this.camera, this.presetLoader);
+    this.layers = this.layerManager.getLayers();
     this.compositor = new Compositor(this.renderer);
 
     this.setupScene();


### PR DESCRIPTION
## Summary
- keep a reference to LayerManager's layers map inside AudioVisualizerEngine

## Testing
- `npm test` (fails: Missing script)
- `npx tsc -p tsconfig.json --noEmit` (fails: Property 'catch' does not exist on type 'void'...)
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_68a9819966988333b2f21663bfc17952