### PR TITLE
Optimize space for track controls

### DIFF
--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -11,6 +11,11 @@
   flex: 1;
   padding: 10px;
   overflow-y: auto;
+  scrollbar-width: none;
+}
+
+.crealab-workspace::-webkit-scrollbar {
+  display: none;
 }
 
 /* TRACKS GRID - 8 tracks fijos */
@@ -18,7 +23,7 @@
   display: grid;
   grid-template-columns: repeat(8, 1fr);
   gap: 1px;
-  height: calc(100vh - 140px); /* Ajustar según TopBar + Footer */
+  height: 100%;
 }
 
 .track-strip {
@@ -34,6 +39,7 @@
   box-sizing: border-box;
   box-shadow: 0 2px 4px rgba(0,0,0,0.5);
   color: #eee;
+  height: 100%;
 }
 
 .track-strip::before {
@@ -228,18 +234,9 @@
 }
 
 .generator-module .control-row .knob-control {
-  flex: 2;
+  flex: none;
 }
 
-.generator-module .control-display {
-  width: 32px;
-  text-align: right;
-  font-size: 10px;
-  padding: 2px 4px;
-  border-radius: 3px;
-  background: #111;
-  border: 1px solid #333;
-}
 
 /* FOOTER */
 .crealab-footer {

--- a/src/crealab/components/GeneratorControls.tsx
+++ b/src/crealab/components/GeneratorControls.tsx
@@ -33,22 +33,18 @@ export const GeneratorControls: React.FC<Props> = ({ track, onChange, mappingMod
       <div className="control-row" onClick={handleMap('intensity')}>
         <label>Intensity</label>
         <KnobControl value={track.controls.intensity} onChange={handleNumber('intensity')} />
-        <span className="control-display">{track.controls.intensity}</span>
       </div>
       <div className="control-row" onClick={handleMap('paramA')}>
         <label>{labels[0]}</label>
         <KnobControl value={track.controls.paramA} onChange={handleNumber('paramA')} />
-        <span className="control-display">{track.controls.paramA}</span>
       </div>
       <div className="control-row" onClick={handleMap('paramB')}>
         <label>{labels[1]}</label>
         <KnobControl value={track.controls.paramB} onChange={handleNumber('paramB')} />
-        <span className="control-display">{track.controls.paramB}</span>
       </div>
       <div className="control-row" onClick={handleMap('paramC')}>
         <label>{labels[2]}</label>
         <KnobControl value={track.controls.paramC} onChange={handleNumber('paramC')} />
-        <span className="control-display">{track.controls.paramC}</span>
       </div>
     </div>
   );

--- a/src/crealab/components/KnobControl.css
+++ b/src/crealab/components/KnobControl.css
@@ -1,7 +1,7 @@
 .knob-control {
   position: relative;
-  width: 40px;
-  height: 40px;
+  width: 24px;
+  height: 24px;
 }
 
 .knob-range {
@@ -16,9 +16,9 @@
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, #fafafa, #b5b5b5);
+  border: 2px solid #bbb;
+  background: transparent;
   position: relative;
-  box-shadow: inset 0 2px 4px rgba(0,0,0,0.4);
 }
 
 .knob-display::after {
@@ -26,9 +26,9 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 3px;
-  height: 12px;
-  background: #333;
+  width: 2px;
+  height: 8px;
+  background: #bbb;
   transform-origin: bottom center;
   transform: translate(-50%, -100%) rotate(calc((var(--value, 0) / 127) * 270deg - 135deg));
 }

--- a/src/crealab/components/LaunchControlStrip.tsx
+++ b/src/crealab/components/LaunchControlStrip.tsx
@@ -14,30 +14,30 @@ const LaunchControlStrip: React.FC<Props> = ({ strip, labels }) => {
 
   return (
     <div className="lcx-strip">
-      <div className="lcx-fader">
-        <div
-          className="lcx-fader-thumb"
-          style={{ ['--value' as any]: strip.values.fader }}
-        />
-      </div>
-      <div className="lcx-controls">
-        <div className="lcx-knobs">
-          <div className="lcx-knob-wrapper">
-            <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob1 }} />
-            <div className="lcx-knob-label">{labels?.[0]}</div>
-          </div>
-          <div className="lcx-knob-wrapper">
-            <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob2 }} />
-            <div className="lcx-knob-label">{labels?.[1]}</div>
-          </div>
-          <div className="lcx-knob-wrapper">
-            <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob3 }} />
-            <div className="lcx-knob-label">{labels?.[2]}</div>
-          </div>
+      <div className="lcx-left">
+        <div className="lcx-fader">
+          <div
+            className="lcx-fader-thumb"
+            style={{ ['--value' as any]: strip.values.fader }}
+          />
         </div>
         <div className="lcx-buttons">
           <div className={`lcx-button ${strip.values.button1 ? 'active' : ''}`} />
           <div className={`lcx-button ${strip.values.button2 ? 'active' : ''}`} />
+        </div>
+      </div>
+      <div className="lcx-knobs">
+        <div className="lcx-knob-wrapper">
+          <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob1 }} />
+          <div className="lcx-knob-label">{labels?.[0]}</div>
+        </div>
+        <div className="lcx-knob-wrapper">
+          <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob2 }} />
+          <div className="lcx-knob-label">{labels?.[1]}</div>
+        </div>
+        <div className="lcx-knob-wrapper">
+          <div className="lcx-knob" style={{ ['--value' as any]: strip.values.knob3 }} />
+          <div className="lcx-knob-label">{labels?.[2]}</div>
         </div>
       </div>
     </div>

--- a/src/crealab/components/LaunchControlVisualizer.css
+++ b/src/crealab/components/LaunchControlVisualizer.css
@@ -21,23 +21,22 @@
   position: relative;
 }
 
-.lcx-controls {
+.lcx-left {
   display: flex;
   flex-direction: column;
-  gap: 8px;
   align-items: center;
+  gap: 8px;
 }
 
 .lcx-knobs {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .lcx-knob-wrapper {
   display: flex;
-  flex-direction: column;
   align-items: center;
   gap: 4px;
 }
@@ -45,16 +44,15 @@
 .lcx-knob-label {
   font-size: 10px;
   color: #111;
-  text-align: center;
 }
 
 .lcx-knob {
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, #fafafa, #b5b5b5);
+  border: 2px solid #bbb;
+  background: transparent;
   position: relative;
-  box-shadow: inset 0 2px 4px rgba(0,0,0,0.4);
 }
 
 .lcx-knob::after {
@@ -62,16 +60,16 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 3px;
-  height: 12px;
-  background: #333;
+  width: 2px;
+  height: 8px;
+  background: #bbb;
   transform-origin: bottom center;
   transform: translate(-50%, -100%) rotate(calc((var(--value, 0) / 127) * 270deg - 135deg));
 }
 
 .lcx-fader {
   width: 20px;
-  height: 60px;
+  height: 64px;
   background: #333;
   position: relative;
   border-radius: 2px;
@@ -84,7 +82,7 @@
   height: 10px;
   background: #ddd;
   border-radius: 2px;
-  bottom: calc((var(--value, 0) / 127) * 50px);
+  bottom: calc((var(--value, 0) / 127) * 54px);
 }
 
 .lcx-buttons {


### PR DESCRIPTION
## Summary
- Redesign MIDI control strip with taller fader, compact outline knobs, side labels, and buttons beneath the fader
- Use minimal outline knobs in generator controls and remove numeric input
- Stretch track grid to full height and allow wheel scrolling without a visible scrollbar

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa2cb7e6b083339f729c4ca7377720