### PR TITLE
feat: add instrument profile suggestions

### DIFF
--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -3,6 +3,7 @@ import { CreaLabProject, GenerativeTrack } from '../types/CrealabTypes';
 import { TopBar } from './TopBar';
 import LaunchControlVisualizer from './LaunchControlVisualizer';
 import useLaunchControlXL from '../hooks/useLaunchControlXL';
+import { InstrumentSelector } from './InstrumentSelector';
 import './CreaLab.css';
 
 interface CreaLabProps {
@@ -118,6 +119,15 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
     }));
   };
 
+  const applyTrackUpdates = (trackNumber: number, updates: Partial<GenerativeTrack>) => {
+    setProject(prev => ({
+      ...prev,
+      tracks: prev.tracks.map(t =>
+        t.trackNumber === trackNumber ? { ...t, ...updates } : t
+      ) as any
+    }));
+  };
+
   return (
     <div className="crealab-container">
       <TopBar
@@ -149,6 +159,12 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
               </div>
 
               <div className="track-controls">
+                <InstrumentSelector
+                  track={track}
+                  onTrackUpdate={updates => applyTrackUpdates(track.trackNumber, updates)}
+                  genre={project.genre}
+                  allTracks={project.tracks}
+                />
                 <div className="midi-config">
                   <select className="device-selector">
                     <option>Device</option>

--- a/src/crealab/components/InstrumentSelector.css
+++ b/src/crealab/components/InstrumentSelector.css
@@ -1,0 +1,219 @@
+.instrument-selector {
+  margin-bottom: 15px;
+}
+
+.current-selection {
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 8px;
+  padding: 8px;
+  margin-bottom: 10px;
+}
+
+.selection-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.track-label {
+  font-weight: bold;
+}
+
+.suggestions-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+}
+
+.current-instrument {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 8px;
+  border: 2px solid;
+  border-radius: 6px;
+}
+
+.instrument-info {
+  flex: 1;
+}
+
+.instrument-name {
+  font-weight: bold;
+}
+
+.instrument-brand {
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+
+.instrument-type {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.instrument-color {
+  width: 14px;
+  height: 40px;
+  border-radius: 4px;
+  margin-left: 10px;
+}
+
+.no-instrument {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.no-instrument button {
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid rgba(255,255,255,0.2);
+  background: rgba(255,255,255,0.05);
+  cursor: pointer;
+}
+
+.suggestions-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.suggestions-modal {
+  background: #1e1e1e;
+  padding: 20px;
+  max-width: 800px;
+  width: 90%;
+  border-radius: 10px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.category-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 15px;
+}
+
+.category-btn {
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.category-btn.active {
+  background: rgba(0,255,136,0.2);
+  border-color: #00ff88;
+}
+
+.instruments-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.instrument-card {
+  border: 2px solid transparent;
+  border-radius: 8px;
+  padding: 10px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: rgba(255,255,255,0.03);
+}
+
+.instrument-card.selected {
+  box-shadow: 0 0 0 2px #00ff88;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.instrument-color-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.instrument-description {
+  font-size: 0.8rem;
+  opacity: 0.85;
+}
+
+.suggested-generators {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.generators-label {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.generators-list {
+  display: flex;
+  gap: 4px;
+}
+
+.generator-tag {
+  background: rgba(0,255,136,0.15);
+  border: 1px solid rgba(0,255,136,0.4);
+  border-radius: 4px;
+  padding: 2px 4px;
+  font-size: 0.75rem;
+}
+
+.instrument-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.tag {
+  background: rgba(255,255,255,0.05);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.7rem;
+}
+
+.card-footer {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+

--- a/src/crealab/components/InstrumentSelector.tsx
+++ b/src/crealab/components/InstrumentSelector.tsx
@@ -1,0 +1,190 @@
+import React, { useState, useEffect } from 'react';
+import { GenerativeTrack, InstrumentProfile } from '../types/CrealabTypes';
+import { InstrumentProfileManager } from '../core/InstrumentProfileManager';
+import { SuggestionPanel } from './SuggestionPanel';
+import './InstrumentSelector.css';
+
+interface InstrumentSelectorProps {
+  track: GenerativeTrack;
+  onTrackUpdate: (updates: Partial<GenerativeTrack>) => void;
+  genre?: string;
+  allTracks?: GenerativeTrack[];
+}
+
+export const InstrumentSelector: React.FC<InstrumentSelectorProps> = ({
+  track,
+  onTrackUpdate,
+  genre,
+  allTracks
+}) => {
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<string>('all');
+  const [profiles, setProfiles] = useState<InstrumentProfile[]>([]);
+  const [suggestions, setSuggestions] = useState<InstrumentProfile[]>([]);
+  
+  const profileManager = InstrumentProfileManager.getInstance();
+  const currentProfile = track.instrumentProfile ? 
+    profileManager.getProfileInfo(track.instrumentProfile) : null;
+
+  useEffect(() => {
+    // Cargar todos los perfiles
+    setProfiles(profileManager.getAllProfiles());
+    
+    // Generar sugerencias
+    const newSuggestions = profileManager.generateSuggestions(
+      track,
+      genre,
+      allTracks
+    );
+    setSuggestions(newSuggestions);
+  }, [track.id, genre, allTracks]);
+
+  const handleProfileSelect = (profileId: string) => {
+    const updates = profileManager.applyProfileToTrack(track, profileId);
+    onTrackUpdate(updates);
+    setShowSuggestions(false);
+  };
+
+  const getFilteredProfiles = () => {
+    if (selectedCategory === 'all') return profiles;
+    return profileManager.getProfilesByType(selectedCategory);
+  };
+
+  const categories = [
+    { id: 'all', name: 'All', icon: '🎛️' },
+    { id: 'bass', name: 'Bass', icon: '🎸' },
+    { id: 'lead', name: 'Lead', icon: '🎹' },
+    { id: 'pad', name: 'Pad', icon: '🌊' },
+    { id: 'drum', name: 'Drums', icon: '🥁' },
+    { id: 'experimental', name: 'Experimental', icon: '🔬' }
+  ];
+
+  return (
+    <div className="instrument-selector">
+      <div className="current-selection">
+        <div className="selection-header">
+          <span className="track-label">Track {track.trackNumber}</span>
+          <button 
+            className="suggestions-btn"
+            onClick={() => setShowSuggestions(!showSuggestions)}
+            title="Show instrument suggestions"
+          >
+            💡
+          </button>
+        </div>
+        
+        {currentProfile ? (
+          <div className="current-instrument" style={{ borderColor: currentProfile.color }}>
+            <div className="instrument-info">
+              <div className="instrument-name">{currentProfile.name}</div>
+              {currentProfile.brand && (
+                <div className="instrument-brand">{currentProfile.brand}</div>
+              )}
+              <div className="instrument-type">{currentProfile.type}</div>
+            </div>
+            <div className="instrument-color" style={{ backgroundColor: currentProfile.color }} />
+          </div>
+        ) : (
+          <div className="no-instrument">
+            <span>No instrument selected</span>
+            <button onClick={() => setShowSuggestions(true)}>
+              Select Instrument
+            </button>
+          </div>
+        )}
+      </div>
+
+      {showSuggestions && (
+        <div className="suggestions-overlay">
+          <div className="suggestions-modal">
+            <div className="modal-header">
+              <h3>Select Instrument for Track {track.trackNumber}</h3>
+              <button 
+                className="close-btn"
+                onClick={() => setShowSuggestions(false)}
+              >
+                ✕
+              </button>
+            </div>
+
+            {/* Sugerencias basadas en contexto */}
+            {suggestions.length > 0 && (
+              <SuggestionPanel
+                suggestions={suggestions}
+                onSelect={handleProfileSelect}
+                title={`💡 Suggested for ${genre || 'this track'}`}
+              />
+            )}
+
+            {/* Filtros por categoría */}
+            <div className="category-filters">
+              {categories.map(category => (
+                <button
+                  key={category.id}
+                  className={`category-btn ${selectedCategory === category.id ? 'active' : ''}`}
+                  onClick={() => setSelectedCategory(category.id)}
+                >
+                  {category.icon} {category.name}
+                </button>
+              ))}
+            </div>
+
+            {/* Lista de instrumentos */}
+            <div className="instruments-grid">
+              {getFilteredProfiles().map(profile => (
+                <div
+                  key={profile.id}
+                  className={`instrument-card ${currentProfile?.id === profile.id ? 'selected' : ''}`}
+                  onClick={() => handleProfileSelect(profile.id)}
+                  style={{ borderColor: profile.color }}
+                >
+                  <div className="card-header">
+                    <div className="instrument-color-dot" style={{ backgroundColor: profile.color }} />
+                    <div className="instrument-name">{profile.name}</div>
+                    {profile.brand && (
+                      <div className="instrument-brand">{profile.brand}</div>
+                    )}
+                  </div>
+                  
+                  <div className="card-body">
+                    <div className="instrument-description">
+                      {profile.description}
+                    </div>
+                    
+                    <div className="suggested-generators">
+                      <span className="generators-label">Best for:</span>
+                      <div className="generators-list">
+                        {profile.suggestedGenerators.slice(0, 2).map(gen => (
+                          <span key={gen} className="generator-tag">
+                            {gen}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                    
+                    {profile.tags && (
+                      <div className="instrument-tags">
+                        {profile.tags.slice(0, 3).map(tag => (
+                          <span key={tag} className="tag">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  
+                  <div className="card-footer">
+                    <div className="note-range">
+                      Range: {profile.defaultParameters.noteRange?.[0] || 24}-{profile.defaultParameters.noteRange?.[1] || 84}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+

--- a/src/crealab/components/SuggestionPanel.css
+++ b/src/crealab/components/SuggestionPanel.css
@@ -1,0 +1,80 @@
+.suggestion-panel {
+  background: linear-gradient(135deg, rgba(0, 255, 136, 0.1), rgba(0, 255, 136, 0.05));
+  border: 1px solid #00ff88;
+  border-radius: 8px;
+  padding: 15px;
+  margin-bottom: 20px;
+}
+
+.suggestion-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.suggestion-count {
+  font-size: 0.85rem;
+  color: #00ff88;
+}
+
+.suggestions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.suggestion-item {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  border: 1px solid rgba(0,255,136,0.3);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.suggestion-item:hover {
+  background: rgba(0,255,136,0.1);
+}
+
+.suggestion-color {
+  width: 12px;
+  height: 40px;
+  border-radius: 4px;
+  margin-right: 10px;
+}
+
+.suggestion-info {
+  flex: 1;
+}
+
+.suggestion-name {
+  font-weight: bold;
+}
+
+.suggestion-brand {
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+.suggestion-generators {
+  margin-top: 4px;
+  display: flex;
+  gap: 4px;
+}
+
+.gen-badge {
+  background: rgba(0,255,136,0.15);
+  border: 1px solid rgba(0,255,136,0.4);
+  border-radius: 4px;
+  padding: 2px 4px;
+  font-size: 0.75rem;
+}
+
+.suggestion-type {
+  font-size: 0.8rem;
+  text-transform: capitalize;
+  opacity: 0.9;
+}
+

--- a/src/crealab/components/SuggestionPanel.tsx
+++ b/src/crealab/components/SuggestionPanel.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { InstrumentProfile } from '../types/CrealabTypes';
+import './SuggestionPanel.css';
+
+interface SuggestionPanelProps {
+  suggestions: InstrumentProfile[];
+  onSelect: (profileId: string) => void;
+  title: string;
+}
+
+export const SuggestionPanel: React.FC<SuggestionPanelProps> = ({
+  suggestions,
+  onSelect,
+  title
+}) => {
+  if (suggestions.length === 0) return null;
+
+  return (
+    <div className="suggestion-panel">
+      <div className="suggestion-header">
+        <h4>{title}</h4>
+        <span className="suggestion-count">{suggestions.length} suggestions</span>
+      </div>
+      
+      <div className="suggestions-list">
+        {suggestions.map(profile => (
+          <div
+            key={profile.id}
+            className="suggestion-item"
+            onClick={() => onSelect(profile.id)}
+          >
+            <div className="suggestion-color" style={{ backgroundColor: profile.color }} />
+            
+            <div className="suggestion-info">
+              <div className="suggestion-name">{profile.name}</div>
+              {profile.brand && (
+                <div className="suggestion-brand">{profile.brand}</div>
+              )}
+              
+              <div className="suggestion-generators">
+                {profile.suggestedGenerators.slice(0, 2).map(gen => (
+                  <span key={gen} className="gen-badge">
+                    {gen}
+                  </span>
+                ))}
+              </div>
+            </div>
+            
+            <div className="suggestion-type">
+              {profile.type}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+

--- a/src/crealab/core/InstrumentProfileManager.ts
+++ b/src/crealab/core/InstrumentProfileManager.ts
@@ -1,0 +1,170 @@
+import { InstrumentProfile, GenerativeTrack, GeneratorType } from '../types/CrealabTypes';
+import { INSTRUMENT_PROFILES, getProfileById, getProfilesByGenre } from '../data/InstrumentProfiles';
+
+export class InstrumentProfileManager {
+  private static instance: InstrumentProfileManager;
+
+  static getInstance(): InstrumentProfileManager {
+    if (!this.instance) {
+      this.instance = new InstrumentProfileManager();
+    }
+    return this.instance;
+  }
+
+  // Aplicar perfil de instrumento a un track
+  applyProfileToTrack(track: GenerativeTrack, profileId: string): Partial<GenerativeTrack> {
+    const profile = getProfileById(profileId);
+    if (!profile) return {};
+
+    console.log(`🎺 Applying profile "${profile.name}" to track ${track.trackNumber}`);
+
+    const updates: Partial<GenerativeTrack> = {
+      instrumentProfile: profileId,
+      color: profile.color,
+      
+      // Actualizar generador sugerido si el actual es 'off'
+      generator: track.generator.type === 'off' ? {
+        ...track.generator,
+        type: profile.suggestedGenerators[0] as GeneratorType,
+        enabled: true,
+        parameters: this.getDefaultParametersForGenerator(
+          profile.suggestedGenerators[0] as GeneratorType,
+          profile
+        )
+      } : track.generator
+    };
+
+    return updates;
+  }
+
+  // Obtener parámetros por defecto para un generador basado en el perfil
+  private getDefaultParametersForGenerator(
+    generatorType: GeneratorType, 
+    profile: InstrumentProfile
+  ): Record<string, any> {
+    const baseParams = profile.defaultParameters;
+    
+    switch (generatorType) {
+      case 'euclidean':
+        return {
+          pulses: baseParams.pulses || 8,
+          steps: baseParams.steps || 16,
+          offset: 0,
+          mutation: baseParams.mutation || 0.1
+        };
+        
+      case 'probabilistic':
+        return {
+          density: baseParams.density || 0.5,
+          variation: 0.3,
+          swing: 0.1
+        };
+        
+      case 'markov':
+        return {
+          order: 2,
+          creativity: baseParams.creativity || 0.5,
+          memory: 8
+        };
+        
+      case 'arpeggiator':
+        return {
+          pattern: baseParams.pattern || 'up',
+          octaves: baseParams.octaves || 2,
+          noteLength: 0.25,
+          swing: 0.1
+        };
+        
+      case 'chaos':
+        return {
+          attractor: baseParams.attractor || 'lorenz',
+          sensitivity: baseParams.sensitivity || 0.5,
+          scaling: 1.0
+        };
+        
+      default:
+        return {};
+    }
+  }
+
+  // Obtener sugerencias de generadores para un perfil
+  getSuggestedGenerators(profileId: string): GeneratorType[] {
+    const profile = getProfileById(profileId);
+    return profile?.suggestedGenerators as GeneratorType[] || [];
+  }
+
+  // Obtener todos los perfiles disponibles
+  getAllProfiles(): InstrumentProfile[] {
+    return INSTRUMENT_PROFILES;
+  }
+
+  // Obtener perfiles por tipo
+  getProfilesByType(type: string): InstrumentProfile[] {
+    return INSTRUMENT_PROFILES.filter(profile => profile.type === type);
+  }
+
+  // Generar sugerencias basadas en el contexto
+  generateSuggestions(
+    currentTrack: GenerativeTrack,
+    genre?: string,
+    existingTracks?: GenerativeTrack[]
+  ): InstrumentProfile[] {
+    let suggestions: InstrumentProfile[] = [];
+
+    // 1. Sugerencias basadas en género
+    if (genre) {
+      suggestions = getProfilesByGenre(genre);
+    }
+
+    // 2. Si no hay suficientes sugerencias, agregar por tipo
+    if (suggestions.length < 3) {
+      const typeProfiles = this.getProfilesByType(currentTrack.instrumentProfile ? 
+        getProfileById(currentTrack.instrumentProfile)?.type || 'bass' : 'bass');
+      suggestions = [...suggestions, ...typeProfiles.slice(0, 3 - suggestions.length)];
+    }
+
+    // 3. Evitar duplicados con tracks existentes
+    if (existingTracks) {
+      const usedProfiles = existingTracks
+        .map(t => t.instrumentProfile)
+        .filter(Boolean);
+      
+      suggestions = suggestions.filter(profile => 
+        !usedProfiles.includes(profile.id));
+    }
+
+    // 4. Limitar a 5 sugerencias máximo
+    return suggestions.slice(0, 5);
+  }
+
+  // Obtener información de un perfil
+  getProfileInfo(profileId: string): InstrumentProfile | null {
+    return getProfileById(profileId) || null;
+  }
+
+  // Crear perfil personalizado
+  createCustomProfile(
+    name: string,
+    type: string,
+    suggestedGenerators: GeneratorType[],
+    defaultParameters: Record<string, any>
+  ): InstrumentProfile {
+    const customProfile: InstrumentProfile = {
+      id: `custom_${Date.now()}`,
+      name,
+      brand: 'Custom',
+      type: type as any,
+      suggestedGenerators,
+      defaultParameters,
+      description: `Custom profile for ${name}`,
+      color: `hsl(${Math.random() * 360}, 70%, 60%)`,
+      tags: ['custom']
+    };
+
+    // En una implementación real, esto se guardaría en localStorage o BD
+    console.log('📝 Custom profile created:', customProfile);
+    
+    return customProfile;
+  }
+}
+

--- a/src/crealab/data/InstrumentProfiles.ts
+++ b/src/crealab/data/InstrumentProfiles.ts
@@ -1,0 +1,230 @@
+import { InstrumentProfile } from '../types/CrealabTypes';
+
+// Base de datos de perfiles de instrumentos
+export const INSTRUMENT_PROFILES: InstrumentProfile[] = [
+  // === BASS SYNTHESIZERS ===
+  {
+    id: 'neutron',
+    name: 'Neutron',
+    brand: 'Behringer',
+    type: 'bass',
+    suggestedGenerators: ['euclidean', 'probabilistic'],
+    defaultParameters: {
+      noteRange: [24, 48], // C1 to C3
+      preferredScale: 'minor',
+      rhythmComplexity: 'medium',
+      density: 0.6,
+      pulses: 6,
+      steps: 16
+    },
+    description: 'Generador de bass progresivo con filtros análogos. Ideal para líneas de bajo potentes y grooves complejos.',
+    color: '#ff6b35',
+    tags: ['bass', 'analog', 'filter', 'progressive']
+  },
+  {
+    id: 'minitaur',
+    name: 'Minitaur',
+    brand: 'Moog',
+    type: 'bass',
+    suggestedGenerators: ['euclidean', 'arpeggiator'],
+    defaultParameters: {
+      noteRange: [24, 60],
+      rhythmComplexity: 'simple',
+      density: 0.7,
+      pulses: 4,
+      steps: 8
+    },
+    description: 'Bass clásico Moog con sub-osciladores potentes. Perfecto para techno y house.',
+    color: '#d62d20',
+    tags: ['bass', 'moog', 'sub', 'classic']
+  },
+
+  // === LEAD SYNTHESIZERS ===
+  {
+    id: 'arp2600',
+    name: 'ARP 2600',
+    brand: 'ARP',
+    type: 'lead',
+    suggestedGenerators: ['markov', 'chaos', 'arpeggiator'],
+    defaultParameters: {
+      noteRange: [48, 84], // C3 to C6
+      preferredScale: 'dorian',
+      rhythmComplexity: 'complex',
+      creativity: 0.7,
+      attractor: 'lorenz',
+      pattern: 'upDown'
+    },
+    description: 'Leads generativos modulares con carácter vintage. Ideal para solos expresivos y melodías evolutivas.',
+    color: '#ffa500',
+    tags: ['lead', 'modular', 'vintage', 'expressive']
+  },
+  {
+    id: 'prophet5',
+    name: 'Prophet-5',
+    brand: 'Sequential',
+    type: 'lead',
+    suggestedGenerators: ['arpeggiator', 'markov'],
+    defaultParameters: {
+      noteRange: [48, 72],
+      pattern: 'up',
+      octaves: 2,
+      creativity: 0.5
+    },
+    description: 'Sintetizador clásico americano. Perfecto para arpeggios y leads melódicos.',
+    color: '#4a90e2',
+    tags: ['lead', 'classic', 'american', 'melodic']
+  },
+
+  // === EXPERIMENTAL SYNTHESIZERS ===
+  {
+    id: 'microfreak',
+    name: 'MicroFreak',
+    brand: 'Arturia',
+    type: 'experimental',
+    suggestedGenerators: ['chaos', 'markov', 'probabilistic'],
+    defaultParameters: {
+      noteRange: [36, 96], // Rango amplio
+      attractor: 'henon',
+      sensitivity: 0.8,
+      creativity: 0.9,
+      microtonal: true
+    },
+    description: 'Secuencias experimentales con microtonalidad y texturas únicas. Para exploración sónica avanzada.',
+    color: '#e74c3c',
+    tags: ['experimental', 'microtonal', 'digital', 'unique']
+  },
+  {
+    id: 'digitakt',
+    name: 'Digitakt',
+    brand: 'Elektron',
+    type: 'experimental',
+    suggestedGenerators: ['euclidean', 'probabilistic'],
+    defaultParameters: {
+      noteRange: [24, 84],
+      pulses: 7,
+      steps: 16,
+      density: 0.4,
+      mutation: 0.3
+    },
+    description: 'Sampler/drum machine para texturas experimentales y ritmos complejos.',
+    color: '#2c3e50',
+    tags: ['sampler', 'experimental', 'elektron', 'complex']
+  },
+
+  // === DRUM MACHINES ===
+  {
+    id: 'modelcycles',
+    name: 'Model:Cycles',
+    brand: 'Elektron',
+    type: 'drum',
+    suggestedGenerators: ['euclidean', 'probabilistic'],
+    defaultParameters: {
+      noteRange: [36, 60], // Drum range
+      pulses: 8,
+      steps: 16,
+      density: 0.8,
+      mutation: 0.2
+    },
+    description: 'Patrones de percusión euclidiana con síntesis FM. Ideal para ritmos complejos y evolución de patrones.',
+    color: '#27ae60',
+    tags: ['drums', 'euclidean', 'fm', 'elektron']
+  },
+  {
+    id: 'tr808',
+    name: 'TR-808',
+    brand: 'Roland',
+    type: 'drum',
+    suggestedGenerators: ['euclidean', 'probabilistic'],
+    defaultParameters: {
+      noteRange: [36, 60],
+      pulses: 4,
+      steps: 16,
+      density: 0.6
+    },
+    description: 'Drum machine clásica. Perfecto para patrones de hip-hop y electrónica.',
+    color: '#95a5a6',
+    tags: ['drums', 'classic', 'roland', 'hiphop']
+  },
+
+  // === PAD/AMBIENT SYNTHESIZERS ===
+  {
+    id: 'deepmind',
+    name: 'DeepMind 12',
+    brand: 'Behringer',
+    type: 'pad',
+    suggestedGenerators: ['probabilistic', 'markov', 'chaos'],
+    defaultParameters: {
+      noteRange: [24, 72],
+      density: 0.3,
+      creativity: 0.6,
+      sensitivity: 0.4
+    },
+    description: 'Pads evolutivos y texturas ambientales. Ideal para fondos generativos y atmosferas.',
+    color: '#9b59b6',
+    tags: ['pad', 'ambient', 'lush', 'evolving']
+  },
+
+  // === GENERIC PROFILES ===
+  {
+    id: 'generic_bass',
+    name: 'Generic Bass',
+    brand: '',
+    type: 'bass',
+    suggestedGenerators: ['euclidean', 'probabilistic'],
+    defaultParameters: {
+      noteRange: [24, 48],
+      density: 0.6,
+      pulses: 6,
+      steps: 16
+    },
+    description: 'Perfil genérico para sintetizadores de bass.',
+    color: '#34495e',
+    tags: ['bass', 'generic']
+  },
+  {
+    id: 'generic_lead',
+    name: 'Generic Lead',
+    brand: '',
+    type: 'lead',
+    suggestedGenerators: ['arpeggiator', 'markov'],
+    defaultParameters: {
+      noteRange: [48, 84],
+      pattern: 'up',
+      creativity: 0.5
+    },
+    description: 'Perfil genérico para sintetizadores lead.',
+    color: '#3498db',
+    tags: ['lead', 'generic']
+  }
+];
+
+// Funciones utilitarias
+export function getProfilesByType(type: string): InstrumentProfile[] {
+  return INSTRUMENT_PROFILES.filter(profile => profile.type === type);
+}
+
+export function getProfileById(id: string): InstrumentProfile | undefined {
+  return INSTRUMENT_PROFILES.find(profile => profile.id === id);
+}
+
+export function getProfilesByTag(tag: string): InstrumentProfile[] {
+  return INSTRUMENT_PROFILES.filter(profile => profile.tags?.includes(tag));
+}
+
+export function getProfilesByGenre(genre: string): InstrumentProfile[] {
+  const genreProfiles: { [key: string]: string[] } = {
+    'Techno': ['neutron', 'tr808', 'modelcycles', 'arp2600'],
+    'House': ['minitaur', 'prophet5', 'tr808'],
+    'Ambient': ['deepmind', 'microfreak', 'arp2600'],
+    'Experimental': ['microfreak', 'digitakt', 'arp2600'],
+    'Drum & Bass': ['neutron', 'modelcycles', 'digitakt'],
+    'Dubstep': ['neutron', 'microfreak', 'modelcycles'],
+    'Trance': ['prophet5', 'arp2600', 'deepmind'],
+    'IDM': ['digitakt', 'microfreak', 'modelcycles']
+  };
+
+  const profileIds = genreProfiles[genre] || [];
+  return profileIds.map(id => getProfileById(id)).filter(Boolean) as InstrumentProfile[];
+}
+
+


### PR DESCRIPTION
## Summary
- add database of instrument profiles with lookup utilities
- introduce instrument profile manager to apply defaults and generate suggestions
- add instrument selector and suggestion panel components and hook into CreaLab

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa03b049fc8333a2f54d68caf858a2