### PR TITLE
feat: eurorack-style modules for CreaLab

### DIFF
--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -22,16 +22,30 @@
 }
 
 .track-strip {
-  background: linear-gradient(135deg, #1e1e1e 0%, #2a2a2a 100%);
-  border: 1px solid #444;
-  border-radius: 0;
-  padding: 8px;
+  background: linear-gradient(180deg, #e0e0e0 0%, #bfbfbf 100%);
+  border: 2px solid #555;
+  border-radius: 8px;
+  padding: 10px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
   position: relative;
   overflow: hidden;
   box-sizing: border-box;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.5);
+  color: #111;
+}
+
+.track-strip::before {
+  content: '';
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #333;
+  top: 4px;
+  left: 4px;
+  box-shadow: calc(100% - 12px) 0 0 #333, 0 calc(100% - 12px) 0 #333, calc(100% - 12px) calc(100% - 12px) 0 #333;
 }
 
 /* TRACK HEADER */
@@ -55,9 +69,9 @@
 
 .track-name-input {
   flex: 1;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid #444;
-  color: white;
+  background: rgba(0, 0, 0, 0.05);
+  border: 1px solid #888;
+  color: #111;
   padding: 4px 6px;
   border-radius: 4px;
   font-size: 12px;
@@ -66,8 +80,8 @@
 
 .track-name-input:focus {
   outline: none;
-  border-color: #666;
-  background: rgba(255, 255, 255, 0.15);
+  border-color: #555;
+  background: rgba(0, 0, 0, 0.1);
 }
 
 /* TRACK CONTROLS */
@@ -82,9 +96,9 @@
 .channel-selector,
 .generator-selector,
 .track-type-selector {
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid #444;
-  color: white;
+  background: rgba(0, 0, 0, 0.05);
+  border: 1px solid #888;
+  color: #111;
   padding: 2px 4px;
   border-radius: 4px;
   font-size: 10px;
@@ -139,7 +153,7 @@
 }
 
 .section-divider {
-  border-top: 1px solid #333;
+  border-top: 1px solid #aaa;
   margin: 4px 0;
 }
 
@@ -147,7 +161,7 @@
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: #bbb;
+  color: #444;
   margin-bottom: 4px;
 }
 
@@ -157,8 +171,8 @@
 }
 
 .generator-status.inactive {
-  background: #333;
-  color: #888;
+  background: #ddd;
+  color: #777;
 }
 
 /* FOOTER */

--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -10,6 +10,7 @@ import MidiConfiguration from './MidiConfiguration';
 import ProjectManager from './ProjectManager';
 import './CreaLab.css';
 import { GeneratorEngine } from '../core/GeneratorEngine';
