### PR TITLE
feat: add track-based view to Crea Lab

### DIFF
--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -89,176 +89,92 @@
 
 .crealab-workspace {
   flex: 1;
-  display: flex;
-  overflow: hidden;
+  overflow: auto;
 }
 
-.scenes-panel {
-  width: 280px;
+.track-view {
+  display: flex;
+  height: 100%;
+}
+
+.section-column {
+  display: flex;
+  flex-direction: column;
   background: #252525;
   border-right: 1px solid #444;
+}
+
+.section-header {
+  padding: 8px;
+  border-bottom: 1px solid #444;
+  text-align: center;
+  font-weight: 500;
+}
+
+.section-label {
+  width: 120px;
+  height: 60px;
+  border-bottom: 1px solid #333;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+}
+
+.add-section {
+  background: #333;
+  border: none;
+  color: #fff;
+  padding: 8px;
+  cursor: pointer;
+  border-top: 1px solid #444;
+}
+
+.track-column {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid #444;
+  width: 180px;
+}
+
+.track-header {
+  background: #2d2d2d;
+  padding: 8px;
+  border-bottom: 1px solid #444;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.track-header input {
+  background: #3a3a3a;
+  border: 1px solid #555;
+  color: #fff;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.clip-slot {
+  height: 60px;
+  border-bottom: 1px solid #333;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #888;
+}
+
+.add-track-column {
   display: flex;
   flex-direction: column;
 }
 
-.scenes-header {
-  padding: 20px;
-  border-bottom: 1px solid #444;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.scenes-header h3 {
-  margin: 0;
-  color: #fff;
-  font-size: 1.1rem;
-}
-
-.scenes-actions {
-  display: flex;
-  gap: 8px;
-}
-
-.add-scene-btn,
-.generate-scene-btn {
+.add-track-column button {
+  margin-top: 40px;
   background: #4CAF50;
   border: none;
-  color: white;
-  padding: 6px 12px;
+  color: #fff;
+  padding: 8px 12px;
+  cursor: pointer;
   border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.75rem;
-  font-weight: 500;
-  transition: background 0.2s ease;
-}
-
-.generate-scene-btn {
-  background: #FF9800;
-}
-
-.add-scene-btn:hover,
-.generate-scene-btn:hover {
-  background: #5CBF60;
-}
-
-.generate-scene-btn:hover {
-  background: #FFB74D;
-}
-
-.scenes-list {
-  flex: 1;
-  padding: 10px;
-  overflow-y: auto;
-}
-
-.scene-item {
-  background: #333;
-  border: 1px solid #555;
-  border-radius: 6px;
-  padding: 12px;
-  margin-bottom: 8px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.scene-item:hover {
-  background: #3a3a3a;
-  border-color: #666;
-}
-
-.scene-item.selected {
-  background: #4CAF50;
-  border-color: #4CAF50;
-  color: #000;
-}
-
-.scene-name {
-  display: block;
-  font-weight: 500;
-  margin-bottom: 4px;
-}
-
-.scene-info {
-  font-size: 0.8rem;
-  opacity: 0.8;
-}
-
-.no-scenes {
-  text-align: center;
-  padding: 40px 20px;
-  color: #777;
-}
-
-.main-workspace {
-  flex: 1;
-  background: #1e1e1e;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.no-scene-selected {
-  text-align: center;
-}
-
-.welcome-message h2 {
-  color: #fff;
-  margin-bottom: 10px;
-}
-
-.welcome-message p {
-  color: #bbb;
-  margin-bottom: 30px;
-}
-
-.primary-btn {
-  background: linear-gradient(45deg, #4CAF50, #8BC34A);
-  border: none;
-  color: white;
-  padding: 12px 24px;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 1rem;
-  font-weight: 600;
-  transition: all 0.2s ease;
-}
-
-.primary-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(76, 175, 80, 0.3);
-}
-
-.secondary-btn {
-  background: linear-gradient(45deg, #FF9800, #FFB74D);
-  border: none;
-  color: white;
-  padding: 12px 24px;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 1rem;
-  font-weight: 600;
-  transition: all 0.2s ease;
-  margin-left: 12px;
-}
-
-.secondary-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(255, 152, 0, 0.3);
-}
-
-.scene-editor {
-  padding: 40px;
-  text-align: center;
-}
-
-.coming-soon {
-  color: #888;
-  font-style: italic;
-  margin-top: 20px;
-}
-
-.quick-actions {
-  display: flex;
-  justify-content: center;
 }

--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import { CreaLabProject, Scene, MidiClip } from '../types/CrealabTypes';
-import { MidiClipGenerator } from '../core/MidiClipGenerator';
-import { SceneEditor } from './SceneEditor';
+import { CreaLabProject, Track, Phase } from '../types/CrealabTypes';
 import './CreaLab.css';
 
 interface CreaLabProps {
@@ -12,75 +10,54 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
   const [project, setProject] = useState<CreaLabProject>({
     id: 'project-1',
     name: 'New Project',
-    scenes: [],
+    tracks: [
+      { id: 'track-1', name: 'Track 1', midiDevice: '', clips: {} }
+    ],
+    phases: [
+      { id: 'phase-1', name: 'Phase 1' }
+    ],
     globalTempo: 128,
     key: 'C',
     scale: 'minor'
   });
 
-  const [selectedScene, setSelectedScene] = useState<string | null>(null);
-  const clipGenerator = MidiClipGenerator.getInstance();
-
-  const createNewScene = () => {
-    const newScene: Scene = {
-      id: `scene-${Date.now()}`,
-      name: `Scene ${project.scenes.length + 1}`,
-      duration: 8,
-      tempo: project.globalTempo,
-      clips: [],
-      visualConfig: {
-        primaryPreset: '',
-        layerPresets: {},
-        triggers: []
-      },
-      musicalContext: 'intro'
+  const addTrack = () => {
+    const newTrack: Track = {
+      id: `track-${Date.now()}`,
+      name: `Track ${project.tracks!.length + 1}`,
+      midiDevice: '',
+      clips: {}
     };
-    
     setProject(prev => ({
       ...prev,
-      scenes: [...prev.scenes, newScene]
+      tracks: [...(prev.tracks || []), newTrack]
     }));
   };
 
-  const generateDubScene = () => {
-    const kick = clipGenerator.generateKick('dub', 8, 10);
-    const bass = clipGenerator.generateBass(project.key, project.scale, 'dub', 8, 1);
-    const arp = clipGenerator.generateArpeggio(project.key, 'dorian', 'floating', 8, 2);
-    const chords = clipGenerator.generateChordProgression(project.key, 'dubClassic', 8, 3);
-    
-    const newScene: Scene = {
-      id: `scene-${Date.now()}`,
-      name: `Dub Scene ${project.scenes.length + 1}`,
-      duration: 8,
-      tempo: project.globalTempo,
-      clips: [kick, bass, arp, chords],
-      visualConfig: {
-        primaryPreset: '',
-        layerPresets: {},
-        triggers: []
-      },
-      musicalContext: 'drop'
+  const renameTrack = (trackId: string, name: string) => {
+    setProject(prev => ({
+      ...prev,
+      tracks: prev.tracks?.map(t => t.id === trackId ? { ...t, name } : t)
+    }));
+  };
+
+  const assignMidi = (trackId: string, device: string) => {
+    setProject(prev => ({
+      ...prev,
+      tracks: prev.tracks?.map(t => t.id === trackId ? { ...t, midiDevice: device } : t)
+    }));
+  };
+
+  const addPhase = () => {
+    const newPhase: Phase = {
+      id: `phase-${Date.now()}`,
+      name: `Phase ${project.phases!.length + 1}`
     };
-    
     setProject(prev => ({
       ...prev,
-      scenes: [...prev.scenes, newScene]
-    }));
-    
-    setSelectedScene(newScene.id);
-  };
-
-  const updateScene = (sceneId: string, updates: Partial<Scene>) => {
-    setProject(prev => ({
-      ...prev,
-      scenes: prev.scenes.map(scene => 
-        scene.id === sceneId ? { ...scene, ...updates } : scene
-      )
+      phases: [...(prev.phases || []), newPhase]
     }));
   };
-
-  const currentScene = selectedScene ? 
-    project.scenes.find(s => s.id === selectedScene) : null;
 
   return (
     <div className="crealab-container">
@@ -89,25 +66,25 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
           <h1>🎼 Crea Lab</h1>
           <span className="project-name">{project.name}</span>
         </div>
-        
+
         <div className="crealab-controls">
           <div className="global-settings">
             <label>
-              BPM: 
-              <input 
-                type="number" 
+              BPM:
+              <input
+                type="number"
                 value={project.globalTempo}
-                onChange={(e) => setProject(prev => ({ 
-                  ...prev, 
-                  globalTempo: parseInt(e.target.value) || 128 
+                onChange={(e) => setProject(prev => ({
+                  ...prev,
+                  globalTempo: parseInt(e.target.value) || 128
                 }))}
                 min={60}
                 max={200}
               />
             </label>
             <label>
-              Key: 
-              <select 
+              Key:
+              <select
                 value={project.key}
                 onChange={(e) => setProject(prev => ({ ...prev, key: e.target.value }))}
               >
@@ -117,7 +94,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
               </select>
             </label>
           </div>
-          
+
           <button onClick={onSwitchToAudioVisualizer} className="switch-app-btn">
             🎨 AudioVisualizer
           </button>
@@ -125,63 +102,39 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
       </header>
 
       <main className="crealab-workspace">
-        <div className="scenes-panel">
-          <div className="scenes-header">
-            <h3>Scenes</h3>
-            <div className="scenes-actions">
-              <button onClick={createNewScene} className="add-scene-btn">+ Empty</button>
-              <button onClick={generateDubScene} className="generate-scene-btn">
-                🎵 Dub
-              </button>
-            </div>
-          </div>
-          
-          <div className="scenes-list">
-            {project.scenes.map(scene => (
-              <div 
-                key={scene.id}
-                className={`scene-item ${selectedScene === scene.id ? 'selected' : ''}`}
-                onClick={() => setSelectedScene(scene.id)}
-              >
-                <span className="scene-name">{scene.name}</span>
-                <span className="scene-info">{scene.duration} bars</span>
-              </div>
+        <div className="track-view">
+          <div className="section-column">
+            <div className="section-header">Phases</div>
+            {project.phases?.map(phase => (
+              <div key={phase.id} className="section-label">{phase.name}</div>
             ))}
-            
-            {project.scenes.length === 0 && (
-              <div className="no-scenes">
-                <p>No scenes yet</p>
-                <p>Create your first scene to start composing</p>
-              </div>
-            )}
+            <button onClick={addPhase} className="add-section">+ Phase</button>
           </div>
-        </div>
 
-        <div className="main-workspace">
-          {selectedScene ? (
-            <SceneEditor 
-              scene={currentScene!}
-              onUpdateScene={(updates) => updateScene(selectedScene, updates)}
-              globalTempo={project.globalTempo}
-              projectKey={project.key}
-              projectScale={project.scale}
-            />
-          ) : (
-            <div className="no-scene-selected">
-              <div className="welcome-message">
-                <h2>Welcome to Crea Lab</h2>
-                <p>Your MIDI generation and creative assistant</p>
-                <div className="quick-actions">
-                  <button onClick={createNewScene} className="primary-btn">
-                    Create First Scene
-                  </button>
-                  <button onClick={generateDubScene} className="secondary-btn">
-                    Generate Dub Scene
-                  </button>
-                </div>
+          {project.tracks?.map(track => (
+            <div key={track.id} className="track-column">
+              <div className="track-header">
+                <input
+                  value={track.name}
+                  onChange={(e) => renameTrack(track.id, e.target.value)}
+                />
+                <input
+                  value={track.midiDevice}
+                  onChange={(e) => assignMidi(track.id, e.target.value)}
+                  placeholder="MIDI Device"
+                />
               </div>
+              {project.phases?.map(phase => (
+                <div key={phase.id} className="clip-slot">
+                  {track.clips[phase.id]?.name || ''}
+                </div>
+              ))}
             </div>
-          )}
+          ))}
+
+          <div className="add-track-column">
+            <button onClick={addTrack}>+ Track</button>
+          </div>
         </div>
       </main>
     </div>

--- a/src/crealab/types/CrealabTypes.ts
+++ b/src/crealab/types/CrealabTypes.ts
@@ -19,6 +19,18 @@ export interface MidiClip {
   enabled: boolean;
 }
 
+export interface Phase {
+  id: string;
+  name: string;
+}
+
+export interface Track {
+  id: string;
+  name: string;
+  midiDevice: string;
+  clips: Record<string, MidiClip | null>; // phaseId -> clip
+}
+
 export interface VisualClip {
   id: string;
   presetId: string;
@@ -51,7 +63,9 @@ export interface VisualSceneConfig {
 export interface CreaLabProject {
   id: string;
   name: string;
-  scenes: Scene[];
+  scenes?: Scene[];
+  phases?: Phase[];
+  tracks?: Track[];
   globalTempo: number;
   key: string;
   scale: string;


### PR DESCRIPTION
## Summary
- Add track and phase structures for organizing MIDI clips
- Replace Crea Lab UI with vertical tracks and horizontal phase groups
- Style new grid layout and controls for track naming and MIDI assignment

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json --noEmit` (fails: Cannot find type definition file for 'vite/client')
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/tonal)


------
https://chatgpt.com/codex/tasks/task_e_68a9e56dcd80833382b74d6f7340f41d