### PR TITLE
Handle invalid shader programs in Gen Lab preset

### DIFF
--- a/src/presets/gen-lab/preset.ts
+++ b/src/presets/gen-lab/preset.ts
@@ -292,10 +292,15 @@ class GenLabPreset extends BasePreset {
       this.renderer.compile(this.scene, this.camera);
       const gl = this.renderer.getContext();
       const program = (material as any).program?.program;
-      if (program && !gl.getProgramParameter(program, gl.LINK_STATUS)) {
-        console.error('Shader program failed to link:', gl.getProgramInfoLog(program));
+      const isLinked = program ? gl.getProgramParameter(program, gl.LINK_STATUS) : false;
+      if (!isLinked) {
+        console.error(
+          'Shader program failed to link:',
+          program ? gl.getProgramInfoLog(program) : 'No program generated'
+        );
         material.fragmentShader = defaultFragmentShader;
         material.needsUpdate = true;
+        material.dispose();
         this.renderer.compile(this.scene, this.camera);
       }
     }


### PR DESCRIPTION
## Summary
- Validate compiled shaders in Gen Lab preset and fall back to default when linking fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b04d1c1c83339b1c50a758aa93f9