### PR TITLE
refactor: refine midi selectors in crealab

### DIFF
--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -131,6 +131,11 @@
   font-size: 0.7rem;
 }
 
+.midi-selectors {
+  display: flex;
+  gap: 3px;
+}
+
 .clip-slot {
   height: 35px;
   border-bottom: 1px solid #333;

--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -152,23 +152,25 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
                   value={track.name}
                   onChange={(e) => renameTrack(track.id, e.target.value)}
                 />
-                <select
-                  value={track.midiDevice}
-                  onChange={(e) => assignMidiDevice(track.id, e.target.value)}
-                >
-                  <option value="">Select MIDI</option>
-                  {midiDevices.map(dev => (
-                    <option key={dev.id} value={dev.id}>{dev.name}</option>
-                  ))}
-                </select>
-                <select
-                  value={track.midiChannel}
-                  onChange={(e) => assignMidiChannel(track.id, parseInt(e.target.value))}
-                >
-                  {Array.from({ length: 16 }, (_, i) => i + 1).map(ch => (
-                    <option key={ch} value={ch}>Ch {ch}</option>
-                  ))}
-                </select>
+                <div className="midi-selectors">
+                  <select
+                    value={track.midiDevice}
+                    onChange={(e) => assignMidiDevice(track.id, e.target.value)}
+                  >
+                    <option value="">MIDI Dev</option>
+                    {midiDevices.map(dev => (
+                      <option key={dev.id} value={dev.id}>{dev.name.substring(0, 8)}</option>
+                    ))}
+                  </select>
+                  <select
+                    value={track.midiChannel}
+                    onChange={(e) => assignMidiChannel(track.id, parseInt(e.target.value))}
+                  >
+                    {Array.from({ length: 16 }, (_, i) => i + 1).map(ch => (
+                      <option key={ch} value={ch}>Ch {ch}</option>
+                    ))}
+                  </select>
+                </div>
               </div>
               {track.clips.map((clip, slotIndex) => (
                 <div
@@ -179,7 +181,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
                   onDragOver={handleDragOver}
                   onDrop={() => handleDrop(trackIndex, slotIndex)}
                 >
-                  {clip?.name || ''}
+                  {clip?.name || '+'}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- wrap MIDI device/channel selectors in a flex container and shorten device names
- show '+' placeholder for empty clip slots
- add styles for new MIDI selectors container

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a9ec5b92c88333ad2656c8771e5139