### PR TITLE
feat: persist session and refine track controls

### DIFF
--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -17,20 +17,21 @@
 .tracks-grid {
   display: grid;
   grid-template-columns: repeat(8, 1fr);
-  gap: 0;
+  gap: 1px;
   height: calc(100vh - 140px); /* Ajustar según TopBar + Footer */
 }
 
 .track-strip {
   background: linear-gradient(135deg, #1e1e1e 0%, #2a2a2a 100%);
-  border: 2px solid #444;
-  border-radius: 8px;
+  border: 1px solid #444;
+  border-radius: 0;
   padding: 8px;
   display: flex;
   flex-direction: column;
   gap: 6px;
   position: relative;
   overflow: hidden;
+  box-sizing: border-box;
 }
 
 /* TRACK HEADER */
@@ -77,11 +78,6 @@
   gap: 6px;
 }
 
-.midi-config {
-  display: flex;
-  gap: 4px;
-}
-
 .device-selector,
 .channel-selector,
 .generator-selector,
@@ -97,14 +93,16 @@
 
 .device-selector {
   flex: 2;
+  width: 100%;
 }
 
 .channel-selector {
   flex: 1;
 }
 
-.generator-config {
-  margin-top: 4px;
+.output-row {
+  display: flex;
+  gap: 4px;
 }
 
 .generator-selector {
@@ -126,7 +124,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-top: 10px;
 }
 
 .lc-controls {
@@ -135,7 +132,7 @@
   gap: 12px;
   background: rgba(0, 0, 0, 0.3);
   padding: 10px;
-  border-radius: 8px;
+  border-radius: 4px;
   border: 1px solid #333;
 }
 
@@ -154,7 +151,7 @@
   align-items: center;
   justify-content: center;
   position: relative;
-  cursor: pointer;
+  cursor: ns-resize;
 }
 
 .knob-value {
@@ -244,6 +241,19 @@
   letter-spacing: 0.5px;
 }
 
+.section-divider {
+  border-top: 1px solid #333;
+  margin: 4px 0;
+}
+
+.section-title {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #bbb;
+  margin-bottom: 4px;
+}
+
 .generator-status.active {
   background: var(--track-color, #666);
   color: black;
@@ -327,28 +337,5 @@
 
 .pattern-step.active {
   background: var(--track-color, #fff);
-}
-
-/* GENERATOR CONTROLS */
-.generator-controls {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-top: 10px;
-}
-
-.generator-controls .control-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.generator-controls .control-row label {
-  width: 70px;
-  font-size: 12px;
-}
-
-.generator-controls .buttons {
-  justify-content: space-between;
 }
 


### PR DESCRIPTION
## Summary
- persist CreaLab project state to disk and restore on launch
- redesign track layout with squared styling and organized sections
- integrate LaunchControl visuals as MIDI parameter controls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: tauri not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa144e84f48333a492d57f46e46139