### PR TITLE
Ensure Gen Lab and Fractal Lab presets fill the canvas

### DIFF
--- a/src/presets/fractal-lab/config.json
+++ b/src/presets/fractal-lab/config.json
@@ -7,6 +7,8 @@
   "tags": ["mandelbrot", "julia", "sierpinski", "mathematical", "audio-reactive"],
   "thumbnail": "fractal_lab_thumb.png",
   "defaultConfig": {
+    "width": 1920,
+    "height": 1080,
     "opacity": 1.0,
     "fractalType": "mandelbrot",
     "iterations": 50,

--- a/src/presets/fractal-lab/preset.ts
+++ b/src/presets/fractal-lab/preset.ts
@@ -56,11 +56,13 @@ class FractalLabPreset extends BasePreset {
 
   public init(): void {
     this.currentConfig = JSON.parse(JSON.stringify(this.config.defaultConfig));
-    const geometry = new THREE.PlaneGeometry(2, 2);
+    const width = (this.currentConfig.width || 1920) / 100;
+    const height = (this.currentConfig.height || 1080) / 100;
+    const geometry = new THREE.PlaneGeometry(width, height);
     const material = new THREE.ShaderMaterial({
       uniforms: {
         uTime: { value: 0.0 },
-        uResolution: { value: new THREE.Vector2(1920, 1080) },
+        uResolution: { value: new THREE.Vector2(this.currentConfig.width || 1920, this.currentConfig.height || 1080) },
         uOpacity: { value: this.opacity },
         uFractalType: { value: 0 },
         uIterations: { value: 50 },
@@ -238,6 +240,16 @@ class FractalLabPreset extends BasePreset {
     if (newConfig.brightness !== undefined) mat.uniforms.uBrightness.value = newConfig.brightness;
     if (newConfig.contrast !== undefined) mat.uniforms.uContrast.value = newConfig.contrast;
     if (newConfig.saturation !== undefined) mat.uniforms.uSaturation.value = newConfig.saturation;
+    if (newConfig.width !== undefined || newConfig.height !== undefined) {
+      const w = (this.currentConfig.width || 1920) / 100;
+      const h = (this.currentConfig.height || 1080) / 100;
+      this.mesh.geometry.dispose();
+      this.mesh.geometry = new THREE.PlaneGeometry(w, h);
+      mat.uniforms.uResolution.value = new THREE.Vector2(
+        this.currentConfig.width || 1920,
+        this.currentConfig.height || 1080
+      );
+    }
   }
 
   public dispose(): void {

--- a/src/presets/gen-lab/preset.ts
+++ b/src/presets/gen-lab/preset.ts
@@ -75,8 +75,9 @@ class GenLabPreset extends BasePreset {
   public init(): void {
     this.renderer.setClearColor(0x000000, 0);
     this.currentConfig = JSON.parse(JSON.stringify(this.config.defaultConfig));
-
-    const geometry = new THREE.PlaneGeometry(2, 2);
+    const width = (this.currentConfig.width || 1920) / 100;
+    const height = (this.currentConfig.height || 1080) / 100;
+    const geometry = new THREE.PlaneGeometry(width, height);
 
     const defaultFragmentShader = `
       uniform float uTime;


### PR DESCRIPTION
## Summary
- Scale Gen Lab presets to match configured width and height
- Scale Fractal Lab presets to 1920×1080 and update resolution uniforms
- Add width and height defaults to Fractal Lab configs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Error failed to get cargo metadata)


------
https://chatgpt.com/codex/tasks/task_e_68a9bc30ecd88333858bd53c55061249