### PR TITLE
Preserve track playback when controller buttons release

### DIFF
--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -165,7 +165,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
             paramA: strip.values.knob1,
             paramB: strip.values.knob2,
             paramC: strip.values.knob3,
-            playStop: strip.values.button1,
+            playStop: strip.values.button1 || t.controls.playStop,
             mode: strip.values.button2 ? 1 : 0
           }
         };


### PR DESCRIPTION
## Summary
- Keep track play status when Launch Control XL buttons return to 0 to avoid disabling generators

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json --noEmit` (fails: multiple TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68aa343df1448333be084dee2e69f434