### PR TITLE
Fix initialization so audiovisualizer loads presets

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -404,12 +404,17 @@ const App: React.FC = () => {
 
   // Inicializar el engine
   useEffect(() => {
+    // Solo inicializar el engine cuando el usuario esté en el modo Audiovisualizer
+    if (currentApp !== 'audiovisualizer') {
+      return;
+    }
+
     const initEngine = async () => {
       if (!canvasRef.current) {
         console.error('❌ Canvas ref is null');
         return;
       }
-      
+
       console.log('🔧 Canvas found, initializing engine...');
       try {
         setStatus('Loading presets...');
@@ -450,7 +455,7 @@ const App: React.FC = () => {
         engineRef.current.dispose();
       }
     };
-  }, [glitchTextPads, visualsPath]);
+  }, [currentApp, glitchTextPads, visualsPath]);
 
 
   // Activar capas almacenadas en modo fullscreen


### PR DESCRIPTION
## Summary
- Ensure engine initialization only runs when the Audiovisualizer mode is active
- Depend on the selected app to load presets and visuals correctly

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a9e2e008d08333b9cdb666c551b5c3