### PR TITLE
feat: add generative MIDI types and engine

### DIFF
--- a/src/crealab/core/GeneratorEngine.ts
+++ b/src/crealab/core/GeneratorEngine.ts
@@ -1,0 +1,308 @@
+import { MidiGenerator, GeneratorType, EuclideanParams, MarkovParams, ProbabilisticParams } from '../types/GeneratorTypes';
+import { MidiNote } from '../types/CrealabTypes';
+import { euclideanRhythm } from '../utils/euclideanPatterns';
+
+export class GeneratorEngine {
+  private static instance: GeneratorEngine;
+  private activeGenerators: Map<string, MidiGenerator> = new Map();
+  private schedulerInterval: NodeJS.Timeout | null = null;
+  private isRunning = false;
+  
+  // MIDI Access para output
+  private midiAccess: any = null;
+  
+  static getInstance(): GeneratorEngine {
+    if (!this.instance) {
+      this.instance = new GeneratorEngine();
+    }
+    return this.instance;
+  }
+  
+  async initialize() {
+    try {
+      this.midiAccess = await (navigator as any).requestMIDIAccess();
+      console.log('🎛️ Generator Engine initialized');
+    } catch (error) {
+      console.error('❌ Failed to initialize MIDI:', error);
+    }
+  }
+  
+  // Iniciar el motor de generación
+  start() {
+    if (this.isRunning) return;
+    
+    this.isRunning = true;
+    this.schedulerInterval = setInterval(() => {
+      this.processGenerators();
+    }, 16); // 60 FPS para precisión
+    
+    console.log('▶️ Generator Engine started');
+  }
+  
+  stop() {
+    this.isRunning = false;
+    if (this.schedulerInterval) {
+      clearInterval(this.schedulerInterval);
+      this.schedulerInterval = null;
+    }
+    console.log('⏹️ Generator Engine stopped');
+  }
+  
+  // Procesar todos los generadores activos
+  private processGenerators() {
+    const currentTime = performance.now() / 1000; // Tiempo en segundos
+    
+    this.activeGenerators.forEach((generator, id) => {
+      if (generator.isActive && generator.isPlaying) {
+        const note = this.generateNote(generator, currentTime);
+        if (note) {
+          this.sendMidiNote(generator, note);
+          generator.generatedNotes.push(note);
+          generator.lastNoteTime = currentTime;
+        }
+      }
+    });
+  }
+  
+  // Registrar un generador
+  registerGenerator(generator: MidiGenerator): void {
+    this.activeGenerators.set(generator.id, generator);
+    console.log(`🔄 Generator registered: ${generator.name}`);
+  }
+  
+  // Desregistrar un generador
+  unregisterGenerator(generatorId: string): void {
+    this.activeGenerators.delete(generatorId);
+    console.log(`❌ Generator unregistered: ${generatorId}`);
+  }
+  
+  // Generar nota según el tipo de generador
+  private generateNote(generator: MidiGenerator, currentTime: number): MidiNote | null {
+    switch (generator.type) {
+      case 'euclidean':
+        return this.generateEuclideanNote(generator, currentTime);
+      case 'markov':
+        return this.generateMarkovNote(generator, currentTime);
+      case 'probabilistic':
+        return this.generateProbabilisticNote(generator, currentTime);
+      case 'arpeggiator':
+        return this.generateArpeggiatorNote(generator, currentTime);
+      default:
+        return null;
+    }
+  }
+  
+  // Generador Euclidiano
+  private generateEuclideanNote(generator: MidiGenerator, currentTime: number): MidiNote | null {
+    const params = generator.parameters.euclidean!;
+    const controls = generator.realTimeControls;
+    
+    // Generar patrón euclidiano
+    const pattern = euclideanRhythm(
+      Math.floor(params.pulses * controls.density),
+      params.steps,
+      params.offset
+    );
+    
+    // Verificar si debe tocar en este step
+    const stepDuration = (60 / generator.parameters.tempo) / 4; // Duración de 16th note
+    const timeSinceLastNote = currentTime - generator.lastNoteTime;
+    
+    if (timeSinceLastNote < stepDuration) return null;
+    
+    const currentStepInPattern = generator.currentStep % params.steps;
+    const shouldTrigger = pattern[currentStepInPattern] && 
+                         Math.random() < controls.probability;
+    
+    generator.currentStep++;
+    
+    if (!shouldTrigger) return null;
+    
+    // Seleccionar nota del pool
+    const notePool = generator.parameters.notePool;
+    const baseNote = notePool[Math.floor(Math.random() * notePool.length)];
+    const octaveShift = Math.floor((controls.octave - 0.5) * 6) * 12; // -3 to +3 octaves
+    
+    return {
+      note: baseNote + octaveShift,
+      time: currentTime,
+      velocity: Math.floor(80 * controls.velocity + Math.random() * 20 * controls.chaos),
+      duration: stepDuration * (1 + controls.swing * 0.5)
+    };
+  }
+  
+  // Generador de Cadenas de Markov
+  private generateMarkovNote(generator: MidiGenerator, currentTime: number): MidiNote | null {
+    const params = generator.parameters.markov!;
+    const controls = generator.realTimeControls;
+    
+    // Implementación simplificada de Markov
+    const recentNotes = generator.generatedNotes
+      .slice(-params.order)
+      .map(n => n.note);
+    
+    if (recentNotes.length < params.order) {
+      // Empezar con nota aleatoria del pool
+      const notePool = generator.parameters.notePool;
+      const note = notePool[Math.floor(Math.random() * notePool.length)];
+      
+      return {
+        note,
+        time: currentTime,
+        velocity: Math.floor(70 * controls.velocity),
+        duration: 0.25
+      };
+    }
+    
+    // Generar siguiente nota basada en contexto
+    // (Implementación simplificada - en producción usar cadena entrenada)
+    const notePool = generator.parameters.notePool;
+    const creativity = params.creativity * controls.chaos;
+    
+    let nextNote;
+    if (Math.random() < creativity) {
+      // Nota creativa/aleatoria
+      nextNote = notePool[Math.floor(Math.random() * notePool.length)];
+    } else {
+      // Nota basada en patrón (simplificado)
+      const lastNote = recentNotes[recentNotes.length - 1];
+      const direction = Math.random() > 0.5 ? 1 : -1;
+      const interval = Math.floor(Math.random() * 4) + 1; // 1-4 semitones
+      nextNote = lastNote + (direction * interval);
+      
+      // Mantener dentro del rango
+      nextNote = Math.max(Math.min(nextNote, Math.max(...notePool)), Math.min(...notePool));
+    }
+    
+    return {
+      note: nextNote,
+      time: currentTime,
+      velocity: Math.floor(60 * controls.velocity + Math.random() * 40),
+      duration: 0.25 + Math.random() * 0.5
+    };
+  }
+  
+  // Generador Probabilístico
+  private generateProbabilisticNote(generator: MidiGenerator, currentTime: number): MidiNote | null {
+    const params = generator.parameters.probabilistic!;
+    const controls = generator.realTimeControls;
+    
+    // Verificar timing basado en patrón rítmico
+    const beatDuration = 60 / generator.parameters.tempo;
+    const timeSinceLastNote = currentTime - generator.lastNoteTime;
+    
+    if (timeSinceLastNote < beatDuration / 4) return null; // 16th note grid
+    
+    // Probabilidad de trigger basada en controles
+    if (Math.random() > controls.probability * controls.density) return null;
+    
+    // Seleccionar nota basada en pesos
+    const weightedNotes = Object.entries(params.noteWeights);
+    const totalWeight = weightedNotes.reduce((sum, [_, weight]) => sum + weight, 0);
+    const random = Math.random() * totalWeight;
+    
+    let accumulator = 0;
+    for (const [noteStr, weight] of weightedNotes) {
+      accumulator += weight;
+      if (random <= accumulator) {
+        return {
+          note: parseInt(noteStr),
+          time: currentTime,
+          velocity: Math.floor(50 + controls.velocity * 60 + controls.chaos * 20),
+          duration: 0.25 + Math.random() * controls.swing
+        };
+      }
+    }
+    
+    return null;
+  }
+  
+  // Arpegiador generativo
+  private generateArpeggiatorNote(generator: MidiGenerator, currentTime: number): MidiNote | null {
+    const params = generator.parameters.arpeggiator!;
+    const controls = generator.realTimeControls;
+    
+    const beatDuration = 60 / generator.parameters.tempo;
+    const noteDuration = beatDuration / 4; // 16th notes
+    const timeSinceLastNote = currentTime - generator.lastNoteTime;
+    
+    if (timeSinceLastNote < noteDuration) return null;
+    
+    // Probabilidad de trigger
+    if (Math.random() > controls.probability) return null;
+    
+    // Generar arpeggio
+    const notePool = generator.parameters.notePool.sort((a, b) => a - b);
+    const arpIndex = generator.currentStep % notePool.length;
+    
+    let note;
+    switch (params.pattern) {
+      case 'up':
+        note = notePool[arpIndex];
+        break;
+      case 'down':
+        note = notePool[notePool.length - 1 - arpIndex];
+        break;
+      case 'upDown':
+        const cycle = (notePool.length - 1) * 2;
+        const pos = generator.currentStep % cycle;
+        note = pos < notePool.length 
+          ? notePool[pos] 
+          : notePool[cycle - pos];
+        break;
+      case 'random':
+        note = notePool[Math.floor(Math.random() * notePool.length)];
+        break;
+      default:
+        note = notePool[arpIndex];
+    }
+    
+    generator.currentStep++;
+    
+    return {
+      note: note + Math.floor((controls.octave - 0.5) * 6) * 12,
+      time: currentTime,
+      velocity: Math.floor(60 + controls.velocity * 50),
+      duration: params.noteLength * (1 + controls.swing)
+    };
+  }
+  
+  // Enviar nota MIDI
+  private sendMidiNote(generator: MidiGenerator, note: MidiNote) {
+    if (!this.midiAccess) return;
+    
+    // Buscar el output device apropiado
+    // (Esto se conectaría con la configuración del track)
+    const outputs = Array.from(this.midiAccess.outputs.values());
+    if (outputs.length === 0) return;
+    
+    const output = outputs[0]; // Por ahora usar el primer dispositivo
+    
+    // Note On
+    output.send([
+      0x90, // Note on, channel 1
+      note.note,
+      note.velocity
+    ]);
+    
+    // Note Off programado
+    setTimeout(() => {
+      output.send([
+        0x80, // Note off, channel 1
+        note.note,
+        0
+      ]);
+    }, note.duration * 1000);
+  }
+  
+  // Control en tiempo real
+  updateGeneratorControl(generatorId: string, control: string, value: number) {
+    const generator = this.activeGenerators.get(generatorId);
+    if (!generator) return;
+    
+    if (control in generator.realTimeControls) {
+      (generator.realTimeControls as any)[control] = value;
+    }
+  }
+}
+

