### PR TITLE
Ensure generators have active default controls

### DIFF
--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -57,10 +57,10 @@ const createDefaultTrack = (n: number): GenerativeTrack => ({
     currentStep: 0
   },
   controls: {
-    intensity: 0,
-    paramA: 0,
-    paramB: 0,
-    paramC: 0,
+    intensity: 64,
+    paramA: 64,
+    paramB: 64,
+    paramC: 64,
     playStop: false,
     mode: 0
   },


### PR DESCRIPTION
## Summary
- Set default generator controls (intensity and parameters) to mid values so tracks produce MIDI immediately when enabled

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa318a25e88333b11fc21fc5939d58