+import { MODULE_KNOB_LABELS, EURORACK_MODULES } from '../data/EurorackModules';
 
 interface CreaLabProps {
   onSwitchToAudioVisualizer: () => void;
@@ -37,15 +38,6 @@ const DEFAULT_TRACK_TYPES: TrackType[] = [
   'lead'
 ];
 
-const KNOB_LABELS: Record<GeneratorType, [string, string, string]> = {
-  off: ['Param A', 'Param B', 'Param C'],
-  euclidean: ['Pulses', 'Steps', 'Offset'],
-  probabilistic: ['Density', 'Variation', 'Swing'],
-  markov: ['Order', 'Creativity', 'Density'],
-  arpeggiator: ['Pattern', 'Octaves', 'Length'],
-  chaos: ['Sensitivity', 'Scaling', 'Attractor'],
-  magenta: ['Steps', 'Temp', 'Density']
-};
 
 const createDefaultTrack = (n: number): GenerativeTrack => ({
   id: `track-${n}`,
@@ -403,7 +395,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
                 <div className="section-title">Controles MIDI</div>
                 <LaunchControlStrip
                   strip={controller?.channelStrips[track.trackNumber - 1] || null}
-                  labels={KNOB_LABELS[track.generator.type]}
+                  labels={MODULE_KNOB_LABELS[track.trackType]}
                 />
 
                 <div className="section-divider" />
@@ -415,13 +407,9 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
                     updateTrackType(track.trackNumber, e.target.value as TrackType)
                   }
                 >
-                  <option value="kick">Kick</option>
-                  <option value="bass">Bass</option>
-                  <option value="arp">Arp</option>
-                  <option value="lead">Lead</option>
-                  <option value="fx">FX</option>
-                  <option value="perc">Perc</option>
-                  <option value="visual">Visual</option>
+                  {EURORACK_MODULES.map(m => (
+                    <option key={m.id} value={m.id}>{m.name}</option>
+                  ))}
                 </select>
 
                 <select

--- a/src/crealab/components/LaunchControlVisualizer.css
+++ b/src/crealab/components/LaunchControlVisualizer.css
@@ -13,10 +13,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding: 4px;
-  background: #1e1e1e;
-  border-radius: 4px;
+  gap: 8px;
+  padding: 8px;
+  background: linear-gradient(180deg, #d8d8d8 0%, #bdbdbd 100%);
+  border: 2px solid #444;
+  border-radius: 6px;
+  position: relative;
 }
 
 .lcx-knobs {
@@ -28,21 +30,22 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 4px;
 }
 
 .lcx-knob-label {
-  margin-top: 2px;
-  font-size: 8px;
-  color: #ccc;
+  font-size: 10px;
+  color: #111;
   text-align: center;
 }
 
 .lcx-knob {
-  width: 20px;
-  height: 20px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
-  background: #555;
+  background: radial-gradient(circle at 30% 30%, #fafafa, #b5b5b5);
   position: relative;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.4);
 }
 
 .lcx-knob::after {
@@ -50,9 +53,9 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 2px;
-  height: 8px;
-  background: #eee;
+  width: 3px;
+  height: 12px;
+  background: #333;
   transform-origin: bottom center;
   transform: translate(-50%, -100%) rotate(calc((var(--value, 0) / 127) * 270deg - 135deg));
 }

--- a/src/crealab/data/EurorackModules.ts
+++ b/src/crealab/data/EurorackModules.ts
@@ -1,0 +1,66 @@
+import type { TrackType } from '../types/CrealabTypes';
+
+export interface EurorackModule {
+  id: TrackType;
+  name: string;
+  description: string;
+  controls: [string, string, string];
+}
+
+export const EURORACK_MODULES: EurorackModule[] = [
+  {
+    id: 'arp',
+    name: 'ARP Sequencer',
+    description: 'Secuenciador rítmico/melódico para líneas repetitivas.',
+    controls: ['Ritmo', 'Patrón', 'Swing']
+  },
+  {
+    id: 'lead',
+    name: 'Lead Synth',
+    description: 'Sintetizador monofónico para melodías principales.',
+    controls: ['Pitch', 'Timbre', 'Filtro']
+  },
+  {
+    id: 'bass',
+    name: 'Bass Synth',
+    description: 'Generador de bajos con cuerpo y pegada.',
+    controls: ['Cutoff', 'Resonancia', 'Drive']
+  },
+  {
+    id: 'kick',
+    name: 'Kick Drum',
+    description: 'Percusión grave y corta para bombo.',
+    controls: ['Frecuencia', 'Decay', 'Drive']
+  },
+  {
+    id: 'perc',
+    name: 'Snare / Clap',
+    description: 'Percusión media con componente de ruido.',
+    controls: ['Tone', 'Decay', 'Crackle']
+  },
+  {
+    id: 'fx',
+    name: 'FX Noise',
+    description: 'Generador de ruido y efectos.',
+    controls: ['Ruido', 'Modulación', 'Filtro']
+  },
+  {
+    id: 'visual',
+    name: 'Visual',
+    description: 'Control de parámetros visuales.',
+    controls: ['Param A', 'Param B', 'Param C']
+  }
+];
+
+export const MODULE_KNOB_LABELS: Record<TrackType, [string, string, string]> = EURORACK_MODULES.reduce(
+  (acc, m) => {
+    acc[m.id] = m.controls;
+    return acc;
+  },
+  {} as Record<TrackType, [string, string, string]>
+);
+
+export function getModule(id: TrackType) {
+  return EURORACK_MODULES.find(m => m.id === id);
+}
+


### PR DESCRIPTION
## Summary
- define reusable Eurorack module presets with three macro controls each
- drive track type and LaunchControl knob labels from module definitions
- restyle track panels and LaunchControl visualizer to mimic Eurorack modules

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: tauri: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa218c3fcc8333ae997b61a196d559