### PR TITLE
Fix fullscreen across monitors and remove white screen

### DIFF
--- a/clone.html
+++ b/clone.html
@@ -9,7 +9,7 @@
       padding: 0;
       width: 100%;
       height: 100%;
-      background: transparent;
+      background: #000;
       display: flex;
       justify-content: center;
       align-items: center;
@@ -18,7 +18,7 @@
       width: 100%;
       height: 100%;
       display: block;
-      background: transparent;
+      background: #000;
     }
   </style>
 </head>

--- a/src/App.css
+++ b/src/App.css
@@ -13,7 +13,7 @@
 html, body, #root {
   width: 100%;
   height: 100%;
-  background: transparent;
+  background: #000;
 }
 
 body {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -541,9 +541,9 @@ const App: React.FC = () => {
         .filter(([, role]) => role === 'secondary')
         .map(([id]) => id);
       const ids = [
-        ...(mainId ? [parseInt(mainId, 10)] : []),
+        ...(mainId !== undefined ? [parseInt(mainId, 10)] : []),
         ...secondaryIds.map(id => parseInt(id, 10))
-      ].filter(Boolean);
+      ].filter(id => !Number.isNaN(id));
       if (ids.length === 0) {
         setStatus('Error: No hay monitores seleccionados');
         return;
@@ -642,7 +642,7 @@ const App: React.FC = () => {
         setStatus('Error: Fullscreen no disponible');
       }
     }
-  }, [activeLayers, monitorRoles, monitors]);
+  }, [activeLayers, monitorRoles, monitors, isFullscreenMode]);
 
   useEffect(() => {
     if (isFullscreenMode) return;


### PR DESCRIPTION
## Summary
- Handle monitor ID `0` so fullscreen hotkey covers secondary monitors
- Use latest fullscreen state in callback
- Set black backgrounds for fullscreen pages to avoid white screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Unable to find web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68a984e20e9483339fb3d6d448c734eb