### PR TITLE
feat: add MIDI I/O management and clock

### DIFF
--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -4,6 +4,7 @@ import { TopBar } from './TopBar';
 import LaunchControlVisualizer from './LaunchControlVisualizer';
 import useLaunchControlXL from '../hooks/useLaunchControlXL';
 import { InstrumentSelector } from './InstrumentSelector';
+import MidiConfiguration from './MidiConfiguration';
 import './CreaLab.css';
 
 interface CreaLabProps {
@@ -56,6 +57,7 @@ const createDefaultTrack = (n: number): GenerativeTrack => ({
 
 export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) => {
   const controller = useLaunchControlXL();
+  const [showMidiConfig, setShowMidiConfig] = useState(false);
   const [project, setProject] = useState<CreaLabProject>({
     id: 'project-1',
     name: 'New Project',
@@ -138,6 +140,8 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
         onKeyChange={key => setProject(p => ({ ...p, key }))}
         onSwitchToAudioVisualizer={onSwitchToAudioVisualizer}
       />
+
+      <button className="open-midi-config" onClick={() => setShowMidiConfig(true)}>MIDI Config</button>
 
       <LaunchControlVisualizer controller={controller} />
 
@@ -232,6 +236,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
           ))}
         </div>
       </main>
+      {showMidiConfig && <MidiConfiguration onClose={() => setShowMidiConfig(false)} />}
     </div>
   );
 };

--- a/src/crealab/components/MidiConfiguration.css
+++ b/src/crealab/components/MidiConfiguration.css
@@ -1,0 +1,254 @@
+.midi-configuration-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.midi-configuration-modal {
+  background: linear-gradient(135deg, #1a1a1a 0%, #2d2d2d 100%);
+  border: 2px solid #444;
+  border-radius: 12px;
+  width: 90vw;
+  max-width: 700px;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 25px;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 25px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid #333;
+}
+
+.modal-header h3 {
+  margin: 0;
+  color: white;
+  font-size: 18px;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 20px;
+  cursor: pointer;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 15px;
+  transition: all 0.2s;
+}
+
+.close-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+/* Config Sections */
+.config-section {
+  margin-bottom: 25px;
+  padding: 20px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  border: 1px solid #333;
+}
+
+.config-section h4 {
+  margin: 0 0 15px 0;
+  color: #00ff88;
+  font-size: 16px;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.refresh-btn {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid #444;
+  color: white;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  transition: all 0.2s;
+}
+
+.refresh-btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+/* Clock Controls */
+.clock-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.checkbox-label input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+}
+
+.clock-source,
+.clock-output {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.clock-source label,
+.clock-output label {
+  font-size: 14px;
+  color: #ccc;
+  min-width: 120px;
+}
+
+.clock-source select,
+.clock-output select {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid #444;
+  color: white;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.clock-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #ccc;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 10px;
+  border-radius: 6px;
+}
+
+.status-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #666;
+}
+
+.status-indicator.running {
+  background: #00ff88;
+  animation: pulse 1.5s infinite;
+}
+
+.status-indicator.stopped {
+  background: #888;
+}
+
+/* Devices List */
+.devices-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.no-devices {
+  text-align: center;
+  color: #888;
+  font-style: italic;
+  padding: 20px;
+}
+
+.device-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid #444;
+  border-radius: 6px;
+  transition: all 0.2s;
+}
+
+.device-item:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.device-info {
+  flex: 1;
+}
+
+.device-name {
+  font-weight: bold;
+  font-size: 14px;
+  color: white;
+  margin-bottom: 2px;
+}
+
+.device-manufacturer {
+  font-size: 12px;
+  color: #888;
+  margin-bottom: 3px;
+}
+
+.device-status {
+  font-size: 11px;
+  text-transform: capitalize;
+}
+
+.device-status.connected {
+  color: #00ff88;
+}
+
+.device-status.disconnected {
+  color: #ff4444;
+}
+
+.test-btn {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid #444;
+  color: white;
+  padding: 6px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  transition: all 0.2s;
+  min-width: 60px;
+}
+
+.test-btn:hover:not(:disabled) {
+  background: #00ff88;
+  color: black;
+}
+
+.test-btn.testing {
+  background: #ffa500;
+  color: black;
+  animation: pulse 1s infinite;
+}
+
+.test-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+

