### PR TITLE
feat: add MIDI scene generation and editor with export tools

### DIFF
--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -115,20 +115,35 @@
   font-size: 1.1rem;
 }
 
-.add-scene-btn {
+.scenes-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.add-scene-btn,
+.generate-scene-btn {
   background: #4CAF50;
   border: none;
   color: white;
   padding: 6px 12px;
   border-radius: 4px;
   cursor: pointer;
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   font-weight: 500;
   transition: background 0.2s ease;
 }
 
-.add-scene-btn:hover {
+.generate-scene-btn {
+  background: #FF9800;
+}
+
+.add-scene-btn:hover,
+.generate-scene-btn:hover {
   background: #5CBF60;
+}
+
+.generate-scene-btn:hover {
+  background: #FFB74D;
 }
 
 .scenes-list {
@@ -214,6 +229,24 @@
   box-shadow: 0 6px 16px rgba(76, 175, 80, 0.3);
 }
 
+.secondary-btn {
+  background: linear-gradient(45deg, #FF9800, #FFB74D);
+  border: none;
+  color: white;
+  padding: 12px 24px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+  margin-left: 12px;
+}
+
+.secondary-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(255, 152, 0, 0.3);
+}
+
 .scene-editor {
   padding: 40px;
   text-align: center;
@@ -223,4 +256,9 @@
   color: #888;
   font-style: italic;
   margin-top: 20px;
+}
+
+.quick-actions {
+  display: flex;
+  justify-content: center;
 }

--- a/src/crealab/components/SceneEditor.css
+++ b/src/crealab/components/SceneEditor.css
@@ -1,0 +1,235 @@
+.scene-editor {
+  flex: 1;
+  background: #1e1e1e;
+  padding: 20px;
+  overflow-y: auto;
+}
+
+.scene-editor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 30px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #333;
+}
+
+.scene-info h2 {
+  margin: 0 0 8px 0;
+  color: #fff;
+  font-size: 1.5rem;
+}
+
+.scene-meta {
+  color: #999;
+  font-size: 0.9rem;
+}
+
+.scene-meta span {
+  margin: 0 6px;
+}
+
+.scene-controls {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.scene-controls label {
+  color: #ccc;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.scene-controls input {
+  background: #3a3a3a;
+  border: 1px solid #555;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  width: 60px;
+}
+
+.export-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.export-btn {
+  background: #666;
+  border: none;
+  color: white;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: all 0.2s ease;
+}
+
+.export-btn:hover {
+  background: #777;
+}
+
+.export-btn.primary {
+  background: #2196F3;
+}
+
+.export-btn.primary:hover {
+  background: #1976D2;
+}
+
+.tracks-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.track-row {
+  background: #252525;
+  border: 1px solid #333;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.track-header {
+  background: #2d2d2d;
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-bottom: 1px solid #333;
+}
+
+.track-icon {
+  font-size: 1.2rem;
+}
+
+.track-label {
+  font-weight: 500;
+  color: #fff;
+  flex: 1;
+}
+
+.generate-clip-btn {
+  background: #4CAF50;
+  border: none;
+  color: white;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+}
+
+.generate-clip-btn:hover {
+  background: #5CBF60;
+  transform: scale(1.1);
+}
+
+.track-clips {
+  padding: 12px 16px;
+  min-height: 60px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.empty-track {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #666;
+  font-size: 0.9rem;
+  font-style: italic;
+  min-height: 40px;
+}
+
+.clip-item {
+  background: #3a3a3a;
+  border: 1px solid #555;
+  border-radius: 6px;
+  padding: 8px 12px;
+  min-width: 140px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: all 0.2s ease;
+}
+
+.clip-item:hover {
+  background: #404040;
+  border-color: #666;
+}
+
+.clip-item.enabled {
+  border-color: #4CAF50;
+}
+
+.clip-item.disabled {
+  opacity: 0.5;
+  border-color: #777;
+}
+
+.clip-name {
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.clip-info {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: #999;
+}
+
+.clip-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.toggle-clip-btn,
+.remove-clip-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 2px 4px;
+  border-radius: 3px;
+  transition: background 0.2s ease;
+}
+
+.toggle-clip-btn:hover {
+  background: rgba(76, 175, 80, 0.2);
+}
+
+.remove-clip-btn:hover {
+  background: rgba(244, 67, 54, 0.2);
+}
+
+.scene-editor-footer {
+  margin-top: 30px;
+  padding-top: 20px;
+  border-top: 1px solid #333;
+}
+
+.help-text {
+  color: #777;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.help-text strong {
+  color: #4CAF50;
+}
+

--- a/src/crealab/components/SceneEditor.tsx
+++ b/src/crealab/components/SceneEditor.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { Scene, MidiClip, TrackType } from '../types/CrealabTypes';
+import { MidiClipGenerator } from '../core/MidiClipGenerator';
+import { MidiExporter } from '../core/MidiExporter';
+import './SceneEditor.css';
+
+interface SceneEditorProps {
+  scene: Scene;
+  onUpdateScene: (updates: Partial<Scene>) => void;
+  globalTempo: number;
+  projectKey: string;
+  projectScale: string;
+}
+
+export const SceneEditor: React.FC<SceneEditorProps> = ({
+  scene,
+  onUpdateScene,
+  globalTempo,
+  projectKey,
+  projectScale
+}) => {
+  const clipGenerator = MidiClipGenerator.getInstance();
+
+  const trackTypes: { type: TrackType; label: string; icon: string }[] = [
+    { type: 'kick', label: 'Kick', icon: '🥁' },
+    { type: 'bass', label: 'Bass', icon: '🎸' },
+    { type: 'arp', label: 'Arp', icon: '🎹' },
+    { type: 'lead', label: 'Lead', icon: '🎵' },
+    { type: 'fx', label: 'FX/Chords', icon: '✨' },
+    { type: 'perc', label: 'Perc', icon: '🔔' },
+    { type: 'visual', label: 'Visual', icon: '🎨' }
+  ];
+
+  const generateClip = (trackType: TrackType) => {
+    let newClip: MidiClip;
+    
+    switch (trackType) {
+      case 'kick':
+        newClip = clipGenerator.generateKick('dub', scene.duration, 10);
+        break;
+      case 'bass':
+        newClip = clipGenerator.generateBass(projectKey, projectScale, 'dub', scene.duration, 1);
+        break;
+      case 'arp':
+        newClip = clipGenerator.generateArpeggio(projectKey, 'dorian', 'floating', scene.duration, 2);
+        break;
+      case 'fx':
+        newClip = clipGenerator.generateChordProgression(projectKey, 'dubClassic', scene.duration, 3);
+        break;
+      default:
+        // Create empty clip for other types
+        newClip = {
+          id: `${trackType}-${Date.now()}`,
+          name: `${trackType} clip`,
+          trackType,
+          notes: [],
+          duration: scene.duration,
+          channel: 4,
+          enabled: true
+        };
+    }
+    
+    const updatedClips = [...scene.clips, newClip];
+    onUpdateScene({ clips: updatedClips });
+  };
+
+  const removeClip = (clipId: string) => {
+    const updatedClips = scene.clips.filter(clip => clip.id !== clipId);
+    onUpdateScene({ clips: updatedClips });
+  };
+
+  const toggleClip = (clipId: string) => {
+    const updatedClips = scene.clips.map(clip => 
+      clip.id === clipId ? { ...clip, enabled: !clip.enabled } : clip
+    );
+    onUpdateScene({ clips: updatedClips });
+  };
+
+  const getClipsForTrackType = (trackType: TrackType) => {
+    return scene.clips.filter(clip => clip.trackType === trackType);
+  };
+
+  const exportScene = () => {
+    const content = MidiExporter.exportSceneToAbleton(scene);
+    MidiExporter.downloadAsFile(
+      content, 
+      `${scene.name.replace(/[^a-zA-Z0-9]/g, '_')}_ableton.txt`
+    );
+  };
+
+  const exportJSON = () => {
+    const content = MidiExporter.exportSceneToText(scene);
+    MidiExporter.downloadAsFile(
+      content,
+      `${scene.name.replace(/[^a-zA-Z0-9]/g, '_')}_midi.txt`
+    );
+  };
+
+  return (
+    <div className="scene-editor">
+      <div className="scene-editor-header">
+        <div className="scene-info">
+          <h2>{scene.name}</h2>
+          <div className="scene-meta">
+            <span>{scene.duration} bars</span>
+            <span>•</span>
+            <span>{scene.tempo} BPM</span>
+            <span>•</span>
+            <span>{scene.clips.length} clips</span>
+          </div>
+        </div>
+        
+        <div className="scene-controls">
+          <label>
+            Duration:
+            <input
+              type="number"
+              value={scene.duration}
+              onChange={(e) => onUpdateScene({ duration: parseInt(e.target.value) || 8 })}
+              min={1}
+              max={64}
+            />
+            bars
+          </label>
+          
+          <div className="export-buttons">
+            <button onClick={exportJSON} className="export-btn">📄 Export Text</button>
+            <button onClick={exportScene} className="export-btn primary">📤 Export for Ableton</button>
+          </div>
+        </div>
+      </div>
+
+      <div className="tracks-grid">
+        {trackTypes.map(({ type, label, icon }) => {
+          const clips = getClipsForTrackType(type);
+          
+          return (
+            <div key={type} className="track-row">
+              <div className="track-header">
+                <span className="track-icon">{icon}</span>
+                <span className="track-label">{label}</span>
+                <button 
+                  className="generate-clip-btn"
+                  onClick={() => generateClip(type)}
+                  title={`Generate ${label} clip`}
+                >
+                  +
+                </button>
+              </div>
+              
+              <div className="track-clips">
+                {clips.length === 0 ? (
+                  <div className="empty-track">
+                    <span>No clips</span>
+                  </div>
+                ) : (
+                  clips.map(clip => (
+                    <div 
+                      key={clip.id} 
+                      className={`clip-item ${clip.enabled ? 'enabled' : 'disabled'}`}
+                    >
+                      <span className="clip-name">{clip.name}</span>
+                      <div className="clip-info">
+                        <span>{clip.notes.length} notes</span>
+                        <span>Ch {clip.channel}</span>
+                      </div>
+                      <div className="clip-actions">
+                        <button 
+                          onClick={() => toggleClip(clip.id)}
+                          className="toggle-clip-btn"
+                          title={clip.enabled ? 'Disable' : 'Enable'}
+                        >
+                          {clip.enabled ? '👁️' : '👁️‍🗨️'}
+                        </button>
+                        <button 
+                          onClick={() => removeClip(clip.id)}
+                          className="remove-clip-btn"
+                          title="Remove clip"
+                        >
+                          🗑️
+                        </button>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      
+      <div className="scene-editor-footer">
+        <p className="help-text">
+          Click <strong>+</strong> to generate clips, or the eye icon to enable/disable clips
+        </p>
+      </div>
+    </div>
+  );
+};
+

--- a/src/crealab/core/MidiClipGenerator.ts
+++ b/src/crealab/core/MidiClipGenerator.ts
@@ -1,0 +1,168 @@
+import { MidiClip, MidiNote, TrackType, MusicalContext } from '../types/CrealabTypes';
+import { MusicTheoryUtils, HARMONIC_PROGRESSIONS } from '../utils/musicTheory';
+import { generateEuclideanPattern, EUCLIDEAN_PATTERNS } from '../utils/euclideanPatterns';
+
+export class MidiClipGenerator {
+  private static instance: MidiClipGenerator;
+  
+  static getInstance(): MidiClipGenerator {
+    if (!this.instance) {
+      this.instance = new MidiClipGenerator();
+    }
+    return this.instance;
+  }
+
+  generateKick(
+    style: 'minimal' | 'dub' | 'hypnotic' | 'fourOnFloor' = 'dub',
+    measures: number = 4,
+    channel: number = 10
+  ): MidiClip {
+    const pattern = generateEuclideanPattern('kick', style);
+    const notes: MidiNote[] = [];
+    
+    for (let measure = 0; measure < measures; measure++) {
+      pattern.forEach((hit, step) => {
+        if (hit) {
+          notes.push({
+            note: 36, // C2 kick
+            time: (measure * pattern.length + step) * (4 / pattern.length), // Convert to beats
+            velocity: this.generateVelocityVariation(80, 20), // Humanization
+            duration: 0.25 // Quarter beat
+          });
+        }
+      });
+    }
+    
+    return {
+      id: `kick-${Date.now()}`,
+      name: `Kick ${style}`,
+      trackType: 'kick',
+      notes,
+      duration: measures,
+      channel,
+      enabled: true
+    };
+  }
+
+  generateBass(
+    key: string = 'C',
+    scale: string = 'minor',
+    style: 'dub' | 'minimal' | 'hypnotic' = 'dub',
+    measures: number = 4,
+    channel: number = 1
+  ): MidiClip {
+    const scaleNotes = MusicTheoryUtils.getScaleNotes(key, scale);
+    const pattern = generateEuclideanPattern('bass', style);
+    const notes: MidiNote[] = [];
+    
+    // Focus on root and fifth for dub bass
+    const bassNotes = [scaleNotes[0], scaleNotes[4]]; // Root and fifth
+    
+    for (let measure = 0; measure < measures; measure++) {
+      pattern.forEach((hit, step) => {
+        if (hit) {
+          const noteChoice = bassNotes[Math.floor(Math.random() * bassNotes.length)];
+          const octave = Math.random() > 0.8 ? '1' : '2'; // Mostly C2, sometimes C1
+          
+          notes.push({
+            note: MusicTheoryUtils.noteToMidi(noteChoice + octave),
+            time: (measure * pattern.length + step) * (4 / pattern.length),
+            velocity: this.generateVelocityVariation(70, 25),
+            duration: 0.75 // Longer bass notes
+          });
+        }
+      });
+    }
+    
+    return {
+      id: `bass-${Date.now()}`,
+      name: `Bass ${style}`,
+      trackType: 'bass',
+      notes,
+      duration: measures,
+      channel,
+      enabled: true
+    };
+  }
+
+  generateArpeggio(
+    key: string = 'C',
+    scale: string = 'dorian',
+    style: 'floating' | 'ambient' | 'maxCooper' = 'floating',
+    measures: number = 4,
+    channel: number = 2
+  ): MidiClip {
+    const scaleNotes = MusicTheoryUtils.getScaleNotes(key, scale);
+    const pattern = generateEuclideanPattern('hihat', style); // Using hihat patterns for arps
+    const notes: MidiNote[] = [];
+    
+    for (let measure = 0; measure < measures; measure++) {
+      pattern.forEach((hit, step) => {
+        if (hit) {
+          // Arpeggio pattern: cycle through scale notes
+          const noteIndex = step % scaleNotes.length;
+          const octave = Math.floor(step / scaleNotes.length) + 4; // Start from octave 4
+          
+          notes.push({
+            note: MusicTheoryUtils.noteToMidi(scaleNotes[noteIndex] + octave),
+            time: (measure * pattern.length + step) * (4 / pattern.length),
+            velocity: this.generateVelocityVariation(50, 30), // Softer for ambient
+            duration: 0.5
+          });
+        }
+      });
+    }
+    
+    return {
+      id: `arp-${Date.now()}`,
+      name: `Arp ${style}`,
+      trackType: 'arp',
+      notes,
+      duration: measures,
+      channel,
+      enabled: true
+    };
+  }
+
+  generateChordProgression(
+    key: string = 'C',
+    progression: keyof typeof HARMONIC_PROGRESSIONS = 'dubClassic',
+    measures: number = 4,
+    channel: number = 3
+  ): MidiClip {
+    const chordRomans = HARMONIC_PROGRESSIONS[progression];
+    const notes: MidiNote[] = [];
+    const beatsPerChord = (measures * 4) / chordRomans.length;
+    
+    chordRomans.forEach((roman, index) => {
+      const chordNotes = MusicTheoryUtils.getChordFromRomanNumeral(roman, key);
+      const startTime = index * beatsPerChord;
+      
+      chordNotes.forEach(note => {
+        notes.push({
+          note: MusicTheoryUtils.noteToMidi(note + '3'), // Chord in octave 3
+          time: startTime,
+          velocity: this.generateVelocityVariation(60, 20),
+          duration: beatsPerChord * 0.9 // Slightly shorter than full duration
+        });
+      });
+    });
+    
+    return {
+      id: `chords-${Date.now()}`,
+      name: `${progression} in ${key}`,
+      trackType: 'fx', // Using fx as chord track
+      notes,
+      duration: measures,
+      channel,
+      enabled: true
+    };
+  }
+
+  private generateVelocityVariation(base: number, variation: number): number {
+    const min = Math.max(1, base - variation);
+    const max = Math.min(127, base + variation);
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+}
+

--- a/src/crealab/core/MidiExporter.ts
+++ b/src/crealab/core/MidiExporter.ts
@@ -1,0 +1,91 @@
+import { MidiClip, Scene } from '../types/CrealabTypes';
+
+export class MidiExporter {
+  static exportSceneToText(scene: Scene): string {
+    let output = `# Scene: ${scene.name}\n`;
+    output += `# Duration: ${scene.duration} bars\n`;
+    output += `# Tempo: ${scene.tempo} BPM\n\n`;
+    
+    scene.clips.forEach(clip => {
+      if (clip.enabled && clip.notes.length > 0) {
+        output += `## Track: ${clip.name} (Channel ${clip.channel})\n`;
+        clip.notes.forEach(note => {
+          output += `Note ${note.note}, Time: ${note.time.toFixed(2)}, Vel: ${note.velocity}, Dur: ${note.duration}\n`;
+        });
+        output += '\n';
+      }
+    });
+    
+    return output;
+  }
+
+  static exportClipToJSON(clip: MidiClip): string {
+    const exportData = {
+      name: clip.name,
+      trackType: clip.trackType,
+      channel: clip.channel,
+      duration: clip.duration,
+      notes: clip.notes.map(note => ({
+        note: note.note,
+        time: note.time,
+        velocity: note.velocity,
+        duration: note.duration
+      }))
+    };
+    
+    return JSON.stringify(exportData, null, 2);
+  }
+
+  static exportSceneToAbleton(scene: Scene): string {
+    let output = `# Ableton Live Session Export\n`;
+    output += `# Import instructions: Create MIDI tracks and import each section\n\n`;
+    
+    // Group by track type
+    const trackGroups: Record<string, MidiClip[]> = {};
+    scene.clips.forEach(clip => {
+      if (clip.enabled) {
+        if (!trackGroups[clip.trackType]) {
+          trackGroups[clip.trackType] = [];
+        }
+        trackGroups[clip.trackType].push(clip);
+      }
+    });
+    
+    Object.entries(trackGroups).forEach(([trackType, clips]) => {
+      output += `## ${trackType.toUpperCase()} TRACK (Create new MIDI track)\n`;
+      clips.forEach((clip, index) => {
+        output += `### Clip ${index + 1}: ${clip.name}\n`;
+        output += `Channel: ${clip.channel}\n`;
+        output += `Notes:\n`;
+        clip.notes.forEach(note => {
+          const bars = Math.floor(note.time / 4);
+          const beats = ((note.time % 4) + 1).toFixed(2);
+          output += `  ${bars}:${beats} - Note ${note.note} (Vel: ${note.velocity})\n`;
+        });
+        output += '\n';
+      });
+    });
+    
+    return output;
+  }
+
+  static downloadAsFile(content: string, filename: string, type: string = 'text/plain') {
+    const blob = new Blob([content], { type });
+    const url = URL.createObjectURL(blob);
+    
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    
+    URL.revokeObjectURL(url);
+  }
+
+  static exportSceneForAudioVisualizer(scene: Scene): any {
+    // This will be implemented later for visual integration
+    return { scene: scene.name, clips: scene.clips.length };
+  }
+}
+


### PR DESCRIPTION
## Summary
- add MidiClipGenerator and MidiExporter utilities for creating and exporting MIDI clips
- integrate SceneEditor with clip generation, toggling and exporting
- enhance CreaLab with dub scene generator and new scene action buttons

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9c5229b3883339cbcc0cd5257095a