--- a/src/crealab/core/SessionMidiController.ts
+++ b/src/crealab/core/SessionMidiController.ts
@@ -1,0 +1,203 @@
+import { SessionMidiController, ChannelStrip } from '../types/GeneratorTypes';
+import { GeneratorEngine } from './GeneratorEngine';
+
+export class SessionMidiManager {
+  private static instance: SessionMidiManager;
+  private midiAccess: any = null;
+  private activeController: SessionMidiController | null = null;
+  private trackMapping: Map<number, string> = new Map(); // strip -> trackId
+  
+  static getInstance(): SessionMidiManager {
+    if (!this.instance) {
+      this.instance = new SessionMidiManager();
+    }
+    return this.instance;
+  }
+  
+  async initialize() {
+    try {
+      this.midiAccess = await (navigator as any).requestMIDIAccess();
+      this.setupMidiListeners();
+      console.log('🎛️ Session MIDI Manager initialized');
+    } catch (error) {
+      console.error('❌ Failed to initialize Session MIDI:', error);
+    }
+  }
+  
+  // Detectar y configurar Launch Control XL
+  detectLaunchControlXL(): SessionMidiController | null {
+    if (!this.midiAccess) return null;
+    
+    const inputs = Array.from(this.midiAccess.inputs.values());
+    const launchControlInput = inputs.find((input: any) => 
+      input.name?.toLowerCase().includes('launch control')
+    );
+    
+    if (!launchControlInput) return null;
+    
+    const controller: SessionMidiController = {
+      id: launchControlInput.id,
+      name: 'Launch Control XL',
+      type: 'launchControl',
+      isConnected: true,
+      channelStrips: this.createLaunchControlStrips(),
+      globalControls: [
+        { name: 'Master Tempo', ccNumber: 14, value: 64, function: 'masterTempo' },
+        { name: 'Global Volume', ccNumber: 15, value: 100, function: 'globalVolume' },
+        { name: 'Scene Select', ccNumber: 16, value: 0, function: 'sceneSelect' }
+      ],
+      currentValues: {}
+    };
+    
+    this.activeController = controller;
+    console.log('🎮 Launch Control XL detected and configured');
+    return controller;
+  }
+  
+  // Crear configuración de strips para Launch Control XL
+  private createLaunchControlStrips(): ChannelStrip[] {
+    const strips: ChannelStrip[] = [];
+    
+    for (let i = 1; i <= 8; i++) {
+      strips.push({
+        stripIndex: i,
+        controls: {
+          fader: 77 + i - 1,      // CC 77-84 (faders)
+          knob1: 13 + (i - 1) * 4,  // CC 13, 17, 21, 25, 29, 33, 37, 41 (knobs superiores)
+          knob2: 14 + (i - 1) * 4,  // CC 14, 18, 22, 26, 30, 34, 38, 42 (knobs medios)
+          knob3: 15 + (i - 1) * 4,  // CC 15, 19, 23, 27, 31, 35, 39, 43 (knobs inferiores)
+          button1: 41 + i - 1,       // CC 41-48 (botones superiores)
+          button2: 57 + i - 1        // CC 57-64 (botones inferiores)
+        },
+        values: {
+          fader: 0,
+          knob1: 0,
+          knob2: 0,
+          knob3: 0,
+          button1: false,
+          button2: false
+        }
+      });
+    }
+    
+    return strips;
+  }
+  
+  // Configurar listeners MIDI
+  private setupMidiListeners() {
+    if (!this.midiAccess) return;
+    
+    const inputs = Array.from(this.midiAccess.inputs.values());
+    inputs.forEach((input: any) => {
+      input.onmidimessage = (message: any) => {
+        this.handleMidiMessage(message.data);
+      };
+    });
+  }
+  
+  // Procesar mensajes MIDI entrantes
+  private handleMidiMessage(data: Uint8Array) {
+    const [status, cc, value] = data;
+    
+    // Solo procesar Control Change (176 = 0xB0 + channel 0)
+    if (status !== 176) return;
+    
+    if (!this.activeController) return;
+    
+    // Actualizar valor actual
+    this.activeController.currentValues[cc] = value;
+    
+    // Determinar qué strip y control
+    const stripIndex = this.determineStripFromCC(cc);
+    const controlType = this.determineControlType(cc);
+    
+    if (stripIndex && controlType) {
+      this.handleStripControl(stripIndex, controlType, value);
+    }
+    
+    // Controles globales
+    this.handleGlobalControl(cc, value);
+  }
+  
+  // Determinar strip desde CC number
+  private determineStripFromCC(cc: number): number | null {
+    // Faders: CC 77-84
+    if (cc >= 77 && cc <= 84) return cc - 76;
+    
+    // Knobs: CC 13-15, 17-19, 21-23, 25-27, 29-31, 33-35, 37-39, 41-43
+    if (cc >= 13 && cc <= 43) {
+      return Math.floor((cc - 13) / 4) + 1;
+    }
+    
+    // Buttons: CC 41-48, 57-64
+    if (cc >= 41 && cc <= 48) return cc - 40;
+    if (cc >= 57 && cc <= 64) return cc - 56;
+    
+    return null;
+  }
+  
+  // Determinar tipo de control
+  private determineControlType(cc: number): string | null {
+    if (cc >= 77 && cc <= 84) return 'fader';
+    if ([13,17,21,25,29,33,37,41].includes(cc)) return 'knob1';
+    if ([14,18,22,26,30,34,38,42].includes(cc)) return 'knob2';
+    if ([15,19,23,27,31,35,39,43].includes(cc)) return 'knob3';
+    if (cc >= 41 && cc <= 48) return 'button1';
+    if (cc >= 57 && cc <= 64) return 'button2';
+    return null;
+  }
+  
+  private handleStripControl(stripIndex: number, control: string, value: number) {
+    if (!this.activeController) return;
+    const strip = this.activeController.channelStrips[stripIndex - 1];
+    if (!strip) return;
+    
+    switch (control) {
+      case 'fader':
+        strip.values.fader = value;
+        break;
+      case 'knob1':
+        strip.values.knob1 = value;
+        this.updateGenerator(strip, 'density', value / 127);
+        break;
+      case 'knob2':
+        strip.values.knob2 = value;
+        this.updateGenerator(strip, 'probability', value / 127);
+        break;
+      case 'knob3':
+        strip.values.knob3 = value;
+        this.updateGenerator(strip, 'velocity', value / 127);
+        break;
+      case 'button1':
+        strip.values.button1 = value > 0;
+        break;
+      case 'button2':
+        strip.values.button2 = value > 0;
+        break;
+    }
+  }
+  
+  private handleGlobalControl(cc: number, value: number) {
+    if (!this.activeController) return;
+    const control = this.activeController.globalControls.find(c => c.ccNumber === cc);
+    if (!control) return;
+    control.value = value;
+  }
+  
+  private updateGenerator(strip: ChannelStrip, control: string, value: number) {
+    const trackId = this.trackMapping.get(strip.stripIndex);
+    if (!trackId) return;
+    GeneratorEngine.getInstance().updateGeneratorControl(trackId, control, value);
+  }
+  
+  // Mapear un track a un strip específico
+  mapTrackToStrip(stripIndex: number, trackId: string) {
+    this.trackMapping.set(stripIndex, trackId);
+  }
+  
+  // Desmapear track de strip
+  unmapTrack(stripIndex: number) {
+    this.trackMapping.delete(stripIndex);
+  }
+}
+

