### PR TITLE
feat: redesign MIDI and generator controls

### DIFF
--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -186,6 +186,14 @@
   margin-top: 8px;
 }
 
+.generator-module.mapping-mode {
+  outline: 1px dashed #4caf50;
+}
+
+.generator-module.mapping-mode .control-row {
+  cursor: pointer;
+}
+
 .generator-module .module-header {
   display: flex;
   align-items: center;
@@ -219,7 +227,7 @@
   font-size: 10px;
 }
 
-.generator-module .control-row input[type='range'] {
+.generator-module .control-row .knob-control {
   flex: 2;
 }
 

--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -80,6 +80,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
   const { inputDevices, outputDevices } = useMidiDevices();
   const [showMidiConfig, setShowMidiConfig] = useState(false);
   const [showProjectManager, setShowProjectManager] = useState(false);
+  const [midiMapping, setMidiMapping] = useState(false);
   const [project, setProject] = useState<CreaLabProject>({
     id: 'project-1',
     name: 'New Project',
@@ -309,6 +310,8 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
             transport: { ...p.transport, isPlaying: !p.transport.isPlaying }
           }))
         }
+        isMidiMapping={midiMapping}
+        onToggleMidiMapping={() => setMidiMapping(m => !m)}
       />
       <main className="crealab-workspace">
         <div className="tracks-grid">
@@ -430,6 +433,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
                 <GeneratorControls
                   track={track}
                   onChange={changes => updateTrackControls(track.trackNumber, changes)}
+                  mappingMode={midiMapping}
                 />
 
                 {track.trackType === 'bass' && (

--- a/src/crealab/components/GeneratorControls.tsx
+++ b/src/crealab/components/GeneratorControls.tsx
@@ -2,49 +2,52 @@ import React from 'react';
 import { GenerativeTrack } from '../types/CrealabTypes';
 import { MODULE_KNOB_LABELS } from '../data/EurorackModules';
 import './CreaLab.css';
+import KnobControl from './KnobControl';
 
 interface Props {
   track: GenerativeTrack;
   onChange: (changes: Partial<GenerativeTrack['controls']>) => void;
+  mappingMode?: boolean;
 }
 
-export const GeneratorControls: React.FC<Props> = ({ track, onChange }) => {
+export const GeneratorControls: React.FC<Props> = ({ track, onChange, mappingMode }) => {
   const handleNumber = (field: keyof GenerativeTrack['controls']) =>
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = Number(e.target.value);
       onChange({ [field]: value });
     };
 
+  const handleMap = (field: keyof GenerativeTrack['controls']) => () => {
+    if (!mappingMode) return;
+    console.log(`MIDI mapping for ${field} not implemented`);
+  };
+
   const labels = MODULE_KNOB_LABELS[track.trackType] || ['Param A', 'Param B', 'Param C'];
 
   return (
-    <div className="generator-module">
+    <div className={`generator-module${mappingMode ? ' mapping-mode' : ''}`}>
       <div className="module-header">
         <span>{track.trackType.toUpperCase()} Module</span>
         <span className={`activity-led ${track.generator.enabled ? 'on' : ''}`} />
       </div>
-      <div className="control-row">
+      <div className="control-row" onClick={handleMap('intensity')}>
         <label>Intensity</label>
-        <input type="range" min={0} max={127} value={track.controls.intensity}
-          onChange={handleNumber('intensity')} />
+        <KnobControl value={track.controls.intensity} onChange={handleNumber('intensity')} />
         <span className="control-display">{track.controls.intensity}</span>
       </div>
-      <div className="control-row">
+      <div className="control-row" onClick={handleMap('paramA')}>
         <label>{labels[0]}</label>
-        <input type="range" min={0} max={127} value={track.controls.paramA}
-          onChange={handleNumber('paramA')} />
+        <KnobControl value={track.controls.paramA} onChange={handleNumber('paramA')} />
         <span className="control-display">{track.controls.paramA}</span>
       </div>
-      <div className="control-row">
+      <div className="control-row" onClick={handleMap('paramB')}>
         <label>{labels[1]}</label>
-        <input type="range" min={0} max={127} value={track.controls.paramB}
-          onChange={handleNumber('paramB')} />
+        <KnobControl value={track.controls.paramB} onChange={handleNumber('paramB')} />
         <span className="control-display">{track.controls.paramB}</span>
       </div>
-      <div className="control-row">
+      <div className="control-row" onClick={handleMap('paramC')}>
         <label>{labels[2]}</label>
-        <input type="range" min={0} max={127} value={track.controls.paramC}
-          onChange={handleNumber('paramC')} />
+        <KnobControl value={track.controls.paramC} onChange={handleNumber('paramC')} />
         <span className="control-display">{track.controls.paramC}</span>
       </div>
     </div>

--- a/src/crealab/components/KnobControl.css
+++ b/src/crealab/components/KnobControl.css
@@ -1,0 +1,34 @@
+.knob-control {
+  position: relative;
+  width: 40px;
+  height: 40px;
+}
+
+.knob-range {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.knob-display {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #fafafa, #b5b5b5);
+  position: relative;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.4);
+}
+
+.knob-display::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 3px;
+  height: 12px;
+  background: #333;
+  transform-origin: bottom center;
+  transform: translate(-50%, -100%) rotate(calc((var(--value, 0) / 127) * 270deg - 135deg));
+}

--- a/src/crealab/components/KnobControl.tsx
+++ b/src/crealab/components/KnobControl.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import './KnobControl.css';
+
+interface Props {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+const KnobControl: React.FC<Props> = ({ value, onChange }) => {
+  return (
+    <div className="knob-control">
+      <input
+        type="range"
+        min={0}
+        max={127}
+        value={value}
+        onChange={e => onChange(Number(e.target.value))}
+        className="knob-range"
+      />
+      <div className="knob-display" style={{ ['--value' as any]: value }} />
+    </div>
+  );
+};
+
+export default KnobControl;

--- a/src/crealab/components/LaunchControlStrip.tsx
+++ b/src/crealab/components/LaunchControlStrip.tsx
@@ -14,29 +14,31 @@ const LaunchControlStrip: React.FC<Props> = ({ strip, labels }) => {
 
   return (
     <div className="lcx-strip">
-      <div className="lcx-knobs">
-        <div className="lcx-knob-wrapper">
-          <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob1 }} />
-          <div className="lcx-knob-label">{labels?.[0]}</div>
-        </div>
-        <div className="lcx-knob-wrapper">
-          <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob2 }} />
-          <div className="lcx-knob-label">{labels?.[1]}</div>
-        </div>
-        <div className="lcx-knob-wrapper">
-          <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob3 }} />
-          <div className="lcx-knob-label">{labels?.[2]}</div>
-        </div>
-      </div>
       <div className="lcx-fader">
         <div
           className="lcx-fader-thumb"
           style={{ ['--value' as any]: strip.values.fader }}
         />
       </div>
