### PR TITLE
Fix WebGL state leaks causing feedback loop errors

### DIFF
--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -100,6 +100,8 @@ export class AudioVisualizerEngine {
       this.renderer.clear();
       this.layerManager.renderLayers();
       this.compositor.composite(this.layerManager.getLayers());
+      // Reset WebGL state to avoid feedback loops with bound textures
+      this.renderer.resetState();
     };
 
     animate();

--- a/src/core/LayerManager.ts
+++ b/src/core/LayerManager.ts
@@ -80,8 +80,6 @@ export class LayerManager {
       this.renderer.setClearColor(0x000000, 0);
       this.renderer.setRenderTarget(layer.renderTarget);
       this.renderer.clear(true, true, false);
-      this.renderer.setRenderTarget(layer.renderTarget);
-      this.renderer.clear();
       this.renderer.render(layer.scene, this.camera);
     });
 


### PR DESCRIPTION
## Summary
- Reset WebGL state after compositing layers to release bound textures and prevent framebuffer feedback loops
- Simplify layer rendering to remove redundant render target clearing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unable to find web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ab7a88348333a8a4a971f870469b