### PR TITLE
Add UI toggle and icon-based controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -673,6 +673,10 @@ const App: React.FC = () => {
     }));
   };
 
+  const handleToggleUi = () => {
+    setIsUiHidden(prev => !prev);
+  };
+
   const handleLayerEffectChange = (layerId: string, effect: string) => {
     setLayerEffects(prev => ({
       ...prev,
@@ -872,6 +876,7 @@ const App: React.FC = () => {
         onAudioGainChange={setAudioGain}
         audioLevel={audioLevel}
         onFullScreen={handleFullScreen}
+        onToggleUi={handleToggleUi}
         onClearAll={handleClearAll}
         onOpenSettings={() => setIsSettingsOpen(true)}
         onOpenResources={() => setResourcesOpen(true)}

--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -145,7 +145,7 @@
   display: flex;
   align-items: center;
   gap: 2px;
-  font-size: 10px;
+  font-size: 12px;
   margin-left: 4px;
 }
 
@@ -174,6 +174,15 @@
   align-items: center;
   gap: 4px;
   font-size: 10px;
+}
+.jump-controls label {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.effect-always span,
+.jump-controls label span {
+  font-size: 12px;
 }
 
 .jump-controls select,

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -254,23 +254,26 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
                 </option>
               ))}
             </select>
-            <label className="effect-always">
+            <label
+              className="effect-always"
+              title="Effect always active"
+            >
               <input
                 type="checkbox"
                 checked={layerEffects[layer.id]?.alwaysOn}
                 onChange={(e) => onLayerEffectToggle(layer.id, e.target.checked)}
               />
-              Always
+              <span role="img" aria-label="always on">♾️</span>
             </label>
             <span className="control-separator">|</span>
             <div className="jump-controls">
-              <label>
+              <label title="Auto jump between presets">
                 <input
                   type="checkbox"
                   checked={layer.autoJump}
                   onChange={(e) => handleLayerConfigChange(layer.id, 'autoJump', e.target.checked)}
                 />
-                Jump
+                <span role="img" aria-label="auto jump">🔀</span>
               </label>
               <select
                 value={layer.jumpDirection}

--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -132,11 +132,14 @@
   background: #333;
   border: none;
   color: #fff;
-  padding: 6px 12px;
+  width: 28px;
+  height: 28px;
   border-radius: 4px;
-  font-size: 11px;
-  font-weight: 600;
+  font-size: 14px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition: all 0.2s ease;
 }
 

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -14,6 +14,7 @@ interface TopBarProps {
   onAudioGainChange: (value: number) => void;
   audioLevel: number;
   onFullScreen: () => void;
+  onToggleUi: () => void;
   onClearAll: () => void;
   onOpenSettings: () => void;
   onOpenResources: () => void;
@@ -36,6 +37,7 @@ export const TopBar: React.FC<TopBarProps> = ({
   onAudioGainChange,
   audioLevel,
   onFullScreen,
+  onToggleUi,
   onClearAll,
   onOpenSettings,
   onOpenResources,
@@ -100,10 +102,36 @@ export const TopBar: React.FC<TopBarProps> = ({
 
         {/* Sección central - Acciones y recursos */}
         <div className="actions-section">
-          <button onClick={onOpenResources} className="action-button">Resources</button>
-          <button onClick={onClearAll} className="action-button">Clear All</button>
-          <button onClick={onFullScreen} className="action-button" alt="Go Full Screen mode!!">Full Screen</button>
-          <button onClick={onOpenSettings} className="action-button">Settings</button>
+          <button
+            onClick={onOpenResources}
+            className="action-button"
+            title="Open resources"
+            aria-label="Open resources"
+          >📂</button>
+          <button
+            onClick={onClearAll}
+            className="action-button"
+            title="Clear all"
+            aria-label="Clear all"
+          >🗑️</button>
+          <button
+            onClick={onToggleUi}
+            className="action-button"
+            title="Hide controls (F10)"
+            aria-label="Hide controls"
+          >🙈</button>
+          <button
+            onClick={onFullScreen}
+            className="action-button"
+            title="Full screen"
+            aria-label="Full screen"
+          >⛶</button>
+          <button
+            onClick={onOpenSettings}
+            className="action-button"
+            title="Settings"
+            aria-label="Settings"
+          >⚙️</button>
         </div>
 
         {/* Espaciador flexible para empujar Launchpad a la derecha */}


### PR DESCRIPTION
## Summary
- Add top bar button to hide/show UI, mirroring F10 hotkey
- Replace top bar action texts with icons and tooltips for cleaner layout
- Use icons with tooltips for layer bar "Always" and "Jump" controls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property errors in presets and layer manager)*

------
https://chatgpt.com/codex/tasks/task_e_68a9903d8ae88333b08c664b8c0b3ccc