### PR TITLE
Ensure generators start when transport plays

### DIFF
--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -327,10 +327,29 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
         onOpenProjectManager={() => setShowProjectManager(true)}
         isPlaying={project.transport.isPlaying}
         onPlayToggle={() =>
-          setProject(p => ({
-            ...p,
-            transport: { ...p.transport, isPlaying: !p.transport.isPlaying }
-          }))
+          setProject(p => {
+            const nextPlaying = !p.transport.isPlaying;
+            const updatedTracks = p.tracks.map(t => ({
+              ...t,
+              controls: {
+                ...t.controls,
+                playStop: nextPlaying ? t.generator.enabled : false
+              },
+              generator: {
+                ...t.generator,
+                lastNoteTime: 0,
+                currentStep: 0
+              }
+            }));
+            // Keep engine in sync with track states
+            const engine = GeneratorEngine.getInstance();
+            engine.updateTracks(updatedTracks);
+            return {
+              ...p,
+              tracks: updatedTracks,
+              transport: { ...p.transport, isPlaying: nextPlaying }
+            };
+          })
         }
         isMidiMapping={midiMapping}
         onToggleMidiMapping={() => setMidiMapping(m => !m)}


### PR DESCRIPTION
## Summary
- Start all configured generators when hitting Play by toggling each track's playStop control and resetting generator timing
- Keep generator engine synchronized with updated track states

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unable to find web assets for Tauri build)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3312fa7083338457a3bea6fe07a3