### PR TITLE
Restore fullscreen UI toggle and endless Gen Lab presets

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -389,6 +389,14 @@ const App: React.FC = () => {
   }, [isFullscreenMode]);
 
   useEffect(() => {
+    if (isFullscreenMode) {
+      setIsUiHidden(true);
+    } else {
+      setIsUiHidden(false);
+    }
+  }, [isFullscreenMode]);
+
+  useEffect(() => {
     const api = (window as any).electronAPI;
     if (!api?.onMainLeaveFullscreen) return;
     const handler = () => {

--- a/src/AppLayout.css
+++ b/src/AppLayout.css
@@ -1,14 +1,14 @@
-.app {
+.app-container {
   position: relative;
   width: 100vw;
   height: 100vh;
   overflow: hidden;
 }
 
-.app.ui-hidden .top-bar,
-.app.ui-hidden .layer-grid-container,
-.app.ui-hidden .controls-panel,
-.app.ui-hidden .status-bar {
+.app-container.ui-hidden .top-bar,
+.app-container.ui-hidden .layer-grid-container,
+.app-container.ui-hidden .controls-panel,
+.app-container.ui-hidden .status-bar {
   display: none;
 }
 

--- a/src/presets/gen-lab/preset.ts
+++ b/src/presets/gen-lab/preset.ts
@@ -60,6 +60,7 @@ class GenLabPreset extends BasePreset {
   private mesh!: THREE.Mesh<THREE.PlaneGeometry, THREE.ShaderMaterial>;
   private currentConfig: any;
   private shaderCode?: string;
+  private timeOffset = Math.random() * 10000;
 
   constructor(
     scene: THREE.Scene,
@@ -185,8 +186,8 @@ class GenLabPreset extends BasePreset {
       void main() {
         vec2 uv = vUv * 0.5 + 0.5;
 
-        // Time manipulation
-        float time = uTime * uSpeed + sin(uTime * uTimeWarp) * 0.5;
+        // Time manipulation without looping
+        float time = uTime * (uSpeed + uTimeWarp);
 
         // Variant-specific UV transformations
         if(uVariant == 0) { // fog
@@ -307,7 +308,7 @@ class GenLabPreset extends BasePreset {
   }
 
   public update(): void {
-    const t = this.clock.getElapsedTime();
+    const t = this.clock.getElapsedTime() + this.timeOffset;
     const mat = this.mesh.material as THREE.ShaderMaterial;
     mat.uniforms.uTime.value = t;
     mat.uniforms.uAudioLow.value = this.audioData.low;


### PR DESCRIPTION
## Summary
- Fix F10 hotkey by aligning `.app-container` styles so controls and grid hide/show correctly
- Hide UI automatically when entering fullscreen while allowing F10 to reveal controls
- Remove looping artifacts in Gen Lab presets via linear time flow and random offset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tonal)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e7b30c508333a2faf047728174bd