### PR TITLE
style: dark Crea Lab tracks with metallic generator modules

### DIFF
--- a/src/crealab/components/BassGeneratorControls.tsx
+++ b/src/crealab/components/BassGeneratorControls.tsx
@@ -22,7 +22,10 @@ const BassGeneratorControls: React.FC<Props> = ({ track, onParametersChange }) =
   };
 
   return (
-    <div className="generator-controls">
+    <div className="generator-module">
+      <div className="module-header">
+        <span>Bass Patterns</span>
+      </div>
       <div className="control-row">
         <label>Pattern</label>
         <select value={currentPattern} onChange={handlePatternChange}>

--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -22,7 +22,7 @@
 }
 
 .track-strip {
-  background: linear-gradient(180deg, #e0e0e0 0%, #bfbfbf 100%);
+  background: linear-gradient(180deg, #2c2c2c 0%, #1a1a1a 100%);
   border: 2px solid #555;
   border-radius: 8px;
   padding: 10px;
@@ -33,7 +33,7 @@
   overflow: hidden;
   box-sizing: border-box;
   box-shadow: 0 2px 4px rgba(0,0,0,0.5);
-  color: #111;
+  color: #eee;
 }
 
 .track-strip::before {
@@ -69,9 +69,9 @@
 
 .track-name-input {
   flex: 1;
-  background: rgba(0, 0, 0, 0.05);
-  border: 1px solid #888;
-  color: #111;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid #444;
+  color: #eee;
   padding: 4px 6px;
   border-radius: 4px;
   font-size: 12px;
@@ -80,8 +80,8 @@
 
 .track-name-input:focus {
   outline: none;
-  border-color: #555;
-  background: rgba(0, 0, 0, 0.1);
+  border-color: #777;
+  background: rgba(0, 0, 0, 0.4);
 }
 
 /* TRACK CONTROLS */
@@ -96,9 +96,9 @@
 .channel-selector,
 .generator-selector,
 .track-type-selector {
-  background: rgba(0, 0, 0, 0.05);
-  border: 1px solid #888;
-  color: #111;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid #444;
+  color: #eee;
   padding: 2px 4px;
   border-radius: 4px;
   font-size: 10px;
@@ -153,7 +153,7 @@
 }
 
 .section-divider {
-  border-top: 1px solid #aaa;
+  border-top: 1px solid #333;
   margin: 4px 0;
 }
 
@@ -161,7 +161,7 @@
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: #444;
+  color: #aaa;
   margin-bottom: 4px;
 }
 
@@ -173,6 +173,64 @@
 .generator-status.inactive {
   background: #ddd;
   color: #777;
+}
+
+/* GENERATOR MODULE */
+.generator-module {
+  background: linear-gradient(180deg, #6e6e6e 0%, #4b4b4b 100%);
+  border: 2px solid #888;
+  border-radius: 6px;
+  padding: 8px;
+  box-shadow: inset 0 2px 2px rgba(255,255,255,0.1), inset 0 -2px 2px rgba(0,0,0,0.4);
+  color: #eee;
+  margin-top: 8px;
+}
+
+.generator-module .module-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+  font-size: 11px;
+}
+
+.generator-module .activity-led {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #222;
+  box-shadow: 0 0 4px rgba(0,0,0,0.8);
+}
+
+.generator-module .activity-led.on {
+  background: #0f0;
+  box-shadow: 0 0 6px #0f0;
+}
+
+.generator-module .control-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.generator-module .control-row label {
+  flex: 1;
+  font-size: 10px;
+}
+
+.generator-module .control-row input[type='range'] {
+  flex: 2;
+}
+
+.generator-module .control-display {
+  width: 32px;
+  text-align: right;
+  font-size: 10px;
+  padding: 2px 4px;
+  border-radius: 3px;
+  background: #111;
+  border: 1px solid #333;
 }
 
 /* FOOTER */

--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -6,6 +6,7 @@ import useLaunchControlXL from '../hooks/useLaunchControlXL';
 import { SessionMidiManager } from '../core/SessionMidiController';
 import { useMidiDevices } from '../hooks/useMidiDevices';
 import BassGeneratorControls from './BassGeneratorControls';
+import GeneratorControls from './GeneratorControls';
 import MidiConfiguration from './MidiConfiguration';
 import ProjectManager from './ProjectManager';
 import './CreaLab.css';
@@ -425,6 +426,11 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
                   <option value="chaos">Chaos</option>
                   <option value="magenta">Magenta</option>
                 </select>
+
+                <GeneratorControls
+                  track={track}
+                  onChange={changes => updateTrackControls(track.trackNumber, changes)}
+                />
 
                 {track.trackType === 'bass' && (
                   <BassGeneratorControls

--- a/src/crealab/components/GeneratorControls.tsx
+++ b/src/crealab/components/GeneratorControls.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { GenerativeTrack } from '../types/CrealabTypes';
+import { MODULE_KNOB_LABELS } from '../data/EurorackModules';
 import './CreaLab.css';
 
 interface Props {
@@ -14,32 +15,37 @@ export const GeneratorControls: React.FC<Props> = ({ track, onChange }) => {
       onChange({ [field]: value });
     };
 
+  const labels = MODULE_KNOB_LABELS[track.trackType] || ['Param A', 'Param B', 'Param C'];
+
   return (
-    <div className="generator-controls">
+    <div className="generator-module">
+      <div className="module-header">
+        <span>{track.trackType.toUpperCase()} Module</span>
+        <span className={`activity-led ${track.generator.enabled ? 'on' : ''}`} />
+      </div>
       <div className="control-row">
         <label>Intensity</label>
         <input type="range" min={0} max={127} value={track.controls.intensity}
           onChange={handleNumber('intensity')} />
+        <span className="control-display">{track.controls.intensity}</span>
       </div>
       <div className="control-row">
-        <label>Param A</label>
+        <label>{labels[0]}</label>
         <input type="range" min={0} max={127} value={track.controls.paramA}
           onChange={handleNumber('paramA')} />
+        <span className="control-display">{track.controls.paramA}</span>
       </div>
       <div className="control-row">
-        <label>Param B</label>
+        <label>{labels[1]}</label>
         <input type="range" min={0} max={127} value={track.controls.paramB}
           onChange={handleNumber('paramB')} />
+        <span className="control-display">{track.controls.paramB}</span>
       </div>
       <div className="control-row">
-        <label>Param C</label>
+        <label>{labels[2]}</label>
         <input type="range" min={0} max={127} value={track.controls.paramC}
           onChange={handleNumber('paramC')} />
-      </div>
-      <div className="control-row buttons">
-        <button onClick={() => onChange({ mode: (track.controls.mode + 1) % 6 })}>
-          Cycle Generator
-        </button>
+        <span className="control-display">{track.controls.paramC}</span>
       </div>
     </div>
   );

--- a/src/crealab/data/EurorackModules.ts
+++ b/src/crealab/data/EurorackModules.ts
@@ -12,37 +12,37 @@ export const EURORACK_MODULES: EurorackModule[] = [
     id: 'arp',
     name: 'ARP Sequencer',
     description: 'Secuenciador rítmico/melódico para líneas repetitivas.',
-    controls: ['Ritmo', 'Patrón', 'Swing']
+    controls: ['Transpose', 'Swing', 'Humanize']
   },
   {
     id: 'lead',
     name: 'Lead Synth',
     description: 'Sintetizador monofónico para melodías principales.',
-    controls: ['Pitch', 'Timbre', 'Filtro']
+    controls: ['Transpose', 'Swing', 'Humanize']
   },
   {
     id: 'bass',
     name: 'Bass Synth',
     description: 'Generador de bajos con cuerpo y pegada.',
-    controls: ['Cutoff', 'Resonancia', 'Drive']
+    controls: ['Transpose', 'Swing', 'Humanize']
   },
   {
     id: 'kick',
     name: 'Kick Drum',
     description: 'Percusión grave y corta para bombo.',
-    controls: ['Frecuencia', 'Decay', 'Drive']
+    controls: ['Transpose', 'Swing', 'Humanize']
   },
   {
     id: 'perc',
     name: 'Snare / Clap',
     description: 'Percusión media con componente de ruido.',
-    controls: ['Tone', 'Decay', 'Crackle']
+    controls: ['Transpose', 'Swing', 'Humanize']
   },
   {
     id: 'fx',
     name: 'FX Noise',
     description: 'Generador de ruido y efectos.',
-    controls: ['Ruido', 'Modulación', 'Filtro']
+    controls: ['Transpose', 'Swing', 'Humanize']
   },
   {
     id: 'visual',


### PR DESCRIPTION
## Summary
- Darken Crea Lab track strips for a subdued workspace
- Render generator controls as metallic Eurorack-style modules with LED and value displays
- Label LaunchControl knobs for generative MIDI parameters like transpose, swing and humanize

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: tauri not found)*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68aa2878c3988333b03ad24bd1ccaeed