### PR TITLE
Add Magenta.js generator for tracks

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tauri-apps/api": "^1.5.0",
     "@types/three": "^0.179.0",
     "ajv": "^8.17.1",
+    "@magenta/music": "^1.23.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-grid-layout": "^1.3.4",

--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -289,6 +289,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
                     <option value="markov">Markov</option>
                     <option value="arpeggiator">Arpeggiator</option>
                     <option value="chaos">Chaos</option>
+                    <option value="magenta">Magenta</option>
                   </select>
                 </div>
 

--- a/src/crealab/core/GeneratorEngine.ts
+++ b/src/crealab/core/GeneratorEngine.ts
@@ -4,6 +4,7 @@ import { ProbabilisticGenerator } from '../generators/ProbabilisticGenerator';
 import { MarkovGenerator } from '../generators/MarkovGenerator';
 import { ArpeggiatorGenerator } from '../generators/ArpeggiatorGenerator';
 import { ChaosGenerator } from '../generators/ChaosGenerator';
+import { MagentaGenerator } from '../generators/MagentaGenerator';
 import { LSystemGenerator } from '../generators/advanced/LSystemGenerator';
 import { CellularAutomataGenerator } from '../generators/advanced/CellularAutomataGenerator';
 import { NeuralNetworkGenerator } from '../generators/advanced/NeuralNetworkGenerator';
@@ -47,6 +48,7 @@ export class GeneratorEngine {
     this.generators.set('markov', new MarkovGenerator());
     this.generators.set('arpeggiator', new ArpeggiatorGenerator());
     this.generators.set('chaos', new ChaosGenerator());
+    this.generators.set('magenta', new MagentaGenerator());
     this.generators.set('lsystem', new LSystemGenerator());
     this.generators.set('cellular', new CellularAutomataGenerator());
     this.generators.set('neural', new NeuralNetworkGenerator());
@@ -256,6 +258,9 @@ export class GeneratorEngine {
         break;
       case 'chaos':
         track.generator.parameters = { attractor: 'lorenz', sensitivity: 0.5, scaling: 1.0 };
+        break;
+      case 'magenta':
+        track.generator.parameters = { steps: 32, temperature: 1.0 };
         break;
       case 'lsystem':
         track.generator.parameters = { rules: { A: 'AB', B: 'A' } };

--- a/src/crealab/generators/MagentaGenerator.ts
+++ b/src/crealab/generators/MagentaGenerator.ts
@@ -1,0 +1,82 @@
+import { GeneratorInstance } from '../core/GeneratorEngine';
+import { GenerativeTrack, MidiNote } from '../types/CrealabTypes';
+import * as mm from '@magenta/music';
+
+export class MagentaGenerator implements GeneratorInstance {
+  private rnn: mm.MusicRNN;
+  private loaded = false;
+  private sequence: mm.INoteSequence | null = null;
+  private generating = false;
+  private step = 0;
+
+  constructor() {
+    this.rnn = new mm.MusicRNN(
+      'https://storage.googleapis.com/magentadata/js/checkpoints/music_rnn/basic_rnn'
+    );
+    this.rnn.initialize().then(() => (this.loaded = true));
+  }
+
+  generate(
+    track: GenerativeTrack,
+    currentTime: number,
+    globalTempo: number,
+    key: string,
+    scale: string
+  ): MidiNote[] {
+    if (!track.controls.playStop || !this.loaded) return [];
+
+    const params = track.generator.parameters;
+    const steps = (params.steps as number) || 32;
+    const temperature = (params.temperature as number) || 1.0;
+
+    if (!this.sequence && !this.generating) {
+      this.generating = true;
+      const seed: mm.INoteSequence = { notes: [], totalTime: 0 };
+      this.rnn
+        .continueSequence(seed, steps, temperature)
+        .then(seq => {
+          this.sequence = mm.sequences.quantizeNoteSequence(seq, 4);
+          this.generating = false;
+          this.step = 0;
+        })
+        .catch(() => {
+          this.generating = false;
+        });
+      return [];
+    }
+
+    if (!this.sequence) return [];
+
+    const notes: MidiNote[] = [];
+    const quantStep = this.step;
+
+    this.sequence.notes.forEach(n => {
+      if (n.quantizedStartStep === quantStep) {
+        const durationSteps = n.quantizedEndStep - n.quantizedStartStep;
+        notes.push({
+          note: n.pitch!,
+          time: currentTime,
+          velocity: n.velocity || 80,
+          duration: durationSteps * 0.25,
+        });
+      }
+    });
+
+    this.step++;
+    if (this.step >= steps) {
+      this.sequence = null;
+      this.step = 0;
+    }
+
+    return notes;
+  }
+
+  updateParameters(track: GenerativeTrack): void {
+    // Parameters handled dynamically in generate
+  }
+
+  reset(): void {
+    this.sequence = null;
+    this.step = 0;
+  }
+}

--- a/src/crealab/types/CrealabTypes.ts
+++ b/src/crealab/types/CrealabTypes.ts
@@ -21,6 +21,7 @@ export type GeneratorType =
   | 'cellular'      // Autómatas celulares
   | 'lsystem'       // L-Systems fractales
   | 'neural'        // Redes neuronales simples
+  | 'magenta'       // Generador basado en Magenta.js
   | 'off';          // Desactivado
 
 // Parámetros base para generadores

--- a/src/crealab/types/GeneratorTypes.ts
+++ b/src/crealab/types/GeneratorTypes.ts
@@ -9,7 +9,8 @@ export type GeneratorType =
   | 'chaos'           // Sistemas caóticos
   | 'cellular'        // Autómatas celulares
   | 'lsystem'        // L-Systems fractales
-  | 'neural';        // Redes neuronales simples
+  | 'neural'        // Redes neuronales simples
+  | 'magenta';      // Generador basado en Magenta.js
 
 export interface MidiGenerator {
   id: string;


### PR DESCRIPTION
## Summary
- add Magenta-based generator with sequence support
- expose Magenta generator option across track UI
- register Magenta generator in engine and types

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@magenta%2fmusic)*
- `npm test` *(fails: Missing script: "test" )*


------
https://chatgpt.com/codex/tasks/task_e_68aa0c4c4bc48333b821907597b161b3