### PR TITLE
Fix device selector height in Crea Lab

### DIFF
--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -95,8 +95,13 @@
 }
 
 .device-selector {
-  flex: 2;
   width: 100%;
+  flex: none;
+}
+
+.output-row .device-selector {
+  flex: 2;
+  width: auto;
 }
 
 .channel-selector {


### PR DESCRIPTION
## Summary
- Prevent track MIDI device selectors from stretching vertically
- Ensure output-row device selectors maintain layout without affecting height

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa1b0ae9788333a7335bfc9a334132