### PR TITLE
feat: add interactive clip slots

### DIFF
--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -140,6 +140,16 @@
   color: #888;
 }
 
+.clip-slot.empty {
+  color: #555;
+  cursor: pointer;
+}
+
+.clip-slot.empty:hover {
+  background: #2d2d2d;
+  color: #aaa;
+}
+
 .add-track-button {
   display: flex;
   flex-direction: column;

--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { CreaLabProject, Track } from '../types/CrealabTypes';
+import { CreaLabProject, Track, MidiClip } from '../types/CrealabTypes';
 import './CreaLab.css';
 
 interface CreaLabProps {
@@ -99,6 +99,26 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
     e.preventDefault();
   };
 
+  const createMidiClip = (trackIndex: number, slotIndex: number) => {
+    setProject(prev => {
+      const tracks = prev.tracks?.map(t => ({ ...t, clips: [...t.clips] })) || [];
+      const track = tracks[trackIndex];
+      if (!track.clips[slotIndex]) {
+        const newClip: MidiClip = {
+          id: `clip-${Date.now()}`,
+          name: `Clip ${slotIndex + 1}`,
+          trackType: 'lead',
+          notes: [],
+          duration: 4,
+          channel: track.midiChannel,
+          enabled: true
+        };
+        track.clips[slotIndex] = newClip;
+      }
+      return { ...prev, tracks };
+    });
+  };
+
   return (
     <div className="crealab-container">
       <header className="crealab-header">
@@ -173,13 +193,14 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
               {track.clips.map((clip, slotIndex) => (
                 <div
                   key={slotIndex}
-                  className="clip-slot"
+                  className={`clip-slot ${!clip ? 'empty' : ''}`}
                   draggable={!!clip}
                   onDragStart={() => handleDragStart(trackIndex, slotIndex)}
                   onDragOver={handleDragOver}
                   onDrop={() => handleDrop(trackIndex, slotIndex)}
+                  onClick={() => !clip && createMidiClip(trackIndex, slotIndex)}
                 >
-                  {clip?.name || ''}
+                  {clip?.name || '+'}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- show a plus sign for empty clip slots and create a MIDI clip when clicked
- mark empty clip slots with a dedicated CSS class for hover and cursor styles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9ec60b14883338ee3290127293727