### PR TITLE
feat: add project serialization and manager

### DIFF
--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -5,6 +5,7 @@ import LaunchControlVisualizer from './LaunchControlVisualizer';
 import useLaunchControlXL from '../hooks/useLaunchControlXL';
 import { InstrumentSelector } from './InstrumentSelector';
 import MidiConfiguration from './MidiConfiguration';
+import ProjectManager from './ProjectManager';
 import './CreaLab.css';
 
 interface CreaLabProps {
@@ -58,6 +59,7 @@ const createDefaultTrack = (n: number): GenerativeTrack => ({
 export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) => {
   const controller = useLaunchControlXL();
   const [showMidiConfig, setShowMidiConfig] = useState(false);
+  const [showProjectManager, setShowProjectManager] = useState(false);
   const [project, setProject] = useState<CreaLabProject>({
     id: 'project-1',
     name: 'New Project',
@@ -142,6 +144,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
       />
 
       <button className="open-midi-config" onClick={() => setShowMidiConfig(true)}>MIDI Config</button>
+      <button className="open-project-manager" onClick={() => setShowProjectManager(true)}>Projects</button>
 
       <LaunchControlVisualizer controller={controller} />
 
@@ -237,6 +240,13 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
         </div>
       </main>
       {showMidiConfig && <MidiConfiguration onClose={() => setShowMidiConfig(false)} />}
+      {showProjectManager && (
+        <ProjectManager
+          project={project}
+          onProjectLoad={setProject}
+          onClose={() => setShowProjectManager(false)}
+        />
+      )}
     </div>
   );
 };

--- a/src/crealab/components/ProjectManager.css
+++ b/src/crealab/components/ProjectManager.css
@@ -1,0 +1,54 @@
+.project-manager-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.project-manager {
+  background: #222;
+  color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  width: 420px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.pm-section {
+  margin-bottom: 1rem;
+}
+
+.backup-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0 0;
+}
+
+.backup-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.backup-info {
+  flex: 1;
+  margin-right: 0.5rem;
+}
+
+.pm-error {
+  color: #ff6b6b;
+  margin-bottom: 1rem;
+}
+
+.pm-actions {
+  text-align: right;
+}
+

--- a/src/crealab/components/ProjectManager.tsx
+++ b/src/crealab/components/ProjectManager.tsx
@@ -1,0 +1,101 @@
+import React, { useRef, useState } from 'react';
+import { CreaLabProject } from '../types/CrealabTypes';
+import { ProjectSerializer } from '../core/ProjectSerializer';
+import './ProjectManager.css';
+
+interface ProjectManagerProps {
+  project: CreaLabProject;
+  onProjectLoad: (project: CreaLabProject) => void;
+  onClose: () => void;
+}
+
+const ProjectManager: React.FC<ProjectManagerProps> = ({ project, onProjectLoad, onClose }) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [backups, setBackups] = useState(ProjectSerializer.getAvailableBackups());
+  const [error, setError] = useState<string | null>(null);
+
+  const handleExport = () => {
+    const data = ProjectSerializer.exportProject(project, 'json');
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${project.name.replace(/\s+/g, '_')}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    file.text().then(text => {
+      try {
+        const imported = ProjectSerializer.deserialize(text);
+        onProjectLoad(imported);
+        setError(null);
+        setBackups(ProjectSerializer.getAvailableBackups());
+        onClose();
+      } catch (err: any) {
+        setError(err.message);
+      }
+    });
+  };
+
+  const handleRestore = (key: string) => {
+    try {
+      const restored = ProjectSerializer.restoreBackup(key);
+      onProjectLoad(restored);
+      setError(null);
+      onClose();
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  const createBackup = () => {
+    ProjectSerializer.createBackup(project);
+    setBackups(ProjectSerializer.getAvailableBackups());
+  };
+
+  return (
+    <div className="project-manager-overlay">
+      <div className="project-manager">
+        <h2>Project Manager</h2>
+        <div className="pm-section">
+          <button onClick={handleExport}>Export JSON</button>
+          <button onClick={() => fileInputRef.current?.click()}>Import JSON</button>
+          <input
+            type="file"
+            accept="application/json"
+            ref={fileInputRef}
+            style={{ display: 'none' }}
+            onChange={handleImport}
+          />
+        </div>
+
+        <div className="pm-section">
+          <h3>Backups</h3>
+          <button onClick={createBackup}>Create Backup</button>
+          <ul className="backup-list">
+            {backups.map(b => (
+              <li key={b.key} className="backup-item">
+                <span className="backup-info">{b.name} - {b.timestamp.toLocaleString()}</span>
+                <button onClick={() => handleRestore(b.key)}>Restore</button>
+              </li>
+            ))}
+            {backups.length === 0 && <li className="backup-item">No backups</li>}
+          </ul>
+        </div>
+
+        {error && <div className="pm-error">{error}</div>}
+
+        <div className="pm-actions">
+          <button onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectManager;
+

--- a/src/crealab/core/ProjectSerializer.ts
+++ b/src/crealab/core/ProjectSerializer.ts
@@ -1,0 +1,354 @@
+import { CreaLabProject, GenerativeTrack, ProjectExportFormat } from '../types/CrealabTypes';
+import { JsonValidator } from '../utils/JsonValidator';
+
+export interface SerializedProject {
+  version: string;
+  timestamp: string;
+  metadata: {
+    exportedBy: string;
+    creaLabVersion: string;
+    platform: string;
+  };
+  project: CreaLabProject;
+}
+
+export class ProjectSerializer {
+  private static readonly CURRENT_VERSION = '2.0.0';
+  private static readonly CREALAB_VERSION = '1.0.0';
+
+  // Serializar proyecto completo a JSON
+  static serialize(project: CreaLabProject): string {
+    const serialized: SerializedProject = {
+      version: this.CURRENT_VERSION,
+      timestamp: new Date().toISOString(),
+      metadata: {
+        exportedBy: 'Jungle Lab Studio - Crea Lab',
+        creaLabVersion: this.CREALAB_VERSION,
+        platform: (typeof navigator !== 'undefined' && navigator.platform) ? navigator.platform : 'Unknown'
+      },
+      project: this.cleanProjectForExport(project)
+    };
+
+    return JSON.stringify(serialized, null, 2);
+  }
+
+  // Deserializar proyecto desde JSON
+  static deserialize(jsonString: string): CreaLabProject {
+    try {
+      const data = JSON.parse(jsonString);
+
+      // Validar estructura básica
+      if (!data.project) {
+        throw new Error('Invalid project file: missing project data');
+      }
+
+      // Validar con JsonValidator
+      const validationResult = JsonValidator.validateProject(data.project);
+      if (!validationResult.valid) {
+        console.warn('Project validation warnings:', validationResult.errors);
+      }
+
+      // Migrar desde versiones anteriores si es necesario
+      const migratedProject = this.migrateProject(data);
+
+      // Limpiar y normalizar
+      return this.normalizeProject(migratedProject.project);
+
+    } catch (error: any) {
+      console.error('Failed to deserialize project:', error);
+      throw new Error(`Project deserialization failed: ${error.message}`);
+    }
+  }
+
+  // Limpiar proyecto para export (remover datos temporales)
+  private static cleanProjectForExport(project: CreaLabProject): CreaLabProject {
+    const cleaned = JSON.parse(JSON.stringify(project));
+
+    // Limpiar datos temporales de transport
+    cleaned.transport = {
+      ...cleaned.transport,
+      isPlaying: false,
+      isPaused: false,
+      currentBeat: 0,
+      currentBar: 0,
+      currentStep: 0
+    };
+
+    // Limpiar estado de generadores
+    cleaned.tracks = cleaned.tracks.map((track: GenerativeTrack) => ({
+      ...track,
+      generator: {
+        ...track.generator,
+        lastNoteTime: 0,
+        currentStep: 0
+      },
+      controls: {
+        ...track.controls,
+        playStop: false // Resetear estados de play
+      }
+    }));
+
+    // Remover datos legacy si existen
+    delete (cleaned as any).scenes;
+    delete (cleaned as any).oldTracks;
+
+    return cleaned;
+  }
+
+  // Migrar desde versiones anteriores
+  private static migrateProject(data: any): SerializedProject {
+    const version = data.version || '1.0.0';
+
+    console.log(`🔄 Migrating project from version ${version} to ${this.CURRENT_VERSION}`);
+
+    switch (version) {
+      case '1.0.0':
+        return this.migrateFromV1(data);
+      case '2.0.0':
+        return data as SerializedProject;
+      default:
+        console.warn(`Unknown project version: ${version}. Attempting migration...`);
+        return this.migrateFromV1(data);
+    }
+  }
+
+  // Migración desde v1.0.0 (clips system) a v2.0.0 (generative system)
+  private static migrateFromV1(data: any): SerializedProject {
+    const oldProject = data.project || data;
+
+    // Crear estructura nueva
+    const migratedProject: CreaLabProject = {
+      id: oldProject.id || `migrated-${Date.now()}`,
+      name: oldProject.name || 'Migrated Project',
+      description: 'Migrated from legacy clip-based system',
+
+      // Crear 8 tracks fijos desde tracks antiguos
+      tracks: this.createFixedTracksFromLegacy(oldProject.tracks || []),
+
+      globalTempo: oldProject.globalTempo || 128,
+      key: oldProject.key || 'C',
+      scale: oldProject.scale || 'minor',
+      genre: 'Techno', // Default para migración
+
+      transport: {
+        isPlaying: false,
+        isPaused: false,
+        currentBeat: 0,
+        currentBar: 0,
+        currentStep: 0
+      },
+
+      launchControl: {
+        connected: false
+      },
+
+      midiClock: {
+        enabled: false,
+        source: 'internal',
+        ppqn: 24
+      }
+    };
+
+    return {
+      version: this.CURRENT_VERSION,
+      timestamp: new Date().toISOString(),
+      metadata: {
+        exportedBy: 'Jungle Lab Studio - Crea Lab (Migration)',
+        creaLabVersion: this.CREALAB_VERSION,
+        platform: (typeof navigator !== 'undefined' && navigator.platform) ? navigator.platform : 'Unknown'
+      },
+      project: migratedProject
+    };
+  }
+
+  // Crear 8 tracks fijos desde sistema legacy
+  private static createFixedTracksFromLegacy(legacyTracks: any[]): [
+    GenerativeTrack, GenerativeTrack, GenerativeTrack, GenerativeTrack,
+    GenerativeTrack, GenerativeTrack, GenerativeTrack, GenerativeTrack
+  ] {
+    const fixedTracks: GenerativeTrack[] = [];
+
+    for (let i = 1; i <= 8; i++) {
+      const legacyTrack = legacyTracks[i - 1];
+
+      const track: GenerativeTrack = {
+        id: `track-${i}`,
+        name: legacyTrack?.name || `Track ${i}`,
+        trackNumber: i,
+        color: `hsl(${(i - 1) * 45}, 70%, 60%)`,
+
+        outputDevice: legacyTrack?.midiDevice || '',
+        midiChannel: legacyTrack?.midiChannel || i,
+
+        generator: {
+          type: 'off', // Migrar como desactivado inicialmente
+          enabled: false,
+          parameters: {},
+          lastNoteTime: 0,
+          currentStep: 0
+        },
+
+        controls: {
+          intensity: 64,
+          paramA: 64,
+          paramB: 64,
+          paramC: 64,
+          playStop: false,
+          mode: 0
+        },
+
+        launchControlMapping: {
+          stripNumber: i,
+          faderCC: 77 + (i - 1),
+          knob1CC: 13 + (i - 1) * 4,
+          knob2CC: 14 + (i - 1) * 4,
+          knob3CC: 15 + (i - 1) * 4,
+          button1CC: 41 + (i - 1),
+          button2CC: 57 + (i - 1)
+        }
+      };
+
+      fixedTracks.push(track);
+    }
+
+    return fixedTracks as [
+      GenerativeTrack, GenerativeTrack, GenerativeTrack, GenerativeTrack,
+      GenerativeTrack, GenerativeTrack, GenerativeTrack, GenerativeTrack
+    ];
+  }
+
+  // Normalizar proyecto después de deserialización
+  private static normalizeProject(project: CreaLabProject): CreaLabProject {
+    // Asegurar que tiene todos los campos requeridos
+    return {
+      ...project,
+      description: project.description || '',
+      genre: project.genre || 'Techno',
+      transport: project.transport || {
+        isPlaying: false,
+        isPaused: false,
+        currentBeat: 0,
+        currentBar: 0,
+        currentStep: 0
+      },
+      launchControl: project.launchControl || {
+        connected: false
+      },
+      midiClock: project.midiClock || {
+        enabled: false,
+        source: 'internal',
+        ppqn: 24
+      }
+    };
+  }
+
+  // Exportar en diferentes formatos
+  static exportProject(project: CreaLabProject, format: ProjectExportFormat): string {
+    switch (format) {
+      case 'json':
+        return this.serialize(project);
+      case 'preset':
+        return this.exportAsPreset(project);
+      case 'ableton':
+        return this.exportForAbleton(project);
+      default:
+        throw new Error(`Unsupported export format: ${format}`);
+    }
+  }
+
+  // Exportar como preset (solo configuración de generadores)
+  private static exportAsPreset(project: CreaLabProject): string {
+    const preset = {
+      name: project.name,
+      genre: project.genre,
+      key: project.key,
+      scale: project.scale,
+      tempo: project.globalTempo,
+      tracks: project.tracks.map(track => ({
+        name: track.name,
+        instrumentProfile: track.instrumentProfile,
+        generator: track.generator,
+        color: track.color
+      }))
+    };
+
+    return JSON.stringify(preset, null, 2);
+  }
+
+  // Exportar para Ableton Live
+  private static exportForAbleton(project: CreaLabProject): string {
+    let output = `# Ableton Live Session Export\n`;
+    output += `# Project: ${project.name}\n`;
+    output += `# Tempo: ${project.globalTempo} BPM\n`;
+    output += `# Key: ${project.key} ${project.scale}\n\n`;
+
+    project.tracks.forEach(track => {
+      if (track.generator.enabled) {
+        output += `## Track ${track.trackNumber}: ${track.name}\n`;
+        output += `MIDI Channel: ${track.midiChannel}\n`;
+        output += `Generator: ${track.generator.type}\n`;
+        output += `Parameters: ${JSON.stringify(track.generator.parameters)}\n\n`;
+      }
+    });
+
+    return output;
+  }
+
+  // Crear backup automático
+  static createBackup(project: CreaLabProject): void {
+    const backupKey = `crealab_backup_${Date.now()}`;
+    const backup = this.serialize(project);
+
+    try {
+      // Mantener solo los últimos 5 backups
+      const existingBackups = Object.keys(localStorage)
+        .filter(key => key.startsWith('crealab_backup_'))
+        .sort()
+        .reverse();
+
+      if (existingBackups.length >= 5) {
+        existingBackups.slice(5).forEach(key => {
+          localStorage.removeItem(key);
+        });
+      }
+
+      localStorage.setItem(backupKey, backup);
+      console.log('📋 Project backup created:', backupKey);
+
+    } catch (error) {
+      console.warn('Failed to create backup:', error);
+    }
+  }
+
+  // Recuperar backups disponibles
+  static getAvailableBackups(): { key: string; timestamp: Date; name: string }[] {
+    const backups: { key: string; timestamp: Date; name: string }[] = [];
+
+    Object.keys(localStorage)
+      .filter(key => key.startsWith('crealab_backup_'))
+      .forEach(key => {
+        try {
+          const data = JSON.parse(localStorage.getItem(key) || '');
+          const timestamp = new Date(data.timestamp);
+          const name = data.project?.name || 'Unknown Project';
+
+          backups.push({ key, timestamp, name });
+        } catch (error) {
+          console.warn(`Invalid backup: ${key}`);
+        }
+      });
+
+    return backups.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+  }
+
+  // Recuperar backup específico
+  static restoreBackup(backupKey: string): CreaLabProject {
+    const backup = localStorage.getItem(backupKey);
+    if (!backup) {
+      throw new Error('Backup not found');
+    }
+
+    return this.deserialize(backup);
+  }
+}
+

--- a/src/crealab/types/CrealabTypes.ts
+++ b/src/crealab/types/CrealabTypes.ts
@@ -222,6 +222,9 @@ export interface CreaLabProject {
   oldTracks?: Track[];
 }
 
+// Tipos de formato para exportar proyectos
+export type ProjectExportFormat = 'json' | 'preset' | 'ableton';
+
 
 // === MIDI SYSTEM TYPES ===
 export interface MidiDevice {

--- a/src/crealab/utils/JsonValidator.ts
+++ b/src/crealab/utils/JsonValidator.ts
@@ -1,0 +1,214 @@
+import { CreaLabProject, GenerativeTrack } from '../types/CrealabTypes';
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+export class JsonValidator {
+  // Validar proyecto completo
+  static validateProject(project: any): ValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    // Validaciones básicas
+    if (!project.id) errors.push('Project ID is required');
+    if (!project.name) errors.push('Project name is required');
+    if (!project.tracks || !Array.isArray(project.tracks)) {
+      errors.push('Project must have tracks array');
+    } else if (project.tracks.length !== 8) {
+      errors.push('Project must have exactly 8 tracks');
+    }
+
+    // Validar tempo
+    if (typeof project.globalTempo !== 'number' || project.globalTempo < 60 || project.globalTempo > 200) {
+      warnings.push('Global tempo should be between 60-200 BPM');
+    }
+
+    // Validar tracks
+    if (project.tracks && Array.isArray(project.tracks)) {
+      project.tracks.forEach((track: any, index: number) => {
+        const trackErrors = this.validateTrack(track, index + 1);
+        errors.push(...trackErrors.errors);
+        warnings.push(...trackErrors.warnings);
+      });
+    }
+
+    // Validar configuración de transporte
+    if (project.transport) {
+      const transportErrors = this.validateTransport(project.transport);
+      errors.push(...transportErrors.errors);
+      warnings.push(...transportErrors.warnings);
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+      warnings
+    };
+  }
+
+  // Validar track individual
+  private static validateTrack(track: any, trackNumber: number): ValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const prefix = `Track ${trackNumber}:`;
+
+    // Campos requeridos
+    if (!track.id) errors.push(`${prefix} ID is required`);
+    if (!track.name) errors.push(`${prefix} Name is required`);
+    if (typeof track.trackNumber !== 'number' || track.trackNumber !== trackNumber) {
+      errors.push(`${prefix} Track number should be ${trackNumber}`);
+    }
+
+    // Validar canal MIDI
+    if (typeof track.midiChannel !== 'number' || track.midiChannel < 1 || track.midiChannel > 16) {
+      errors.push(`${prefix} MIDI channel must be between 1-16`);
+    }
+
+    // Validar generador
+    if (!track.generator) {
+      errors.push(`${prefix} Generator configuration is required`);
+    } else {
+      const genErrors = this.validateGenerator(track.generator, trackNumber);
+      errors.push(...genErrors.errors);
+      warnings.push(...genErrors.warnings);
+    }
+
+    // Validar controles
+    if (!track.controls) {
+      errors.push(`${prefix} Controls configuration is required`);
+    } else {
+      const controlErrors = this.validateControls(track.controls, trackNumber);
+      errors.push(...controlErrors.errors);
+      warnings.push(...controlErrors.warnings);
+    }
+
+    // Validar mapeo de Launch Control
+    if (!track.launchControlMapping) {
+      warnings.push(`${prefix} Launch Control mapping is missing`);
+    }
+
+    return { valid: errors.length === 0, errors, warnings };
+  }
+
+  // Validar generador
+  private static validateGenerator(generator: any, trackNumber: number): ValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const prefix = `Track ${trackNumber} Generator:`;
+
+    const validTypes = ['off', 'euclidean', 'probabilistic', 'markov', 'arpeggiator', 'chaos'];
+    if (!validTypes.includes(generator.type)) {
+      errors.push(`${prefix} Invalid generator type '${generator.type}'`);
+    }
+
+    if (typeof generator.enabled !== 'boolean') {
+      warnings.push(`${prefix} 'enabled' should be boolean`);
+    }
+
+    if (!generator.parameters || typeof generator.parameters !== 'object') {
+      warnings.push(`${prefix} Parameters should be an object`);
+    }
+
+    return { valid: errors.length === 0, errors, warnings };
+  }
+
+  // Validar controles
+  private static validateControls(controls: any, trackNumber: number): ValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const prefix = `Track ${trackNumber} Controls:`;
+
+    const requiredControls = ['intensity', 'paramA', 'paramB', 'paramC', 'playStop', 'mode'];
+
+    requiredControls.forEach(control => {
+      if (!(control in controls)) {
+        errors.push(`${prefix} Missing control '${control}'`);
+      }
+    });
+
+    // Validar rangos
+    ['intensity', 'paramA', 'paramB', 'paramC'].forEach(control => {
+      const value = controls[control];
+      if (typeof value === 'number' && (value < 0 || value > 127)) {
+        warnings.push(`${prefix} ${control} should be between 0-127`);
+      }
+    });
+
+    return { valid: errors.length === 0, errors, warnings };
+  }
+
+  // Validar configuración de transporte
+  private static validateTransport(transport: any): ValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    const requiredFields = ['isPlaying', 'isPaused', 'currentBeat', 'currentBar', 'currentStep'];
+
+    requiredFields.forEach(field => {
+      if (!(field in transport)) {
+        warnings.push(`Transport: Missing field '${field}'`);
+      }
+    });
+
+    return { valid: errors.length === 0, errors, warnings };
+  }
+
+  // Validar archivo antes de importar
+  static validateImportFile(fileContent: string): ValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    try {
+      const data = JSON.parse(fileContent);
+
+      // Verificar que es un archivo de Crea Lab
+      if (!data.project && !data.id) {
+        errors.push('File does not appear to be a valid Crea Lab project');
+        return { valid: false, errors, warnings };
+      }
+
+      // Validar estructura del proyecto
+      const projectData = data.project || data;
+      return this.validateProject(projectData);
+
+    } catch (error: any) {
+      errors.push(`Invalid JSON format: ${error.message}`);
+      return { valid: false, errors, warnings };
+    }
+  }
+
+  // Sanitizar datos de entrada
+  static sanitizeProject(project: any): any {
+    const sanitized = JSON.parse(JSON.stringify(project));
+
+    // Limpiar campos potencialmente problemáticos
+    if (sanitized.tracks) {
+      sanitized.tracks.forEach((track: any) => {
+        // Asegurar que los controles están en rango válido
+        if (track.controls) {
+          ['intensity', 'paramA', 'paramB', 'paramC'].forEach(control => {
+            if (typeof track.controls[control] === 'number') {
+              track.controls[control] = Math.max(0, Math.min(127, track.controls[control]));
+            }
+          });
+        }
+
+        // Validar canal MIDI
+        if (track.midiChannel) {
+          track.midiChannel = Math.max(1, Math.min(16, track.midiChannel));
+        }
+      });
+    }
+
+    // Validar tempo global
+    if (sanitized.globalTempo) {
+      sanitized.globalTempo = Math.max(60, Math.min(200, sanitized.globalTempo));
+    }
+
+    return sanitized;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add JSON validator for project structure
- serialize/deserialize projects with backup support
- integrate project manager UI for import/export

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'vite/client')*


------
https://chatgpt.com/codex/tasks/task_e_68aa07cf07388333acf9fc40b9e11862