### PR TITLE
Add configurable resource path for visuals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -212,6 +212,9 @@ const App: React.FC = () => {
   const [canvasBrightness, setCanvasBrightness] = useState(() => parseFloat(localStorage.getItem('canvasBrightness') || '1'));
   const [canvasVibrance, setCanvasVibrance] = useState(() => parseFloat(localStorage.getItem('canvasVibrance') || '1'));
   const [canvasBackground, setCanvasBackground] = useState(() => localStorage.getItem('canvasBackground') || '#000000');
+  const [visualsPath, setVisualsPath] = useState(
+    () => localStorage.getItem('visualsPath') || './src/presets/'
+  );
 
   useEffect(() => {
     const channel = new BroadcastChannel('av-sync');
@@ -268,6 +271,10 @@ const App: React.FC = () => {
   useEffect(() => {
     localStorage.setItem('canvasBackground', canvasBackground);
   }, [canvasBackground]);
+
+  useEffect(() => {
+    localStorage.setItem('visualsPath', visualsPath);
+  }, [visualsPath]);
 
   useEffect(() => {
     if (!isFullscreenMode && midiTrigger) {
@@ -406,7 +413,7 @@ const App: React.FC = () => {
       console.log('🔧 Canvas found, initializing engine...');
       try {
         setStatus('Loading presets...');
-        const engine = new AudioVisualizerEngine(canvasRef.current, { glitchTextPads });
+        const engine = new AudioVisualizerEngine(canvasRef.current, { glitchTextPads, visualsPath });
         await engine.initialize();
         engineRef.current = engine;
         setGenLabBasePreset(engine.getGenLabBasePreset());
@@ -443,7 +450,7 @@ const App: React.FC = () => {
         engineRef.current.dispose();
       }
     };
-  }, [glitchTextPads]);
+  }, [glitchTextPads, visualsPath]);
 
 
   // Activar capas almacenadas en modo fullscreen
@@ -1193,6 +1200,8 @@ const App: React.FC = () => {
         onCanvasVibranceChange={setCanvasVibrance}
         canvasBackground={canvasBackground}
         onCanvasBackgroundChange={setCanvasBackground}
+        visualsPath={visualsPath}
+        onVisualsPathChange={setVisualsPath}
       />
 
       {/* Modal de galeria de presets */}

--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -88,6 +88,8 @@ interface GlobalSettingsModalProps {
   onCanvasVibranceChange: (value: number) => void;
   canvasBackground: string;
   onCanvasBackgroundChange: (value: string) => void;
+  visualsPath: string;
+  onVisualsPathChange: (value: string) => void;
 }
 
 export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
@@ -146,6 +148,8 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
   onCanvasVibranceChange,
   canvasBackground,
   onCanvasBackgroundChange,
+  visualsPath,
+  onVisualsPathChange,
 }) => {
   const [activeTab, setActiveTab] = useState('audio');
 
@@ -263,6 +267,8 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
                 onStartMonitorChange={onStartMonitorChange}
                 sidebarCollapsed={sidebarCollapsed}
                 onSidebarCollapsedChange={onSidebarCollapsedChange}
+                visualsPath={visualsPath}
+                onVisualsPathChange={onVisualsPathChange}
               />
             )}
           </div>

--- a/src/components/settings/SystemSettings.tsx
+++ b/src/components/settings/SystemSettings.tsx
@@ -17,6 +17,8 @@ interface SystemSettingsProps {
   onStartMonitorChange: (id: string | null) => void;
   sidebarCollapsed: boolean;
   onSidebarCollapsedChange: (value: boolean) => void;
+  visualsPath: string;
+  onVisualsPathChange: (value: string) => void;
 }
 
 export const SystemSettings: React.FC<SystemSettingsProps> = ({
@@ -27,6 +29,8 @@ export const SystemSettings: React.FC<SystemSettingsProps> = ({
   onStartMonitorChange,
   sidebarCollapsed,
   onSidebarCollapsedChange,
+  visualsPath,
+  onVisualsPathChange,
 }) => {
   const [autoCleanCache, setAutoCleanCache] = useState(() =>
     localStorage.getItem('autoCleanCache') !== 'false'
@@ -35,6 +39,11 @@ export const SystemSettings: React.FC<SystemSettingsProps> = ({
     parseInt(localStorage.getItem('memoryLimit') || '512')
   );
   const [webglSupport, setWebglSupport] = useState<string>('Detecting...');
+  const [resourcesPath, setResourcesPath] = useState(visualsPath);
+
+  useEffect(() => {
+    setResourcesPath(visualsPath);
+  }, [visualsPath]);
 
   useEffect(() => {
     localStorage.setItem('autoCleanCache', autoCleanCache.toString());
@@ -57,6 +66,11 @@ export const SystemSettings: React.FC<SystemSettingsProps> = ({
       setWebglSupport('Not available');
     }
   }, []);
+
+  const handlePathChange = (value: string) => {
+    setResourcesPath(value);
+    onVisualsPathChange(value);
+  };
 
   const handleClearCache = () => {
     const keysToKeep = [
@@ -153,6 +167,19 @@ export const SystemSettings: React.FC<SystemSettingsProps> = ({
           />
           <span>Collapse sidebar on start</span>
         </label>
+      </div>
+
+      <div className="setting-group">
+        <label className="setting-label">
+          <span>Visuals Path</span>
+          <input
+            type="text"
+            value={resourcesPath}
+            onChange={e => handlePathChange(e.target.value)}
+            className="setting-input"
+          />
+        </label>
+        <small className="setting-hint">Base folder for visual presets</small>
       </div>
 
       {memInfo && (

--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -32,7 +32,10 @@ export class AudioVisualizerEngine {
   private multiMonitorMode = false;
   private currentBpm: number = 120;
 
-  constructor(private canvas: HTMLCanvasElement, options: { glitchTextPads?: number } = {}) {
+  constructor(
+    private canvas: HTMLCanvasElement,
+    options: { glitchTextPads?: number; visualsPath?: string } = {}
+  ) {
     this.camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
     this.renderer = new THREE.WebGLRenderer({
       canvas: this.canvas,
@@ -46,7 +49,12 @@ export class AudioVisualizerEngine {
     this.renderer.setClearColor(0x000000, 0);
     this.renderer.outputColorSpace = THREE.SRGBColorSpace;
 
-    this.presetLoader = new PresetLoader(this.camera, this.renderer, options.glitchTextPads ?? 1);
+    this.presetLoader = new PresetLoader(
+      this.camera,
+      this.renderer,
+      options.glitchTextPads ?? 1,
+      options.visualsPath
+    );
     this.layerManager = new LayerManager(this.renderer, this.camera, this.presetLoader);
     this.layers = this.layerManager.getLayers();
     this.compositor = new Compositor(this.renderer);
@@ -189,7 +197,7 @@ export class AudioVisualizerEngine {
   // utilities is avoided to stay compatible with the browser/Tauri runtime.
   private getLayerConfigPath(presetId: string, layerId: string): string {
     const loaded = this.presetLoader.getLoadedPresets().find(p => p.id === presetId);
-    const folder = loaded?.folderPath ?? `src/presets/${presetId}`;
+    const folder = loaded?.folderPath ?? `${this.presetLoader.getBasePath()}/${presetId}`;
     const variantMatch = presetId.match(/-(\d+)$/);
     const variantSuffix = variantMatch ? `-${variantMatch[1]}` : '';
     return `${folder}/layers/${layerId}${variantSuffix}.json`;

--- a/src/core/LayerManager.ts
+++ b/src/core/LayerManager.ts
@@ -169,7 +169,7 @@ export class LayerManager {
 
   private getLayerConfigPath(presetId: string, layerId: string): string {
     const loaded = this.presetLoader.getLoadedPresets().find(p => p.id === presetId);
-    const folder = loaded?.folderPath ?? `src/presets/${presetId}`;
+    const folder = loaded?.folderPath ?? `${this.presetLoader.getBasePath()}/${presetId}`;
     const variantMatch = presetId.match(/-(\d+)$/);
     const variantSuffix = variantMatch ? `-${variantMatch[1]}` : '';
     return `${folder}/layers/${layerId}${variantSuffix}.json`;


### PR DESCRIPTION
## Summary
- Allow configuring the visuals resource path from System settings, defaulting to `./src/presets/`
- Pass the configured path through the app, engine and preset loader so visuals and templates populate correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: sh: 1: tauri: not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tsc)*

------
https://chatgpt.com/codex/tasks/task_e_68a9de9b17448333a47feb1799657774