### PR TITLE
Refactor Crea Lab tracks and session controls

### DIFF
--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -23,32 +23,14 @@
 
 .track-strip {
   background: linear-gradient(135deg, #1e1e1e 0%, #2a2a2a 100%);
-  border: 2px solid var(--track-color, #444);
+  border: 2px solid #444;
   border-radius: 8px;
   padding: 8px;
   display: flex;
   flex-direction: column;
   gap: 6px;
-  transition: all 0.3s ease;
   position: relative;
   overflow: hidden;
-}
-
-.track-strip::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: var(--track-color, #444);
-  opacity: 0.8;
-}
-
-.track-strip:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.4);
-  border-color: var(--track-color);
 }
 
 /* TRACK HEADER */
@@ -60,7 +42,7 @@
 }
 
 .track-number {
-  background: var(--track-color, #444);
+  background: #444;
   color: black;
   font-weight: bold;
   padding: 2px 4px;
@@ -83,7 +65,7 @@
 
 .track-name-input:focus {
   outline: none;
-  border-color: var(--track-color, #666);
+  border-color: #666;
   background: rgba(255, 255, 255, 0.15);
 }
 

--- a/src/crealab/components/GeneratorControls.tsx
+++ b/src/crealab/components/GeneratorControls.tsx
@@ -37,9 +37,6 @@ export const GeneratorControls: React.FC<Props> = ({ track, onChange }) => {
           onChange={handleNumber('paramC')} />
       </div>
       <div className="control-row buttons">
-        <button onClick={() => onChange({ playStop: !track.controls.playStop })}>
-          {track.controls.playStop ? 'Stop' : 'Play'}
-        </button>
         <button onClick={() => onChange({ mode: (track.controls.mode + 1) % 6 })}>
           Cycle Generator
         </button>

--- a/src/crealab/components/TopBar.css
+++ b/src/crealab/components/TopBar.css
@@ -3,9 +3,21 @@
   border-bottom: 1px solid #444;
   padding: 8px 12px;
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  min-height: 40px;
+  gap: 10px;
+}
+
+.topbar-left,
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.topbar-center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
 }
 
 .topbar-title {
@@ -60,20 +72,22 @@
   width: 50px;
 }
 
-.switch-app-btn {
-  background: linear-gradient(45deg, #2196F3, #21CBF3);
-  border: none;
-  color: white;
-  padding: 4px 8px;
-  border-radius: 6px;
+.icon-btn,
+.switch-app-btn,
+.play-btn {
+  background: #3a3a3a;
+  border: 1px solid #555;
+  color: #fff;
+  padding: 4px 6px;
+  border-radius: 4px;
   cursor: pointer;
   font-size: 0.8rem;
-  font-weight: 500;
-  transition: all 0.2s ease;
+  transition: background 0.2s;
 }
 
-.switch-app-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(33, 150, 243, 0.3);
+.icon-btn:hover,
+.switch-app-btn:hover,
+.play-btn:hover {
+  background: #4a4a4a;
 }
 

--- a/src/crealab/components/TopBar.tsx
+++ b/src/crealab/components/TopBar.tsx
@@ -8,6 +8,10 @@ interface TopBarProps {
   keySignature: string;
   onKeyChange: (key: string) => void;
   onSwitchToAudioVisualizer: () => void;
+  onOpenMidiConfig: () => void;
+  onOpenProjectManager: () => void;
+  isPlaying: boolean;
+  onPlayToggle: () => void;
 }
 
 export const TopBar: React.FC<TopBarProps> = ({
@@ -16,40 +20,52 @@ export const TopBar: React.FC<TopBarProps> = ({
   onTempoChange,
   keySignature,
   onKeyChange,
-  onSwitchToAudioVisualizer
+  onSwitchToAudioVisualizer,
+  onOpenMidiConfig,
+  onOpenProjectManager,
+  isPlaying,
+  onPlayToggle
 }) => {
   return (
     <header className="topbar-container">
-      <div className="topbar-title">
-        <h1>🎼 Crea Lab</h1>
-        <span className="project-name">{projectName}</span>
+      <div className="topbar-left">
+        <div className="topbar-title">
+          <h1>🎼 Crea Lab</h1>
+          <span className="project-name">{projectName}</span>
+        </div>
+        <button className="icon-btn" onClick={onOpenMidiConfig} title="MIDI Config">🎛️</button>
+        <button className="icon-btn" onClick={onOpenProjectManager} title="Projects">📁</button>
       </div>
 
-      <div className="topbar-controls">
-        <div className="global-settings">
-          <label>
-            BPM:
-            <input
-              type="number"
-              value={tempo}
-              min={60}
-              max={200}
-              onChange={e => onTempoChange(parseInt(e.target.value) || 0)}
-            />
-          </label>
-          <label>
-            Key:
-            <select value={keySignature} onChange={e => onKeyChange(e.target.value)}>
-              {['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'].map(k => (
-                <option key={k} value={k}>{k}</option>
-              ))}
-            </select>
-          </label>
-        </div>
+      <div className="topbar-center">
+        <button className="play-btn" onClick={onPlayToggle}>{isPlaying ? '⏹️' : '▶️'}</button>
+      </div>
 
-        <button onClick={onSwitchToAudioVisualizer} className="switch-app-btn">
-          🎨 AudioVisualizer
-        </button>
+      <div className="topbar-right">
+        <div className="topbar-controls">
+          <div className="global-settings">
+            <label>
+              BPM:
+              <input
+                type="number"
+                value={tempo}
+                min={60}
+                max={200}
+                onChange={e => onTempoChange(parseInt(e.target.value) || 0)}
+              />
+            </label>
+            <label>
+              Key:
+              <select value={keySignature} onChange={e => onKeyChange(e.target.value)}>
+                {['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'].map(k => (
+                  <option key={k} value={k}>{k}</option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <button onClick={onSwitchToAudioVisualizer} className="switch-app-btn">🎨</button>
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- Simplify track visuals with uniform dark borders and no hover bump
- Replace instrument field with MIDI input/output selectors on each track
- Centralize session play control and move project/MIDI buttons to top bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: sh: 1: tauri: not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68aa10ead5848333a34a19941adb4b58