### PR TITLE
feat: integrate generators with midi and launch control

### DIFF
--- a/src/crealab/components/LaunchControlStrip.tsx
+++ b/src/crealab/components/LaunchControlStrip.tsx
@@ -4,9 +4,10 @@ import './LaunchControlVisualizer.css';
 
 interface Props {
   strip: ChannelStrip | null;
+  labels?: [string, string, string];
 }
 
-const LaunchControlStrip: React.FC<Props> = ({ strip }) => {
+const LaunchControlStrip: React.FC<Props> = ({ strip, labels }) => {
   if (!strip) {
     return <div className="lcx-strip lcx-disconnected">No strip</div>;
   }
@@ -14,9 +15,18 @@ const LaunchControlStrip: React.FC<Props> = ({ strip }) => {
   return (
     <div className="lcx-strip">
       <div className="lcx-knobs">
-        <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob1 }} />
-        <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob2 }} />
-        <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob3 }} />
+        <div className="lcx-knob-wrapper">
+          <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob1 }} />
+          <div className="lcx-knob-label">{labels?.[0]}</div>
+        </div>
+        <div className="lcx-knob-wrapper">
+          <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob2 }} />
+          <div className="lcx-knob-label">{labels?.[1]}</div>
+        </div>
+        <div className="lcx-knob-wrapper">
+          <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob3 }} />
+          <div className="lcx-knob-label">{labels?.[2]}</div>
+        </div>
       </div>
       <div className="lcx-fader">
         <div

--- a/src/crealab/components/LaunchControlVisualizer.css
+++ b/src/crealab/components/LaunchControlVisualizer.css
@@ -24,6 +24,19 @@
   gap: 4px;
 }
 
