### PR TITLE
Add note activity indicators

### DIFF
--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -84,6 +84,19 @@
   font-weight: 500;
 }
 
+.track-led {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #222;
+  box-shadow: 0 0 4px rgba(0,0,0,0.8);
+}
+
+.track-led.on {
+  background: #0f0;
+  box-shadow: 0 0 6px #0f0;
+}
+
 .track-name-input:focus {
   outline: none;
   border-color: #777;

--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -81,6 +81,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
   const [showMidiConfig, setShowMidiConfig] = useState(false);
   const [showProjectManager, setShowProjectManager] = useState(false);
   const [midiMapping, setMidiMapping] = useState(false);
+  const [trackActivity, setTrackActivity] = useState<Record<string, boolean>>({});
   const [project, setProject] = useState<CreaLabProject>({
     id: 'project-1',
     name: 'New Project',
@@ -174,6 +175,16 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
       return { ...prev, tracks: newTracks };
     });
   }, [controller]);
+
+  useEffect(() => {
+    const handler = (e: any) => {
+      const id = e.detail.trackId;
+      setTrackActivity(prev => ({ ...prev, [id]: true }));
+      setTimeout(() => setTrackActivity(prev => ({ ...prev, [id]: false })), 100);
+    };
+    window.addEventListener('trackNote', handler);
+    return () => window.removeEventListener('trackNote', handler);
+  }, []);
 
   const updateTrackName = (trackNumber: number, name: string) => {
     setProject(prev => ({
@@ -339,6 +350,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
                   value={track.name}
                   onChange={e => updateTrackName(track.trackNumber, e.target.value)}
                 />
+                <span className={`track-led ${trackActivity[track.id] ? 'on' : ''}`} />
               </div>
 
               <div className="track-controls">

--- a/src/crealab/components/GeneratorControls.tsx
+++ b/src/crealab/components/GeneratorControls.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { GenerativeTrack } from '../types/CrealabTypes';
 import { MODULE_KNOB_LABELS } from '../data/EurorackModules';
 import './CreaLab.css';
@@ -24,11 +24,24 @@ export const GeneratorControls: React.FC<Props> = ({ track, onChange, mappingMod
 
   const labels = MODULE_KNOB_LABELS[track.trackType] || ['Param A', 'Param B', 'Param C'];
 
+  const [noteActive, setNoteActive] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: any) => {
+      if (e.detail.trackId === track.id) {
+        setNoteActive(true);
+        setTimeout(() => setNoteActive(false), 100);
+      }
+    };
+    window.addEventListener('generatorNote', handler);
+    return () => window.removeEventListener('generatorNote', handler);
+  }, [track.id]);
+
   return (
     <div className={`generator-module${mappingMode ? ' mapping-mode' : ''}`}>
       <div className="module-header">
         <span>{track.trackType.toUpperCase()} Module</span>
-        <span className={`activity-led ${track.generator.enabled ? 'on' : ''}`} />
+        <span className={`activity-led ${noteActive ? 'on' : ''}`} />
       </div>
       <div className="control-row" onClick={handleMap('intensity')}>
         <label>Intensity</label>

--- a/src/crealab/core/GeneratorEngine.ts
+++ b/src/crealab/core/GeneratorEngine.ts
@@ -156,6 +156,14 @@ export class GeneratorEngine {
 
     // Enviar notas MIDI si hay alguna
     if (notes.length > 0) {
+      // Notificar que el generador produjo notas
+      track.generator.lastNoteTime = this.currentTime;
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(
+          new CustomEvent('generatorNote', { detail: { trackId: track.id } })
+        );
+      }
+
       this.sendMidiNotes(notes, track, globalTempo);
     }
   }
@@ -185,6 +193,13 @@ export class GeneratorEngine {
         )
       )
     );
+
+    // Notificar que se enviaron notas al dispositivo
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(
+        new CustomEvent('trackNote', { detail: { trackId: track.id } })
+      );
+    }
 
     if (this.broadcast && track.visualLayer && typeof track.visualPad === 'number') {
       notes.forEach(note => {


### PR DESCRIPTION
## Summary
- Dispatch custom events when generators create and send notes to highlight activity.
- Flash LEDs in generator modules on note generation.
- Add per-track LEDs and styling to show MIDI routing activity.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*


------
https://chatgpt.com/codex/tasks/task_e_68aa2fe717648333930798ae212da6fb