### PR TITLE
fix: remove missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "react-dom": "^18.2.0",
     "react-grid-layout": "^1.3.4",
     "three": "^0.179.1",
-    "tonal": "^5.0.0",
-    "euclidean-rhythm": "^1.0.1"
+    "tonal": "^5.0.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^1.5.0",


### PR DESCRIPTION
## Summary
- remove euclidean-rhythm from dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tonal)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c68547f88333a0e548ffdba76e7e