### PR TITLE
feat: support custom shader code for gen lab presets

### DIFF
--- a/src/presets/gen-lab/preset.ts
+++ b/src/presets/gen-lab/preset.ts
@@ -59,12 +59,196 @@ export const config: PresetConfig = {
 class GenLabPreset extends BasePreset {
   private mesh!: THREE.Mesh<THREE.PlaneGeometry, THREE.ShaderMaterial>;
   private currentConfig: any;
+  private shaderCode?: string;
+
+  constructor(
+    scene: THREE.Scene,
+    camera: THREE.Camera,
+    renderer: THREE.WebGLRenderer,
+    config: PresetConfig,
+    shaderCode?: string
+  ) {
+    super(scene, camera, renderer, config);
+    this.shaderCode = shaderCode;
+  }
 
   public init(): void {
     this.renderer.setClearColor(0x000000, 0);
     this.currentConfig = JSON.parse(JSON.stringify(this.config.defaultConfig));
 
     const geometry = new THREE.PlaneGeometry(2, 2);
+
+    const defaultFragmentShader = `
+      uniform float uTime;
+      uniform float uOpacity;
+      uniform float uAudioLow;
+      uniform float uAudioMid;
+      uniform float uAudioHigh;
+      uniform int uAlgorithm;
+      uniform int uVariant;
+      uniform float uNoiseScale;
+      uniform float uSpeed;
+      uniform float uTurbulence;
+      uniform float uDensity;
+      uniform float uFlow;
+      uniform vec3 uColor1;
+      uniform vec3 uColor2;
+      uniform vec3 uColor3;
+      uniform float uColorMix;
+      uniform float uRadialBlur;
+      uniform float uUvDistort;
+      uniform float uTimeWarp;
+      uniform float uBrightness;
+      uniform float uContrast;
+      uniform float uSaturation;
+
+      varying vec2 vUv;
+
+      // Hash functions for noise
+      float hash(vec2 p) {
+        return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+      }
+
+      // Improved noise functions
+      float noise(vec2 p) {
+        vec2 i = floor(p);
+        vec2 f = fract(p);
+        float a = hash(i), b = hash(i + vec2(1., 0.));
+        float c = hash(i + vec2(0., 1.)), d = hash(i + vec2(1., 1.));
+        vec2 u = f * f * (3. - 2. * f);
+        return mix(a, b, u.x) + (c - a) * u.y * (1. - u.x) + (d - b) * u.x * u.y;
+      }
+
+      // Simplex noise approximation
+      float simplex(vec2 p) {
+        const float F2 = 0.3660254037844386;
+        const float G2 = 0.21132486540518713;
+        vec2 s = (p.x + p.y) * F2;
+        vec2 i = floor(p + s);
+        vec2 t = (i.x + i.y) * G2;
+        vec2 P0 = i - t;
+        vec2 p0 = p - P0;
+        vec2 i1 = (p0.x > p0.y) ? vec2(1., 0.) : vec2(0., 1.);
+        vec2 p1 = p0 - i1 + G2;
+        vec2 p2 = p0 - 1. + 2. * G2;
+        float n0 = max(0., 0.5 - dot(p0, p0)) * hash(i);
+        float n1 = max(0., 0.5 - dot(p1, p1)) * hash(i + i1);
+        float n2 = max(0., 0.5 - dot(p2, p2)) * hash(i + 1.);
+        return 70. * (n0 + n1 + n2);
+      }
+
+      // Ridged noise
+      float ridged(vec2 p) {
+        return 1. - abs(noise(p));
+      }
+
+      // Billow noise
+      float billow(vec2 p) {
+        return abs(noise(p));
+      }
+
+      // Fractal Brownian Motion
+      float fbm(vec2 p) {
+        float v = 0., a = 0.5;
+        float lacunarity = 2.0 + uTurbulence;
+
+        for(int i = 0; i < 6; i++) {
+          if(uAlgorithm == 0) v += a * noise(p);          // Perlin
+          else if(uAlgorithm == 1) v += a * simplex(p);    // Simplex
+          else if(uAlgorithm == 2) v += a * ridged(p);     // Ridged
+          else if(uAlgorithm == 3) v += a * billow(p);     // Billow
+          else v += a * noise(p);                          // Default to Perlin
+
+          p *= lacunarity;
+          a *= 0.5;
+        }
+        return v;
+      }
+
+      // Color space conversions
+      vec3 rgb2hsv(vec3 c) {
+        vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+        vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+        vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+        float d = q.x - min(q.w, q.y);
+        float e = 1.0e-10;
+        return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+      }
+
+      vec3 hsv2rgb(vec3 c) {
+        vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+        vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+        return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+      }
+
+      void main() {
+        vec2 uv = vUv * 0.5 + 0.5;
+
+        // Time manipulation
+        float time = uTime * uSpeed + sin(uTime * uTimeWarp) * 0.5;
+
+        // Variant-specific UV transformations
+        if(uVariant == 0) { // fog
+          uv += vec2(time * 0.1, sin(time) * 0.05);
+        } else if(uVariant == 1) { // smoke
+          uv.y += time * 0.3;
+          uv.x += sin(uv.y * 8.0 + time) * 0.03;
+        } else if(uVariant == 2) { // clouds
+          uv += vec2(time * 0.05, time * 0.02);
+        } else if(uVariant == 3) { // vapor
+          uv.x += time * 0.2;
+          uv.y += sin(uv.x * 10.0 + time) * 0.02;
+        } else if(uVariant == 4) { // plasma
+          vec2 p = uv * 2.0 - 1.0;
+          float r = length(p);
+          float theta = atan(p.y, p.x);
+          uv = vec2(theta / 6.28318 + 0.5 + time * 0.1, r + sin(time) * 0.1);
+        } else if(uVariant == 5) { // mist
+          uv += vec2(sin(time * 0.7) * 0.02, cos(time * 0.5) * 0.03);
+        } else if(uVariant == 6) { // storm
+          uv += vec2(sin(time * 2.0) * 0.05, cos(time * 1.7) * 0.08);
+        }
+
+        // Audio-reactive distortion
+        uv += (uv - 0.5) * uAudioMid * uUvDistort;
+
+        // Flow effects
+        vec2 flowUv = uv + vec2(cos(time + uv.y * 5.0), sin(time + uv.x * 5.0)) * uFlow * 0.1;
+
+        // Generate noise
+        float n1 = fbm(flowUv * uNoiseScale);
+        float n2 = fbm((flowUv + vec2(100.0)) * uNoiseScale * 0.7);
+        float n3 = fbm((flowUv + vec2(200.0)) * uNoiseScale * 1.3);
+
+        // Combine noise layers with density control
+        float n = mix(n1, n2 * n3, uDensity) * (1.0 + uAudioLow * 0.5);
+
+        // Radial falloff
+        float r = length(uv - 0.5);
+        n *= 1.0 - r * uRadialBlur;
+
+        // Color mixing
+        vec3 col1 = mix(uColor1, uColor2, n + uAudioHigh * 0.3);
+        vec3 col2 = mix(uColor2, uColor3, n2 + sin(time) * 0.2);
+        vec3 col = mix(col1, col2, uColorMix + uAudioMid * 0.2);
+
+        // Color adjustments
+        vec3 hsv = rgb2hsv(col);
+        hsv.y *= uSaturation;
+        hsv.z *= uBrightness;
+        col = hsv2rgb(hsv);
+
+        // Contrast adjustment
+        col = (col - 0.5) * uContrast + 0.5;
+
+        // Final alpha with improved falloff
+        float alpha = smoothstep(0.0, 0.3, n) * smoothstep(1.0, 0.7, r) * uOpacity;
+
+        gl_FragColor = vec4(col, alpha);
+      }
+    `;
+    const fragmentShaderCode = this.shaderCode ?? defaultFragmentShader;
+
     const material = new THREE.ShaderMaterial({
       transparent: true,
       uniforms: {
@@ -98,179 +282,23 @@ class GenLabPreset extends BasePreset {
           gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
         }
       `,
-      fragmentShader: `
-        uniform float uTime;
-        uniform float uOpacity;
-        uniform float uAudioLow;
-        uniform float uAudioMid;
-        uniform float uAudioHigh;
-        uniform int uAlgorithm;
-        uniform int uVariant;
-        uniform float uNoiseScale;
-        uniform float uSpeed;
-        uniform float uTurbulence;
-        uniform float uDensity;
-        uniform float uFlow;
-        uniform vec3 uColor1;
-        uniform vec3 uColor2;
-        uniform vec3 uColor3;
-        uniform float uColorMix;
-        uniform float uRadialBlur;
-        uniform float uUvDistort;
-        uniform float uTimeWarp;
-        uniform float uBrightness;
-        uniform float uContrast;
-        uniform float uSaturation;
-        
-        varying vec2 vUv;
-        
-        // Hash functions for noise
-        float hash(vec2 p) {
-          return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
-        }
-        
-        // Improved noise functions
-        float noise(vec2 p) {
-          vec2 i = floor(p);
-          vec2 f = fract(p);
-          float a = hash(i), b = hash(i + vec2(1., 0.));
-          float c = hash(i + vec2(0., 1.)), d = hash(i + vec2(1., 1.));
-          vec2 u = f * f * (3. - 2. * f);
-          return mix(a, b, u.x) + (c - a) * u.y * (1. - u.x) + (d - b) * u.x * u.y;
-        }
-        
-        // Simplex noise approximation
-        float simplex(vec2 p) {
-          const float F2 = 0.3660254037844386;
-          const float G2 = 0.21132486540518713;
-          vec2 s = (p.x + p.y) * F2;
-          vec2 i = floor(p + s);
-          vec2 t = (i.x + i.y) * G2;
-          vec2 P0 = i - t;
-          vec2 p0 = p - P0;
-          vec2 i1 = (p0.x > p0.y) ? vec2(1., 0.) : vec2(0., 1.);
-          vec2 p1 = p0 - i1 + G2;
-          vec2 p2 = p0 - 1. + 2. * G2;
-          float n0 = max(0., 0.5 - dot(p0, p0)) * hash(i);
-          float n1 = max(0., 0.5 - dot(p1, p1)) * hash(i + i1);
-          float n2 = max(0., 0.5 - dot(p2, p2)) * hash(i + 1.);
-          return 70. * (n0 + n1 + n2);
-        }
-        
-        // Ridged noise
-        float ridged(vec2 p) {
-          return 1. - abs(noise(p));
-        }
-        
-        // Billow noise
-        float billow(vec2 p) {
-          return abs(noise(p));
-        }
-        
-        // Fractal Brownian Motion
-        float fbm(vec2 p) {
-          float v = 0., a = 0.5;
-          float lacunarity = 2.0 + uTurbulence;
-          
-          for(int i = 0; i < 6; i++) {
-            if(uAlgorithm == 0) v += a * noise(p);          // Perlin
-            else if(uAlgorithm == 1) v += a * simplex(p);    // Simplex
-            else if(uAlgorithm == 2) v += a * ridged(p);     // Ridged
-            else if(uAlgorithm == 3) v += a * billow(p);     // Billow
-            else v += a * noise(p);                          // Default to Perlin
-            
-            p *= lacunarity;
-            a *= 0.5;
-          }
-          return v;
-        }
-        
-        // Color space conversions
-        vec3 rgb2hsv(vec3 c) {
-          vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-          vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
-          vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
-          float d = q.x - min(q.w, q.y);
-          float e = 1.0e-10;
-          return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-        }
-        
-        vec3 hsv2rgb(vec3 c) {
-          vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-          vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
-          return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
-        }
-        
-        void main() {
-          vec2 uv = vUv * 0.5 + 0.5;
-          
-          // Time manipulation
-          float time = uTime * uSpeed + sin(uTime * uTimeWarp) * 0.5;
-          
-          // Variant-specific UV transformations
-          if(uVariant == 0) { // fog
-            uv += vec2(time * 0.1, sin(time) * 0.05);
-          } else if(uVariant == 1) { // smoke
-            uv.y += time * 0.3;
-            uv.x += sin(uv.y * 8.0 + time) * 0.03;
-          } else if(uVariant == 2) { // clouds
-            uv += vec2(time * 0.05, time * 0.02);
-          } else if(uVariant == 3) { // vapor
-            uv.x += time * 0.2;
-            uv.y += sin(uv.x * 10.0 + time) * 0.02;
-          } else if(uVariant == 4) { // plasma
-            vec2 p = uv * 2.0 - 1.0;
-            float r = length(p);
-            float theta = atan(p.y, p.x);
-            uv = vec2(theta / 6.28318 + 0.5 + time * 0.1, r + sin(time) * 0.1);
-          } else if(uVariant == 5) { // mist
-            uv += vec2(sin(time * 0.7) * 0.02, cos(time * 0.5) * 0.03);
-          } else if(uVariant == 6) { // storm
-            uv += vec2(sin(time * 2.0) * 0.05, cos(time * 1.7) * 0.08);
-          }
-          
-          // Audio-reactive distortion
-          uv += (uv - 0.5) * uAudioMid * uUvDistort;
-          
-          // Flow effects
-          vec2 flowUv = uv + vec2(cos(time + uv.y * 5.0), sin(time + uv.x * 5.0)) * uFlow * 0.1;
-          
-          // Generate noise
-          float n1 = fbm(flowUv * uNoiseScale);
-          float n2 = fbm((flowUv + vec2(100.0)) * uNoiseScale * 0.7);
-          float n3 = fbm((flowUv + vec2(200.0)) * uNoiseScale * 1.3);
-          
-          // Combine noise layers with density control
-          float n = mix(n1, n2 * n3, uDensity) * (1.0 + uAudioLow * 0.5);
-          
-          // Radial falloff
-          float r = length(uv - 0.5);
-          n *= 1.0 - r * uRadialBlur;
-          
-          // Color mixing
-          vec3 col1 = mix(uColor1, uColor2, n + uAudioHigh * 0.3);
-          vec3 col2 = mix(uColor2, uColor3, n2 + sin(time) * 0.2);
-          vec3 col = mix(col1, col2, uColorMix + uAudioMid * 0.2);
-          
-          // Color adjustments
-          vec3 hsv = rgb2hsv(col);
-          hsv.y *= uSaturation;
-          hsv.z *= uBrightness;
-          col = hsv2rgb(hsv);
-          
-          // Contrast adjustment
-          col = (col - 0.5) * uContrast + 0.5;
-          
-          // Final alpha with improved falloff
-          float alpha = smoothstep(0.0, 0.3, n) * smoothstep(1.0, 0.7, r) * uOpacity;
-          
-          gl_FragColor = vec4(col, alpha);
-        }
-      `
+      fragmentShader: fragmentShaderCode
     });
 
     this.mesh = new THREE.Mesh(geometry, material);
     this.scene.add(this.mesh);
+
+    if (this.shaderCode) {
+      this.renderer.compile(this.scene, this.camera);
+      const gl = this.renderer.getContext();
+      const program = (material as any).program?.program;
+      if (program && !gl.getProgramParameter(program, gl.LINK_STATUS)) {
+        console.error('Shader program failed to link:', gl.getProgramInfoLog(program));
+        material.fragmentShader = defaultFragmentShader;
+        material.needsUpdate = true;
+        this.renderer.compile(this.scene, this.camera);
+      }
+    }
   }
 
   public update(): void {
@@ -341,5 +369,5 @@ export function createPreset(
   cfg: PresetConfig,
   shaderCode?: string
 ): BasePreset {
-  return new GenLabPreset(scene, camera, renderer, cfg);
+  return new GenLabPreset(scene, camera, renderer, cfg, shaderCode);
 }


### PR DESCRIPTION
## Summary
- allow Gen Lab presets to accept custom fragment shaders
- compile custom shaders and log linker errors, falling back to default code

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'fs', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ac9fe4888333ad5b9a40cf3610d2