### PR TITLE
feat: add piano roll editor and rhythm utilities

### DIFF
--- a/src/crealab/components/PianoRoll.css
+++ b/src/crealab/components/PianoRoll.css
@@ -1,0 +1,270 @@
+.piano-roll-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.9);
+  backdrop-filter: blur(5px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.piano-roll-container {
+  width: 95vw;
+  height: 90vh;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.piano-roll-header {
+  background: #2d2d2d;
+  border-bottom: 1px solid #444;
+  padding: 12px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  min-height: 60px;
+}
+
+.clip-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.clip-name-input {
+  background: #3a3a3a;
+  border: 1px solid #555;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: 500;
+  min-width: 200px;
+}
+
+.clip-details {
+  color: #aaa;
+  font-size: 0.85rem;
+}
+
+.piano-roll-controls {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+}
+
+.generation-buttons {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.generation-label {
+  color: #ccc;
+  font-size: 0.9rem;
+  margin-right: 8px;
+}
+
+.generation-btn {
+  background: linear-gradient(135deg, #4CAF50, #45a049);
+  border: none;
+  color: white;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  text-transform: capitalize;
+}
+
+.generation-btn:hover {
+  background: linear-gradient(135deg, #45a049, #3d8b40);
+  transform: translateY(-1px);
+}
+
+.playback-controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.play-btn, .clear-btn, .close-btn {
+  background: #444;
+  border: 1px solid #666;
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.play-btn:hover, .clear-btn:hover {
+  background: #555;
+}
+
+.close-btn {
+  background: #d32f2f;
+  border-color: #d32f2f;
+}
+
+.close-btn:hover {
+  background: #b71c1c;
+}
+
+.piano-roll-content {
+  flex: 1;
+  display: flex;
+  overflow: auto;
+  background: #0f0f0f;
+}
+
+.piano-grid {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.piano-keys {
+  width: 120px;
+  background: #222;
+  border-right: 1px solid #444;
+  display: flex;
+  flex-direction: column-reverse;
+}
+
+.piano-key {
+  height: 24px;
+  border-bottom: 1px solid #333;
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  position: relative;
+}
+
+.piano-key.white {
+  background: #3a3a3a;
+  border-right: 1px solid #555;
+}
+
+.piano-key.black {
+  background: #1a1a1a;
+  border-right: 1px solid #333;
+  margin-left: 20px;
+  width: 80px;
+}
+
+.piano-key:hover {
+  background: #555 !important;
+}
+
+.note-label {
+  font-size: 0.7rem;
+  color: #ccc;
+  font-weight: 500;
+}
+
+.note-grid {
+  flex: 1;
+  display: flex;
+  flex-direction: column-reverse;
+  overflow: auto;
+}
+
+.note-row {
+  height: 24px;
+  display: flex;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.grid-cell {
+  min-width: 40px;
+  height: 100%;
+  border-right: 1px solid #2a2a2a;
+  cursor: pointer;
+  position: relative;
+  transition: all 0.1s ease;
+}
+
+.grid-cell:hover {
+  background: rgba(255, 255, 255, 0.1) !important;
+}
+
+.grid-cell.has-note {
+  background: rgba(76, 175, 80, 0.7);
+  border: 1px solid #4CAF50;
+}
+
+.note-velocity {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  right: 2px;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.grid-cell:hover .note-velocity {
+  opacity: 1;
+}
+
+.note-velocity input {
+  width: 100%;
+  height: 4px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.piano-roll-footer {
+  background: #2d2d2d;
+  border-top: 1px solid #444;
+  padding: 8px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+}
+
+.scale-info {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  color: #ccc;
+}
+
+.scale-notes {
+  display: flex;
+  gap: 4px;
+}
+
+.scale-note {
+  background: rgba(76, 175, 80, 0.2);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  color: #4CAF50;
+}
+
+.clip-stats {
+  color: #aaa;
+}
+
+/* Grid styling for beats */
+.grid-cell:nth-child(4n+1) {
+  border-left: 2px solid #555;
+}
+
+.grid-cell:nth-child(16n+1) {
+  border-left: 2px solid #777;
+}
+

--- a/src/crealab/components/PianoRoll.tsx
+++ b/src/crealab/components/PianoRoll.tsx
@@ -1,0 +1,281 @@
+import React, { useState } from 'react';
+import { MidiClip } from '../types/CrealabTypes';
+import { MidiClipGenerator } from '../core/MidiClipGenerator';
+import './PianoRoll.css';
+
+interface PianoRollProps {
+  clip: MidiClip;
+  projectKey: string;
+  projectScale: string;
+  onClipUpdate: (clip: MidiClip) => void;
+  onClose: () => void;
+}
+
+const NOTES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+const OCTAVES = [7, 6, 5, 4, 3, 2, 1, 0];
+const GRID_RESOLUTION = 16; // 16th notes
+
+export const PianoRoll: React.FC<PianoRollProps> = ({
+  clip,
+  projectKey,
+  projectScale,
+  onClipUpdate,
+  onClose
+}) => {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const generator = MidiClipGenerator.getInstance();
+
+  // Generate intelligent MIDI based on track type and style
+  const generateIntelligentClip = (style: string) => {
+    let newClip: MidiClip;
+
+    switch (clip.trackType) {
+      case 'kick':
+        newClip = generator.generateKick(style as any, 4, clip.channel);
+        break;
+      case 'bass':
+        newClip = generator.generateBass(projectKey, projectScale, style as any, 4, clip.channel);
+        break;
+      case 'arp':
+        newClip = generator.generateArpeggio(projectKey, projectScale, style as any, 4, clip.channel);
+        break;
+      case 'lead':
+        newClip = generator.generateMelody(projectKey, projectScale, style as any, 4, clip.channel);
+        break;
+      default:
+        newClip = generator.generateChordProgression(projectKey, style as any, 4, clip.channel);
+    }
+
+    const updatedClip = {
+      ...clip,
+      notes: newClip.notes,
+      name: `${clip.trackType} ${style}`
+    };
+
+    onClipUpdate(updatedClip);
+  };
+
+  const getNoteColor = (midiNote: number): string => {
+    const note = NOTES[midiNote % 12];
+    const scaleNotes = getScaleNotes(projectKey, projectScale);
+    const isInScale = scaleNotes.includes(note);
+
+    if (note === projectKey) return '#4CAF50'; // Root
+    if (isInScale) return '#2196F3'; // Scale
+    return '#757575'; // Chromatic
+  };
+
+  const getScaleNotes = (key: string, scale: string): string[] => {
+    const scaleIntervals: { [key: string]: number[] } = {
+      minor: [0, 2, 3, 5, 7, 8, 10],
+      major: [0, 2, 4, 5, 7, 9, 11],
+      dorian: [0, 2, 3, 5, 7, 9, 10],
+      phrygian: [0, 1, 3, 5, 7, 8, 10],
+      pentatonic: [0, 2, 5, 7, 9]
+    };
+
+    const keyIndex = NOTES.indexOf(key);
+    const intervals = scaleIntervals[scale] || scaleIntervals.minor;
+
+    return intervals.map(interval => NOTES[(keyIndex + interval) % 12]);
+  };
+
+  const handleNoteClick = (midiNote: number, time: number, velocity: number = 80) => {
+    const existingNoteIndex = clip.notes.findIndex(
+      n => n.note === midiNote && Math.abs(n.time - time) < 0.1
+    );
+
+    const updatedNotes = [...clip.notes];
+
+    if (existingNoteIndex >= 0) {
+      updatedNotes.splice(existingNoteIndex, 1);
+    } else {
+      updatedNotes.push({
+        note: midiNote,
+        time,
+        velocity,
+        duration: 0.25
+      });
+    }
+
+    onClipUpdate({ ...clip, notes: updatedNotes });
+  };
+
+  const handleVelocityChange = (noteIndex: number, velocity: number) => {
+    const updatedNotes = [...clip.notes];
+    updatedNotes[noteIndex].velocity = velocity;
+    onClipUpdate({ ...clip, notes: updatedNotes });
+  };
+
+  const getTrackTypeStyles = (): string[] => {
+    switch (clip.trackType) {
+      case 'kick':
+        return ['minimal', 'dub', 'hypnotic', 'fourOnFloor'];
+      case 'bass':
+        return ['dub', 'minimal', 'hypnotic', 'octaveBass', 'psytrance'];
+      case 'arp':
+        return ['floating', 'ambient', 'maxCooper', 'scales', 'random'];
+      case 'lead':
+        return ['melody', 'ambient', 'experimental', 'hypnotic'];
+      default:
+        return ['dubClassic', 'minimal', 'floatingPoints', 'maxCooper'];
+    }
+  };
+
+  const renderGrid = () => {
+    const beats = clip.duration * 4; // 4 beats per bar
+    const steps = beats * (GRID_RESOLUTION / 4); // 16th note grid
+    const allMidiNotes = OCTAVES.flatMap(octave =>
+      NOTES.map((note, index) => octave * 12 + index)
+    );
+
+    return (
+      <div className="piano-grid">
+        {/* Piano keys */}
+        <div className="piano-keys">
+          {allMidiNotes.map(midiNote => {
+            const note = NOTES[midiNote % 12];
+            const octave = Math.floor(midiNote / 12);
+            const isBlackKey = note.includes('#');
+
+            return (
+              <div
+                key={midiNote}
+                className={`piano-key ${isBlackKey ? 'black' : 'white'}`}
+                style={{ backgroundColor: getNoteColor(midiNote) }}
+              >
+                <span className="note-label">
+                  {note}
+                  {octave}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Grid */}
+        <div className="note-grid">
+          {allMidiNotes.map(midiNote => (
+            <div key={midiNote} className="note-row">
+              {Array.from({ length: steps }, (_, step) => {
+                const time = (step / GRID_RESOLUTION) * 4;
+                const existingNote = clip.notes.find(
+                  n => n.note === midiNote && Math.abs(n.time - time) < 0.1
+                );
+
+                return (
+                  <div
+                    key={step}
+                    className={`grid-cell ${existingNote ? 'has-note' : ''}`}
+                    onClick={() => handleNoteClick(midiNote, time)}
+                    style={{
+                      backgroundColor: existingNote
+                        ? `rgba(76, 175, 80, ${existingNote.velocity / 127})`
+                        : undefined
+                    }}
+                  >
+                    {existingNote && (
+                      <div className="note-velocity">
+                        <input
+                          type="range"
+                          min="1"
+                          max="127"
+                          value={existingNote.velocity}
+                          onChange={e => {
+                            const noteIndex = clip.notes.indexOf(existingNote);
+                            handleVelocityChange(
+                              noteIndex,
+                              parseInt(e.target.value)
+                            );
+                          }}
+                          onClick={e => e.stopPropagation()}
+                        />
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="piano-roll-overlay">
+      <div className="piano-roll-container">
+        <div className="piano-roll-header">
+          <div className="clip-info">
+            <input
+              type="text"
+              value={clip.name}
+              onChange={e => onClipUpdate({ ...clip, name: e.target.value })}
+              className="clip-name-input"
+            />
+            <span className="clip-details">
+              {clip.trackType} • {projectKey} {projectScale} • Ch {clip.channel}
+            </span>
+          </div>
+
+          <div className="piano-roll-controls">
+            <div className="generation-buttons">
+              <span className="generation-label">Generate:</span>
+              {getTrackTypeStyles().map(style => (
+                <button
+                  key={style}
+                  className="generation-btn"
+                  onClick={() => generateIntelligentClip(style)}
+                >
+                  {style}
+                </button>
+              ))}
+            </div>
+
+            <div className="playback-controls">
+              <button
+                className={`play-btn ${isPlaying ? 'playing' : ''}`}
+                onClick={() => setIsPlaying(!isPlaying)}
+              >
+                {isPlaying ? '⏸️' : '▶️'}
+              </button>
+
+              <button
+                className="clear-btn"
+                onClick={() => onClipUpdate({ ...clip, notes: [] })}
+              >
+                Clear
+              </button>
+
+              <button className="close-btn" onClick={onClose}>
+                ✕
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="piano-roll-content">{renderGrid()}</div>
+
+        <div className="piano-roll-footer">
+          <div className="scale-info">
+            <span>
+              Scale: {projectKey} {projectScale}
+            </span>
+            <div className="scale-notes">
+              {getScaleNotes(projectKey, projectScale).map(note => (
+                <span key={note} className="scale-note">
+                  {note}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="clip-stats">
+            Notes: {clip.notes.length} • Duration: {clip.duration} bars
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+

--- a/src/crealab/core/MidiClipGenerator.ts
+++ b/src/crealab/core/MidiClipGenerator.ts
@@ -124,6 +124,30 @@ export class MidiClipGenerator {
     };
   }
 
+  generateMelody(
+    key: string = 'C',
+    scale: string = 'minor',
+    style: 'melody' | 'ambient' | 'experimental' | 'hypnotic' = 'melody',
+    measures: number = 4,
+    channel: number = 3
+  ): MidiClip {
+    const styleMap: Record<string, 'floating' | 'ambient' | 'maxCooper'> = {
+      melody: 'floating',
+      ambient: 'ambient',
+      experimental: 'maxCooper',
+      hypnotic: 'floating'
+    };
+
+    const arpStyle = styleMap[style] ?? 'floating';
+    const arpClip = this.generateArpeggio(key, scale, arpStyle, measures, channel);
+    return {
+      ...arpClip,
+      id: `melody-${Date.now()}`,
+      name: `Melody ${style}`,
+      trackType: 'lead'
+    };
+  }
+
   generateChordProgression(
     key: string = 'C',
     progression: keyof typeof HARMONIC_PROGRESSIONS = 'dubClassic',

--- a/src/crealab/utils/euclideanPatterns.ts
+++ b/src/crealab/utils/euclideanPatterns.ts
@@ -69,11 +69,58 @@ export const EUCLIDEAN_PATTERNS = {
 };
 
 export function generateEuclideanPattern(
-  trackType: keyof typeof EUCLIDEAN_PATTERNS, 
+  trackType: keyof typeof EUCLIDEAN_PATTERNS,
   style: string
 ): boolean[] {
-  const pattern = EUCLIDEAN_PATTERNS[trackType]?.[style as keyof typeof EUCLIDEAN_PATTERNS[typeof trackType]];
-  if (!pattern) return [true, false, false, false]; // Default 4/4
-  
+  const patterns = EUCLIDEAN_PATTERNS[trackType];
+  if (!patterns) {
+    return [true, false, false, false];
+  }
+
+  const pattern = patterns[style as keyof typeof patterns];
+  if (!pattern) {
+    const firstStyle = Object.keys(patterns)[0];
+    const firstPattern = patterns[firstStyle as keyof typeof patterns];
+    return euclideanRhythm(firstPattern.pulses, firstPattern.steps, firstPattern.offset);
+  }
+
   return euclideanRhythm(pattern.pulses, pattern.steps, pattern.offset);
+}
+
+export function generateIntelligentPattern(
+  trackType: keyof typeof EUCLIDEAN_PATTERNS,
+  genre: 'dubTechno' | 'ambient' | 'experimental' | 'hypnotic' = 'dubTechno'
+): { pattern: boolean[]; style: string } {
+  const genreStyleMappings = {
+    dubTechno: {
+      kick: 'dub',
+      bass: 'dub',
+      hihat: 'floating',
+      perc: 'subtle'
+    },
+    ambient: {
+      kick: 'minimal',
+      bass: 'minimal',
+      hihat: 'ambient',
+      perc: 'subtle'
+    },
+    experimental: {
+      kick: 'hypnotic',
+      bass: 'syncopated',
+      hihat: 'maxCooper',
+      perc: 'complex'
+    },
+    hypnotic: {
+      kick: 'hypnotic',
+      bass: 'hypnotic',
+      hihat: 'floating',
+      perc: 'driving'
+    }
+  } as const;
+
+  const style =
+    genreStyleMappings[genre][trackType] ||
+    Object.keys(EUCLIDEAN_PATTERNS[trackType])[0];
+  const pattern = generateEuclideanPattern(trackType, style);
+  return { pattern, style };
 }


### PR DESCRIPTION
## Summary
- add PianoRoll component with interactive note grid and generation controls
- expand euclidean rhythm utilities with genre-based pattern generation
- support melody clip creation in MidiClipGenerator

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc --noEmit` (fails: Cannot find type definition file for 'vite/client')
- `npm run build` (fails: tauri: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a9f6bd828883339bd4215a0dfe9cf4