### PR TITLE
Reorganize top bar layout and button styles

### DIFF
--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -128,10 +128,16 @@
   animation: pulse-green 1.5s infinite;
 }
 
-.actions-section > button {
-  margin-right: 5px;
+.action-button {
+  background: #333;
+  border: none;
+  color: #fff;
+  padding: 6px 12px;
+  border-radius: 4px;
   font-size: 11px;
-  padding: 6px 10px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
 }
 
 @keyframes pulse-green {

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -95,38 +95,43 @@ export const TopBar: React.FC<TopBarProps> = ({
         </div>
       </div>
 
-      {/* Espaciador flexible para empujar contenido a la derecha */}
-      <div className="top-bar-spacer"></div>
+        {/* Espaciador flexible para centrar la sección de acciones */}
+        <div className="top-bar-spacer"></div>
 
-      {/* Sección derecha - Controles de Launchpad y acciones */}
-      <div className="actions-section">
+        {/* Sección central - Acciones y recursos */}
+        <div className="actions-section">
+          <button onClick={onOpenResources} className="action-button">Resources</button>
+          <button onClick={onClearAll} className="action-button">Clear All</button>
+          <button onClick={onFullScreen} className="action-button" alt="Go Full Screen mode!!">Full Screen</button>
+          <button onClick={onOpenSettings} className="action-button">Settings</button>
+        </div>
+
+        {/* Espaciador flexible para empujar Launchpad a la derecha */}
+        <div className="top-bar-spacer"></div>
+
+        {/* Sección derecha - Controles de Launchpad */}
         {launchpadAvailable && (
-          <div className="launchpad-controls">
-            <select
-              value={launchpadPreset}
-              onChange={(e) => onLaunchpadPresetChange(e.target.value)}
-              className="launchpad-preset-select"
-            >
-              {LAUNCHPAD_PRESETS.map(p => (
-                <option key={p.id} value={p.id}>{p.label}</option>
-              ))}
-            </select>
-            <button 
-              onClick={onToggleLaunchpad}
-              className={`launchpad-button ${launchpadRunning ? 'running' : ''}`}
-            >
-              {launchpadRunning ? 'Stop Launchpad' : 'Go Launchpad'}
-            </button>
-          </div>
+          <>
+            <div className="separator" />
+            <div className="launchpad-controls">
+              <select
+                value={launchpadPreset}
+                onChange={(e) => onLaunchpadPresetChange(e.target.value)}
+                className="launchpad-preset-select"
+              >
+                {LAUNCHPAD_PRESETS.map(p => (
+                  <option key={p.id} value={p.id}>{p.label}</option>
+                ))}
+              </select>
+              <button
+                onClick={onToggleLaunchpad}
+                className={`launchpad-button ${launchpadRunning ? 'running' : ''}`}
+              >
+                {launchpadRunning ? 'Stop Launchpad' : 'Go Launchpad'}
+              </button>
+            </div>
+          </>
         )}
-        
-        <div className="separator" />
-        
-        <button onClick={onFullScreen} alt="Go Full Screen mode!!">Full Screen</button>
-        <button onClick={onClearAll}>Clear All</button>
-        <button onClick={onOpenResources}>Resources</button>
-        <button onClick={onOpenSettings}>Settings</button>
-      </div>
-    </div>
+        </div>
   );
 };


### PR DESCRIPTION
## Summary
- Center main action buttons and move Launchpad controls to the far right of the top bar
- Restyle action buttons to match Launchpad button aesthetics using dark background and white text

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a98e69a3f483338df47fd79b512502