### PR TITLE
Fix template preset modals and empty preset notice

### DIFF
--- a/src/components/ResourcesModal.css
+++ b/src/components/ResourcesModal.css
@@ -670,6 +670,12 @@
   margin-left: 12px;
 }
 
+.tree-placeholder {
+  padding: 8px;
+  color: rgba(255, 255, 255, 0.7);
+  font-style: italic;
+}
+
 
 @media (max-width: 768px) {
   .preset-gallery-content {

--- a/src/components/ResourcesModal.tsx
+++ b/src/components/ResourcesModal.tsx
@@ -572,20 +572,6 @@ export const ResourcesModal: React.FC<ResourcesModalProps> = ({
                 </li>
               ))}
             </ul>
-            {genLabBasePreset && (
-              <GenLabPresetModal
-                isOpen={isGenLabModalOpen}
-                onClose={() => {
-                  setGenLabModalOpen(false);
-                  setEditingGenLabIndex(null);
-                }}
-                basePreset={genLabBasePreset}
-                initial={
-                  editingGenLabIndex !== null ? genLabPresets[editingGenLabIndex] : undefined
-                }
-                onSave={handleSaveGenLabPreset}
-              />
-            )}
           </div>
         );
       }
@@ -607,20 +593,6 @@ export const ResourcesModal: React.FC<ResourcesModalProps> = ({
               <button onClick={() => handleDuplicateGenLabPreset(idx)}>Duplicate</button>
               <button onClick={() => handleDeleteGenLabPreset(idx)}>Delete</button>
             </div>
-            {genLabBasePreset && (
-              <GenLabPresetModal
-                isOpen={isGenLabModalOpen}
-                onClose={() => {
-                  setGenLabModalOpen(false);
-                  setEditingGenLabIndex(null);
-                }}
-                basePreset={genLabBasePreset}
-                initial={
-                  editingGenLabIndex !== null ? genLabPresets[editingGenLabIndex] : undefined
-                }
-                onSave={handleSaveGenLabPreset}
-              />
-            )}
           </div>
         );
       }
@@ -680,22 +652,6 @@ export const ResourcesModal: React.FC<ResourcesModalProps> = ({
                 </li>
               ))}
             </ul>
-            {fractalLabBasePreset && (
-              <FractalLabPresetModal
-                isOpen={isFractalLabModalOpen}
-                onClose={() => {
-                  setFractalLabModalOpen(false);
-                  setEditingFractalLabIndex(null);
-                }}
-                basePreset={fractalLabBasePreset}
-                initial={
-                  editingFractalLabIndex !== null
-                    ? fractalLabPresets[editingFractalLabIndex]
-                    : undefined
-                }
-                onSave={handleSaveFractalLabPreset}
-              />
-            )}
           </div>
         );
       }
@@ -721,22 +677,6 @@ export const ResourcesModal: React.FC<ResourcesModalProps> = ({
                 Delete
               </button>
             </div>
-            {fractalLabBasePreset && (
-              <FractalLabPresetModal
-                isOpen={isFractalLabModalOpen}
-                onClose={() => {
-                  setFractalLabModalOpen(false);
-                  setEditingFractalLabIndex(null);
-                }}
-                basePreset={fractalLabBasePreset}
-                initial={
-                  editingFractalLabIndex !== null
-                    ? fractalLabPresets[editingFractalLabIndex]
-                    : undefined
-                }
-                onSave={handleSaveFractalLabPreset}
-              />
-            )}
           </div>
         );
       }
@@ -773,31 +713,67 @@ export const ResourcesModal: React.FC<ResourcesModalProps> = ({
   };
 
   return (
-    <div className="preset-gallery-overlay" onClick={onClose}>
-      <div
-        className="preset-gallery-modal"
-        onClick={e => e.stopPropagation()}
-        ref={modalRef}
-        style={{ ['--sidebar-width' as any]: `${sidebarWidth}px` }}
-      >
-        <div className="preset-gallery-header">
-          <h2>📁 Resources</h2>
-          <button className="close-button" onClick={onClose}>
-            ✕
-          </button>
-        </div>
-        <div className="resources-layout">
-          <div className="resources-tree">
-            {tree.map(node => renderNode(node))}
+    <>
+      <div className="preset-gallery-overlay" onClick={onClose}>
+        <div
+          className="preset-gallery-modal"
+          onClick={e => e.stopPropagation()}
+          ref={modalRef}
+          style={{ ['--sidebar-width' as any]: `${sidebarWidth}px` }}
+        >
+          <div className="preset-gallery-header">
+            <h2>📁 Resources</h2>
+            <button className="close-button" onClick={onClose}>
+              ✕
+            </button>
           </div>
-          <div
-            className="resources-resizer"
-            onMouseDown={() => setIsResizing(true)}
-          ></div>
-          <div className="resources-details">{renderDetails()}</div>
+          <div className="resources-layout">
+            <div className="resources-tree">
+              {presets.length === 0 ? (
+                <div className="tree-placeholder">No presets available</div>
+              ) : (
+                tree.map(node => renderNode(node))
+              )}
+            </div>
+            <div
+              className="resources-resizer"
+              onMouseDown={() => setIsResizing(true)}
+            ></div>
+            <div className="resources-details">{renderDetails()}</div>
+          </div>
         </div>
       </div>
-    </div>
+      {genLabBasePreset && (
+        <GenLabPresetModal
+          isOpen={isGenLabModalOpen}
+          onClose={() => {
+            setGenLabModalOpen(false);
+            setEditingGenLabIndex(null);
+          }}
+          basePreset={genLabBasePreset}
+          initial={
+            editingGenLabIndex !== null ? genLabPresets[editingGenLabIndex] : undefined
+          }
+          onSave={handleSaveGenLabPreset}
+        />
+      )}
+      {fractalLabBasePreset && (
+        <FractalLabPresetModal
+          isOpen={isFractalLabModalOpen}
+          onClose={() => {
+            setFractalLabModalOpen(false);
+            setEditingFractalLabIndex(null);
+          }}
+          basePreset={fractalLabBasePreset}
+          initial={
+            editingFractalLabIndex !== null
+              ? fractalLabPresets[editingFractalLabIndex]
+              : undefined
+          }
+          onSave={handleSaveFractalLabPreset}
+        />
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- show placeholder when resources modal has no presets
- render Gen Lab and Fractal Lab preset modals outside the tree so they open correctly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9e11d5218833391cd9e902cd3302a