### PR TITLE
fix fullscreen layer activation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -428,13 +428,14 @@ const App: React.FC = () => {
       const stored = localStorage.getItem('activeLayers');
       if (stored) {
         const layers = JSON.parse(stored) as Record<string, string>;
-        Object.entries(layers).forEach(([layerId, presetId]) => {
-          engineRef.current!.activateLayerPreset(layerId, presetId);
-        })
-        .catch((err: any) => {
-          console.error('Failed to access MIDI devices', err);
+        Promise.all(
+          Object.entries(layers).map(([layerId, presetId]) =>
+            engineRef.current!.activateLayerPreset(layerId, presetId)
+          )
+        ).catch(err => {
+          console.error('Failed to activate stored layers', err);
         });
-    }
+      }
     }
   }, [isFullscreenMode, isInitialized]);
 


### PR DESCRIPTION
## Summary
- correctly activate stored layers when entering fullscreen to restore visuals

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Unable to find your web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68a986bbcf748333ba0234dde609839c