+.lcx-knob-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.lcx-knob-label {
+  margin-top: 2px;
+  font-size: 8px;
+  color: #ccc;
+  text-align: center;
+}
+
 .lcx-knob {
   width: 20px;
   height: 20px;

--- a/src/crealab/core/SessionMidiController.ts
+++ b/src/crealab/core/SessionMidiController.ts
@@ -1,5 +1,4 @@
 import { SessionMidiController, ChannelStrip } from '../types/GeneratorTypes';
-import { LegacyGeneratorEngine } from './LegacyGeneratorEngine';
 
 export class SessionMidiManager {
   private static instance: SessionMidiManager;
@@ -160,15 +159,12 @@ export class SessionMidiManager {
         break;
       case 'knob1':
         strip.values.knob1 = value;
-        this.updateGenerator(strip, 'density', value / 127);
         break;
       case 'knob2':
         strip.values.knob2 = value;
-        this.updateGenerator(strip, 'probability', value / 127);
         break;
       case 'knob3':
         strip.values.knob3 = value;
-        this.updateGenerator(strip, 'velocity', value / 127);
         break;
       case 'button1':
         strip.values.button1 = value > 0;
@@ -186,12 +182,6 @@ export class SessionMidiManager {
     if (!control) return;
     control.value = value;
     this.emitUpdate();
-  }
-  
-  private updateGenerator(strip: ChannelStrip, control: string, value: number) {
-    const trackId = this.trackMapping.get(strip.stripIndex);
-    if (!trackId) return;
-    LegacyGeneratorEngine.getInstance().updateGeneratorControl(trackId, control, value);
   }
   
   // Mapear un track a un strip específico

--- a/src/crealab/generators/ArpeggiatorGenerator.ts
+++ b/src/crealab/generators/ArpeggiatorGenerator.ts
@@ -12,10 +12,11 @@ export class ArpeggiatorGenerator implements GeneratorInstance {
     key: string,
     scale: string
   ): MidiNote[] {
-    const params = track.generator.parameters;
-    const pattern = params.pattern || 'up';
-    const octaves = params.octaves || 1;
-    const noteLength = params.noteLength || 0.25;
+    // Map real-time controls to parameters
+    const patternIndex = Math.floor((track.controls.paramA / 127) * 4);
+    const pattern = ['up', 'down', 'upDown', 'random'][patternIndex] || 'up';
+    const octaves = Math.max(1, Math.floor((track.controls.paramB / 127) * 4));
+    const noteLength = 0.1 + (track.controls.paramC / 127) * 0.9;
 
     const scaleNotes = getScaleNotes(key, scale);
     const sequence = this.buildSequence(scaleNotes, pattern, octaves);

--- a/src/crealab/generators/ChaosGenerator.ts
+++ b/src/crealab/generators/ChaosGenerator.ts
@@ -14,11 +14,11 @@ export class ChaosGenerator implements GeneratorInstance {
     key: string,
     scale: string
   ): MidiNote[] {
-    const params = track.generator.parameters;
-    const attractor = params.attractor || 'lorenz';
-    const sensitivity = params.sensitivity || 0.5;
-    const scaling = params.scaling || 1.0;
     const intensity = track.controls.intensity / 127;
+    const sensitivity = track.controls.paramA / 127;
+    const scaling = 0.5 + (track.controls.paramB / 127) * 1.5;
+    const attractorIndex = Math.floor((track.controls.paramC / 127) * 3);
+    const attractor = ['lorenz', 'henon', 'logistic'][attractorIndex] || 'lorenz';
 
     const scaleNotes = getScaleNotes(key, scale);
 

--- a/src/crealab/generators/MagentaGenerator.ts
+++ b/src/crealab/generators/MagentaGenerator.ts
@@ -25,9 +25,9 @@ export class MagentaGenerator implements GeneratorInstance {
   ): MidiNote[] {
     if (!track.controls.playStop || !this.loaded) return [];
 
-    const params = track.generator.parameters;
-    const steps = (params.steps as number) || 32;
-    const temperature = (params.temperature as number) || 1.0;
+    const steps = Math.max(1, Math.floor((track.controls.paramA / 127) * 64));
+    const temperature = 0.1 + (track.controls.paramB / 127) * 1.9;
+    const density = track.controls.paramC / 127;
 
     if (!this.sequence && !this.generating) {
       this.generating = true;
@@ -51,12 +51,16 @@ export class MagentaGenerator implements GeneratorInstance {
     const quantStep = this.step;
 
     this.sequence.notes.forEach(n => {
-      if (n.quantizedStartStep === quantStep) {
+      if (n.quantizedStartStep === quantStep && Math.random() < density) {
         const durationSteps = n.quantizedEndStep - n.quantizedStartStep;
+        const velocity = Math.max(
+          1,
+          Math.floor((n.velocity || 80) * (track.controls.intensity / 127))
+        );
         notes.push({
           note: n.pitch!,
           time: currentTime,
-          velocity: n.velocity || 80,
+          velocity,
           duration: durationSteps * 0.25,
         });
       }

--- a/src/crealab/generators/MarkovGenerator.ts
+++ b/src/crealab/generators/MarkovGenerator.ts
@@ -18,9 +18,9 @@ export class MarkovGenerator implements GeneratorInstance {
     scale: string
   ): MidiNote[] {
     const notes: MidiNote[] = [];
-    const params = track.generator.parameters;
-    const order = Math.max(1, params.order || 1);
-    const creativity = params.creativity || 0.5;
+    const order = Math.max(1, Math.floor((track.controls.paramA / 127) * 4));
+    const creativity = track.controls.paramB / 127;
+    const density = track.controls.paramC / 127;
     const intensity = track.controls.intensity / 127;
 
     const scaleNotes = getScaleNotes(key, scale);
@@ -30,8 +30,8 @@ export class MarkovGenerator implements GeneratorInstance {
       this.train(scaleNotes);
     }
 
-    // Probability to trigger
-    if (Math.random() > intensity) {
+    // Probability to trigger based on intensity and density
+    if (Math.random() > intensity * density) {
       return notes;
     }
 


### PR DESCRIPTION
## Summary
- show generator-specific knob labels for LaunchControl XL
- route track state into GeneratorEngine to send MIDI notes
- add real-time parameter control for Arpeggiator, Markov, Chaos, and Magenta generators

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa1c6ff7088333954f3eccdf0277d9