### PR TITLE
Use MIDI event timestamps for BPM

### DIFF
--- a/src/hooks/useMidi.ts
+++ b/src/hooks/useMidi.ts
@@ -232,7 +232,9 @@ export function useMidi(options: MidiOptions) {
 
       // MIDI Clock messages
       if (statusByte === 0xf8 && midiClockSettings.type === 'midi') {
-        handleClockTick(performance.now(), false);
+        const timestamp =
+          event.timeStamp ?? event.receivedTime ?? performance.now();
+        handleClockTick(timestamp, false);
         return;
       }
 


### PR DESCRIPTION
## Summary
- use MIDI message timestamps to compute BPM, improving accuracy with external clocks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: see TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a99c6443908333b08b4b25d102185d