-      <div className="lcx-buttons">
-        <div className={`lcx-button ${strip.values.button1 ? 'active' : ''}`} />
-        <div className={`lcx-button ${strip.values.button2 ? 'active' : ''}`} />
+      <div className="lcx-controls">
+        <div className="lcx-knobs">
+          <div className="lcx-knob-wrapper">
+            <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob1 }} />
+            <div className="lcx-knob-label">{labels?.[0]}</div>
+          </div>
+          <div className="lcx-knob-wrapper">
+            <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob2 }} />
+            <div className="lcx-knob-label">{labels?.[1]}</div>
+          </div>
+          <div className="lcx-knob-wrapper">
+            <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob3 }} />
+            <div className="lcx-knob-label">{labels?.[2]}</div>
+          </div>
+        </div>
+        <div className="lcx-buttons">
+          <div className={`lcx-button ${strip.values.button1 ? 'active' : ''}`} />
+          <div className={`lcx-button ${strip.values.button2 ? 'active' : ''}`} />
+        </div>
       </div>
     </div>
   );

--- a/src/crealab/components/LaunchControlVisualizer.css
+++ b/src/crealab/components/LaunchControlVisualizer.css
@@ -9,10 +9,10 @@
   font-style: italic;
 }
 
+
 .lcx-strip {
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
   padding: 8px;
   background: linear-gradient(180deg, #d8d8d8 0%, #bdbdbd 100%);
@@ -21,9 +21,18 @@
   position: relative;
 }
 
+.lcx-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+}
+
 .lcx-knobs {
   display: flex;
-  gap: 4px;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
 }
 
 .lcx-knob-wrapper {

--- a/src/crealab/components/TopBar.css
+++ b/src/crealab/components/TopBar.css
@@ -91,3 +91,8 @@
   background: #4a4a4a;
 }
 
+.icon-btn.active {
+  background: #4caf50;
+  color: #000;
+}
+

--- a/src/crealab/components/TopBar.tsx
+++ b/src/crealab/components/TopBar.tsx
@@ -12,6 +12,8 @@ interface TopBarProps {
   onOpenProjectManager: () => void;
   isPlaying: boolean;
   onPlayToggle: () => void;
+  isMidiMapping: boolean;
+  onToggleMidiMapping: () => void;
 }
 
 export const TopBar: React.FC<TopBarProps> = ({
@@ -24,7 +26,9 @@ export const TopBar: React.FC<TopBarProps> = ({
   onOpenMidiConfig,
   onOpenProjectManager,
   isPlaying,
-  onPlayToggle
+  onPlayToggle,
+  isMidiMapping,
+  onToggleMidiMapping
 }) => {
   return (
     <header className="topbar-container">
@@ -34,6 +38,7 @@ export const TopBar: React.FC<TopBarProps> = ({
           <span className="project-name">{projectName}</span>
         </div>
         <button className="icon-btn" onClick={onOpenMidiConfig} title="MIDI Config">🎛️</button>
+        <button className={"icon-btn" + (isMidiMapping ? ' active' : '')} onClick={onToggleMidiMapping} title="MIDI Mapping">MIDI</button>
         <button className="icon-btn" onClick={onOpenProjectManager} title="Projects">📁</button>
       </div>
 


### PR DESCRIPTION
## Summary
- Arrange track MIDI controls with left-aligned fader and vertical knob column
- Replace generator sliders with knob components and add MIDI mapping mode toggle in top bar
- Stub mapping mode highlighting for generator controls

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa2a8d1dd88333b5882f71b02a7b24