--- a/src/crealab/components/MidiConfiguration.tsx
+++ b/src/crealab/components/MidiConfiguration.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import { useMidiDevices } from '../hooks/useMidiDevices';
+import './MidiConfiguration.css';
+
+interface Props {
+  onClose: () => void;
+}
+
+export const MidiConfiguration: React.FC<Props> = ({ onClose }) => {
+  const { inputDevices, outputDevices, midiClock, testDevice, refreshDevices } = useMidiDevices();
+  const [testing, setTesting] = useState<string | null>(null);
+
+  const handleTest = async (id: string) => {
+    setTesting(id);
+    await testDevice(id);
+    setTesting(null);
+  };
+
+  return (
+    <div className="midi-configuration-overlay">
+      <div className="midi-configuration-modal">
+        <div className="modal-header">
+          <h3>MIDI Configuration</h3>
+          <button className="close-btn" onClick={onClose}>×</button>
+        </div>
+
+        <div className="config-section">
+          <div className="section-header">
+            <h4>Clock</h4>
+          </div>
+          <div className="clock-status">
+            <div className={`status-indicator ${midiClock.isRunning ? 'running' : 'stopped'}`}></div>
+            <span>{midiClock.isRunning ? 'Running' : 'Stopped'} @ {midiClock.bpm} BPM</span>
+          </div>
+        </div>
+
+        <div className="config-section">
+          <div className="section-header">
+            <h4>Input Devices</h4>
+            <button className="refresh-btn" onClick={refreshDevices}>Refresh</button>
+          </div>
+          <div className="devices-list">
+            {inputDevices.length === 0 && (
+              <div className="no-devices">No input devices</div>
+            )}
+            {inputDevices.map(dev => (
+              <div key={dev.id} className="device-item">
+                <div className="device-info">
+                  <div className="device-name">{dev.name}</div>
+                  <div className="device-manufacturer">{dev.manufacturer}</div>
+                  <div className={`device-status ${dev.state}`}>{dev.state}</div>
+                </div>
+                <button
+                  className={`test-btn ${testing === dev.id ? 'testing' : ''}`}
+                  disabled={testing === dev.id}
+                  onClick={() => handleTest(dev.id)}
+                >
+                  {testing === dev.id ? '...' : 'Test'}
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="config-section">
+          <div className="section-header">
+            <h4>Output Devices</h4>
+            <button className="refresh-btn" onClick={refreshDevices}>Refresh</button>
+          </div>
+          <div className="devices-list">
+            {outputDevices.length === 0 && (
+              <div className="no-devices">No output devices</div>
+            )}
+            {outputDevices.map(dev => (
+              <div key={dev.id} className="device-item">
+                <div className="device-info">
+                  <div className="device-name">{dev.name}</div>
+                  <div className="device-manufacturer">{dev.manufacturer}</div>
+                  <div className={`device-status ${dev.state}`}>{dev.state}</div>
+                </div>
+                <button
+                  className={`test-btn ${testing === dev.id ? 'testing' : ''}`}
+                  disabled={testing === dev.id}
+                  onClick={() => handleTest(dev.id)}
+                >
+                  {testing === dev.id ? '...' : 'Test'}
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MidiConfiguration;

--- a/src/crealab/core/MidiClock.ts
+++ b/src/crealab/core/MidiClock.ts
@@ -1,0 +1,93 @@
+export interface MidiClockState {
+  isRunning: boolean;
+  bpm: number;
+  currentBeat: number;
+  currentStep: number;
+  source: 'internal' | 'external';
+}
+
+type MidiClockListener = (state: MidiClockState) => void;
+
+export class MidiClock {
+  private state: MidiClockState = {
+    isRunning: false,
+    bpm: 120,
+    currentBeat: 0,
+    currentStep: 0,
+    source: 'internal'
+  };
+  private listeners: Set<MidiClockListener> = new Set();
+  private intervalId: any = null;
+
+  start(bpm?: number) {
+    if (bpm) this.state.bpm = bpm;
+    if (this.state.isRunning) return;
+    this.state.isRunning = true;
+    const interval = (60 / this.state.bpm / 24) * 1000; // 24 PPQN
+    this.intervalId = setInterval(() => this.tick(), interval);
+    this.emit();
+  }
+
+  stop() {
+    this.state.isRunning = false;
+    if (this.intervalId) clearInterval(this.intervalId);
+    this.intervalId = null;
+    this.emit();
+  }
+
+  private tick() {
+    if (!this.state.isRunning) return;
+    this.state.currentStep++;
+    if (this.state.currentStep % 24 === 0) {
+      this.state.currentBeat++;
+    }
+    this.emit();
+  }
+
+  setSource(source: 'internal' | 'external') {
+    this.state.source = source;
+    this.emit();
+  }
+
+  receiveClock() {
+    if (this.state.source !== 'external') return;
+    this.tick();
+  }
+
+  receiveStart() {
+    if (this.state.source !== 'external') return;
+    this.state.isRunning = true;
+    this.state.currentBeat = 0;
+    this.state.currentStep = 0;
+    this.emit();
+  }
+
+  receiveContinue() {
+    if (this.state.source !== 'external') return;
+    this.state.isRunning = true;
+    this.emit();
+  }
+
+  receiveStop() {
+    if (this.state.source !== 'external') return;
+    this.state.isRunning = false;
+    this.emit();
+  }
+
+  addListener(cb: MidiClockListener) {
+    this.listeners.add(cb);
+  }
+
+  removeListener(cb: MidiClockListener) {
+    this.listeners.delete(cb);
+  }
+
+  private emit() {
+    const snapshot: MidiClockState = { ...this.state };
+    this.listeners.forEach(l => l(snapshot));
+  }
+
+  getState(): MidiClockState {
+    return { ...this.state };
+  }
+}

--- a/src/crealab/core/MidiManager.ts
+++ b/src/crealab/core/MidiManager.ts
@@ -1,0 +1,230 @@
+import { MidiDevice, MidiMessage, MidiNote } from '../types/CrealabTypes';
+import { MidiClock } from './MidiClock';
+
+export interface MidiConnectionStatus {
+  connected: boolean;
+  lastActivity: number;
+  messageCount: number;
+}
+
+export class MidiManager {
+  private static instance: MidiManager;
+  private midiAccess: any = null;
+  private inputDevices: Map<string, MidiDevice> = new Map();
+  private outputDevices: Map<string, MidiDevice> = new Map();
+  private connectionStatus: Map<string, MidiConnectionStatus> = new Map();
+  private messageListeners: Map<string, (message: MidiMessage) => void> = new Map();
+  private midiClock: MidiClock;
+
+  static getInstance(): MidiManager {
+    if (!this.instance) {
+      this.instance = new MidiManager();
+    }
+    return this.instance;
+  }
+
+  private constructor() {
+    this.midiClock = new MidiClock();
+    this.initialize();
+  }
+
+  async initialize() {
+    if (this.midiAccess) return;
+    try {
+      this.midiAccess = await (navigator as any).requestMIDIAccess({ sysex: true });
+      this.midiAccess.onstatechange = this.handleStateChange.bind(this);
+      this.scanDevices();
+      console.log('MIDI Manager initialized');
+    } catch (error) {
+      console.error('Failed to initialize MIDI Manager:', error);
+    }
+  }
+
+  private scanDevices() {
+    if (!this.midiAccess) return;
+
+    this.inputDevices.clear();
+    for (const input of this.midiAccess.inputs.values()) {
+      const device: MidiDevice = {
+        id: input.id,
+        name: input.name || 'Unknown Input',
+        manufacturer: input.manufacturer || '',
+        type: 'input',
+        state: input.state,
+        connection: input.connection
+      };
+      this.inputDevices.set(input.id, device);
+      this.setupInputListener(input);
+      this.connectionStatus.set(input.id, {
+        connected: input.state === 'connected',
+        lastActivity: 0,
+        messageCount: 0
+      });
+    }
+
+    this.outputDevices.clear();
+    for (const output of this.midiAccess.outputs.values()) {
+      const device: MidiDevice = {
+        id: output.id,
+        name: output.name || 'Unknown Output',
+        manufacturer: output.manufacturer || '',
+        type: 'output',
+        state: output.state,
+        connection: output.connection
+      };
+      this.outputDevices.set(output.id, device);
+      this.connectionStatus.set(output.id, {
+        connected: output.state === 'connected',
+        lastActivity: 0,
+        messageCount: 0
+      });
+    }
+  }
+
+  refreshDevices() {
+    this.scanDevices();
+  }
+
+  private setupInputListener(input: any) {
+    input.onmidimessage = (event: any) => {
+      const message: MidiMessage = {
+        data: event.data,
+        timestamp: event.timeStamp,
+        deviceId: input.id
+      };
+      this.handleMidiMessage(message);
+      const status = this.connectionStatus.get(input.id);
+      if (status) {
+        status.lastActivity = Date.now();
+        status.messageCount++;
+      }
+    };
+  }
+
+  private handleMidiMessage(message: MidiMessage) {
+    const [status, , data2] = message.data;
+    if ((status & 0xf0) === 0x90 && data2 > 0) {
+      this.notifyMessage('noteOn', message);
+    } else if ((status & 0xf0) === 0x80 || ((status & 0xf0) === 0x90 && data2 === 0)) {
+      this.notifyMessage('noteOff', message);
+    } else if ((status & 0xf0) === 0xb0) {
+      this.notifyMessage('controlChange', message);
+    } else if (status === 0xf8) {
+      this.midiClock.receiveClock();
+    } else if (status === 0xfa) {
+      this.midiClock.receiveStart();
+    } else if (status === 0xfb) {
+      this.midiClock.receiveContinue();
+    } else if (status === 0xfc) {
+      this.midiClock.receiveStop();
+    }
+  }
+
+  private notifyMessage(type: string, message: MidiMessage) {
+    Array.from(this.messageListeners.values()).forEach(cb => {
+      try {
+        cb(message);
+      } catch (err) {
+        console.warn('Error in MIDI message listener', err);
+      }
+    });
+    window.dispatchEvent(new CustomEvent('midiMessage', { detail: { type, message } }));
+  }
+
+  private handleStateChange(event: any) {
+    this.scanDevices();
+    window.dispatchEvent(new CustomEvent('midiDeviceChange', {
+      detail: { device: event.port, state: event.port.state }
+    }));
+  }
+
+  async sendNote(
+    deviceId: string,
+    channel: number,
+    note: number,
+    velocity: number,
+    duration: number = 100
+  ): Promise<boolean> {
+    const output = this.midiAccess?.outputs.get(deviceId);
+    if (!output) return false;
+    try {
+      const noteOn = [0x90 + (channel - 1), note, velocity];
+      const noteOff = [0x80 + (channel - 1), note, 0];
+      output.send(noteOn);
+      if (duration > 0) {
+        setTimeout(() => output.send(noteOff), duration);
+      }
+      const status = this.connectionStatus.get(deviceId);
+      if (status) {
+        status.lastActivity = Date.now();
+        status.messageCount++;
+      }
+      return true;
+    } catch (err) {
+      console.error('Failed to send MIDI note', err);
+      return false;
+    }
+  }
+
+  async sendCC(
+    deviceId: string,
+    channel: number,
+    controller: number,
+    value: number
+  ): Promise<boolean> {
+    const output = this.midiAccess?.outputs.get(deviceId);
+    if (!output) return false;
+    try {
+      const message = [0xb0 + (channel - 1), controller, value];
+      output.send(message);
+      const status = this.connectionStatus.get(deviceId);
+      if (status) {
+        status.lastActivity = Date.now();
+        status.messageCount++;
+      }
+      return true;
+    } catch (err) {
+      console.error('Failed to send MIDI CC', err);
+      return false;
+    }
+  }
+
+  async sendChord(
+    deviceId: string,
+    channel: number,
+    notes: MidiNote[]
+  ): Promise<boolean> {
+    const results = await Promise.all(
+      notes.map(n => this.sendNote(deviceId, channel, n.note, n.velocity, n.duration * 1000))
+    );
+    return results.every(Boolean);
+  }
+
+  addMessageListener(id: string, callback: (message: MidiMessage) => void) {
+    this.messageListeners.set(id, callback);
+  }
+
+  removeMessageListener(id: string) {
+    this.messageListeners.delete(id);
+  }
+
+  getInputDevices(): MidiDevice[] {
+    return Array.from(this.inputDevices.values());
+  }
+
+  getOutputDevices(): MidiDevice[] {
+    return Array.from(this.outputDevices.values());
+  }
+
+  getDeviceById(id: string): MidiDevice | undefined {
+    return this.inputDevices.get(id) || this.outputDevices.get(id);
+  }
+
+  testDevice(deviceId: string): Promise<boolean> {
+    return this.sendNote(deviceId, 1, 60, 100, 200);
+  }
+
+  getMidiClock(): MidiClock {
+    return this.midiClock;
+  }
+}

--- a/src/crealab/hooks/useMidiDevices.ts
+++ b/src/crealab/hooks/useMidiDevices.ts
@@ -1,0 +1,95 @@
+import { useEffect, useState, useCallback } from 'react';
+import { MidiDevice } from '../types/CrealabTypes';
+import { MidiManager } from '../core/MidiManager';
+import { MidiClockState } from '../core/MidiClock';
+
+interface UseMidiDevicesReturn {
+  inputDevices: MidiDevice[];
+  outputDevices: MidiDevice[];
+  midiClock: MidiClockState;
+  isInitialized: boolean;
+  testDevice: (deviceId: string) => Promise<boolean>;
+  refreshDevices: () => void;
+  sendNote: (deviceId: string, channel: number, note: number, velocity: number, duration?: number) => Promise<boolean>;
+  sendCC: (deviceId: string, channel: number, controller: number, value: number) => Promise<boolean>;
+}
+
+export const useMidiDevices = (): UseMidiDevicesReturn => {
+  const [inputDevices, setInputDevices] = useState<MidiDevice[]>([]);
+  const [outputDevices, setOutputDevices] = useState<MidiDevice[]>([]);
+  const [midiClock, setMidiClock] = useState<MidiClockState>({
+    isRunning: false,
+    bpm: 120,
+    currentBeat: 0,
+    currentStep: 0,
+    source: 'internal'
+  });
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  const midiManager = MidiManager.getInstance();
+
+  const refreshDevices = useCallback(() => {
+    setInputDevices(midiManager.getInputDevices());
+    setOutputDevices(midiManager.getOutputDevices());
+  }, [midiManager]);
+
+  useEffect(() => {
+    const initializeMidi = async () => {
+      await midiManager.initialize();
+      refreshDevices();
+      setIsInitialized(true);
+    };
+
+    initializeMidi();
+
+    const clockListener = (state: MidiClockState) => {
+      setMidiClock(state);
+    };
+    midiManager.getMidiClock().addListener(clockListener);
+
+    const handleDeviceChange = () => {
+      refreshDevices();
+    };
+    window.addEventListener('midiDeviceChange', handleDeviceChange);
+
+    return () => {
+      midiManager.getMidiClock().removeListener(clockListener);
+      window.removeEventListener('midiDeviceChange', handleDeviceChange);
+    };
+  }, [midiManager, refreshDevices]);
+
+  const testDevice = useCallback(async (deviceId: string): Promise<boolean> => {
+    return midiManager.testDevice(deviceId);
+  }, [midiManager]);
+
+  const sendNote = useCallback(async (
+    deviceId: string,
+    channel: number,
+    note: number,
+    velocity: number,
+    duration: number = 100
+  ): Promise<boolean> => {
+    return midiManager.sendNote(deviceId, channel, note, velocity, duration);
+  }, [midiManager]);
+
+  const sendCC = useCallback(async (
+    deviceId: string,
+    channel: number,
+    controller: number,
+    value: number
+  ): Promise<boolean> => {
+    return midiManager.sendCC(deviceId, channel, controller, value);
+  }, [midiManager]);
+
+  return {
+    inputDevices,
+    outputDevices,
+    midiClock,
+    isInitialized,
+    testDevice,
+    refreshDevices,
+    sendNote,
+    sendCC
+  };
+};
+

--- a/src/crealab/types/CrealabTypes.ts
+++ b/src/crealab/types/CrealabTypes.ts
@@ -222,3 +222,27 @@ export interface CreaLabProject {
   oldTracks?: Track[];
 }
 
+
+// === MIDI SYSTEM TYPES ===
+export interface MidiDevice {
+  id: string;
+  name: string;
+  manufacturer?: string;
+  type: 'input' | 'output';
+  state: 'connected' | 'disconnected';
+  connection: string;
+}
+
+export interface MidiMessage {
+  data: Uint8Array;
+  timestamp: number;
+  deviceId: string;
+}
+
+export interface MidiClockState {
+  isRunning: boolean;
+  bpm: number;
+  currentBeat: number;
+  currentStep: number;
+  source: 'internal' | 'external';
+}


### PR DESCRIPTION
## Summary
- add MidiManager and MidiClock for device handling and sync
- expose MIDI devices and clock state with React hook and modal UI
- integrate MIDI configuration into CreaLab workspace

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa04d253888333b9ee2181a34997a5