### PR TITLE
fix: avoid shader disposal causing invalid program

### DIFF
--- a/src/presets/gen-lab/preset.ts
+++ b/src/presets/gen-lab/preset.ts
@@ -300,7 +300,6 @@ class GenLabPreset extends BasePreset {
         );
         material.fragmentShader = defaultFragmentShader;
         material.needsUpdate = true;
-        material.dispose();
         this.renderer.compile(this.scene, this.camera);
       }
     }


### PR DESCRIPTION
## Summary
- avoid disposing Gen Lab shader when fallback to default to keep WebGL program valid

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'onBeat' does not exist on type 'LoadedPreset', plus other TS2564 errors)*


------
https://chatgpt.com/codex/tasks/task_e_68a9b2a387ec83338bf22dd861942bbd