--- a/src/crealab/types/CrealabTypes.ts
+++ b/src/crealab/types/CrealabTypes.ts
@@ -1,3 +1,5 @@
+import { SlotContent, SessionMidiController } from './GeneratorTypes';
+
 export type TrackType = 'kick' | 'bass' | 'arp' | 'lead' | 'fx' | 'visual' | 'perc';
 
 export type MusicalContext = 'intro' | 'buildup' | 'drop' | 'breakdown' | 'outro';
@@ -22,9 +24,30 @@ export interface MidiClip {
 export interface Track {
   id: string;
   name: string;
-  midiDevice: string;
+  color?: string; // Hex color para UI
+  
+  // MIDI Input/Output devices
+  midiInputDevice: string;   // Para controladores como AKAI
+  midiInputDeviceName?: string;
+  midiOutputDevice: string;  // Para sintetizadores
+  midiOutputDeviceName?: string;
   midiChannel: number;
-  clips: (MidiClip | null)[];
+  
+  // Control settings
+  volume: number;     // 0-127
+  pan: number;        // -64 to +63
+  mute: boolean;
+  solo: boolean;
+  record: boolean;
+  
+  // Clips híbridos (MIDI clips + generators)
+  slots: SlotContent[];
+  
+  // Track type específico
+  trackType: TrackType;
+  
+  // Mapping a controlador de sesión
+  sessionControllerStrip?: number; // 1-8 for Launch Control XL
 }
 
 export interface VisualClip {
@@ -59,9 +82,15 @@ export interface VisualSceneConfig {
 export interface CreaLabProject {
   id: string;
   name: string;
+  description?: string;
+
   scenes?: Scene[];
   tracks?: Track[];
+
   globalTempo: number;
   key: string;
   scale: string;
+
+  // Session MIDI controller
+  sessionController?: SessionMidiController;
 }

--- a/src/crealab/types/GeneratorTypes.ts
+++ b/src/crealab/types/GeneratorTypes.ts
@@ -1,0 +1,180 @@
+import { MidiNote } from './CrealabTypes';
+
+export type GeneratorType = 
+  | 'euclidean'        // Patrones euclidianos dinámicos
+  | 'markov'          // Cadenas de Markov
+  | 'probabilistic'   // Notas por probabilidad
+  | 'arpeggiator'     // Arpegiador generativo
+  | 'sequencer'       // Secuenciador con variaciones
+  | 'chaos'           // Sistemas caóticos
+  | 'cellular'        // Autómatas celulares
+  | 'lsystem';        // L-Systems fractales
+
+export interface MidiGenerator {
+  id: string;
+  name: string;
+  type: GeneratorType;
+  isActive: boolean;
+  isPlaying: boolean;
+  parameters: GeneratorParameters;
+  lastNoteTime: number;
+  currentStep: number;
+  generatedNotes: MidiNote[];
+  
+  // Control en tiempo real
+  realTimeControls: {
+    density: number;      // 0-1: Densidad de notas
+    probability: number;  // 0-1: Probabilidad de trigger
+    velocity: number;     // 0-1: Velocity multiplier
+    octave: number;       // -3 to +3: Octave shift
+    chaos: number;        // 0-1: Randomness amount
+    evolution: number;    // 0-1: Pattern evolution rate
+    swing: number;        // 0-1: Timing swing
+    filter: number;       // 0-1: Note filtering
+  };
+  
+  // MIDI mapping para controladores
+  midiMapping?: {
+    controllerId: string;
+    channelStrip: number; // 1-8 for Launch Control XL
+    ccMappings: {
+      [control: string]: number; // CC number
+    };
+  };
+}
+
+export interface GeneratorParameters {
+  // Parámetros base
+  scale: string;
+  key: string;
+  notePool: number[];
+  tempo: number;
+  
+  // Parámetros específicos por tipo
+  euclidean?: EuclideanParams;
+  markov?: MarkovParams;
+  probabilistic?: ProbabilisticParams;
+  arpeggiator?: ArpeggiatorParams;
+  chaos?: ChaosParams;
+}
+
+export interface EuclideanParams {
+  pulses: number;        // Número de hits
+  steps: number;         // Longitud del patrón
+  offset: number;        // Rotación del patrón
+  mutationRate: number;  // Tasa de evolución
+  polyrhythm: boolean;   // Habilitar polirritmia
+}
+
+export interface MarkovParams {
+  order: number;         // N-gram order (1-4)
+  creativity: number;    // 0-1: Balance entre repetición y novedad
+  trainingClips: string[]; // IDs de clips para entrenar
+  contextLength: number; // Longitud del contexto
+}
+
+export interface ProbabilisticParams {
+  noteWeights: { [note: number]: number }; // Peso por nota
+  rhythmPattern: number[]; // Patrón rítmico base
+  variation: number;     // Variación rítmica
+}
+
+export interface ArpeggiatorParams {
+  pattern: 'up' | 'down' | 'upDown' | 'random' | 'custom';
+  octaveRange: number;   // Rango de octavas
+  noteLength: number;    // Duración de notas
+  swing: number;         // Swing amount
+  customPattern?: number[]; // Patrón personalizado
+}
+
+export interface ChaosParams {
+  attractor: 'lorenz' | 'henon' | 'rossler';
+  sensitivity: number;   // Sensibilidad al caos
+  scaling: number;       // Escalado de valores
+  dimensions: 2 | 3;     // Dimensiones del atractor
+}
+
+// Tipos para control de slots híbridos
+export type SlotContentType = 'empty' | 'midiClip' | 'generator' | 'hybrid';
+
+export interface SlotContent {
+  id: string;
+  type: SlotContentType;
+  name: string;
+  slotIndex: number;
+  
+  // Contenido específico
+  midiClip?: any; // MidiClip existente
+  generator?: MidiGenerator;
+  hybrid?: HybridContent;
+  
+  // Control
+  isActive: boolean;
+  volume: number; // 0-1
+  probability: number; // 0-1
+}
+
+export interface HybridContent {
+  staticClip: any; // MidiClip base
+  generator: MidiGenerator;
+  blendMode: 'add' | 'multiply' | 'replace' | 'interleave';
+  generatorInfluence: number; // 0-1
+}
+
+// Interfaces para controladores MIDI
+export interface SessionMidiController {
+  id: string;
+  name: string;
+  type: 'launchControl' | 'akai' | 'oxygen' | 'generic';
+  isConnected: boolean;
+  
+  // Mapping de controles
+  channelStrips: ChannelStrip[];
+  globalControls: GlobalMidiControl[];
+  
+  // Estado actual
+  currentValues: { [ccNumber: number]: number };
+}
+
+export interface ChannelStrip {
+  stripIndex: number; // 1-8 for Launch Control XL
+  trackId?: string;   // Track asignado
+  
+  controls: {
+    fader: number;      // CC para fader principal
+    knob1: number;      // CC para knob 1 (density)
+    knob2: number;      // CC para knob 2 (probability)
+    knob3: number;      // CC para knob 3 (velocity)
+    button1: number;    // CC para botón 1 (play/stop)
+    button2: number;    // CC para botón 2 (record)
+  };
+  
+  // Estado actual
+  values: {
+    fader: number;      // 0-127
+    knob1: number;      // 0-127
+    knob2: number;      // 0-127
+    knob3: number;      // 0-127
+    button1: boolean;   // pressed
+    button2: boolean;   // pressed
+  };
+}
+
+export interface GlobalMidiControl {
+  name: string;
+  ccNumber: number;
+  value: number;
+  function: 'masterTempo' | 'globalVolume' | 'sceneSelect' | 'transport';
+}
+
+// Templates de generadores
+export interface GeneratorTemplate {
+  id: string;
+  name: string;
+  description: string;
+  type: GeneratorType;
+  bestFor: string[]; // ['kick', 'bass', etc.]
+  defaultParameters: GeneratorParameters;
+  previewPattern?: boolean[]; // Preview del patrón
+}
+


### PR DESCRIPTION
## Summary
- define comprehensive generator, slot, and MIDI controller types
- add generator engine with euclidean, markov, probabilistic and arpeggiator support
- implement session MIDI manager for Launch Control XL mapping

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tonal)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fb05cba48333a0eb565269a07e58