### PR TITLE
feat: add bassline generator and unified sync

### DIFF
--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -56,14 +56,14 @@ const createDefaultTrack = (n: number): GenerativeTrack => ({
     lastNoteTime: 0,
     currentStep: 0
   },
-  controls: {
-    intensity: 64,
-    paramA: 64,
-    paramB: 64,
-    paramC: 64,
-    playStop: false,
-    mode: 0
-  },
+    controls: {
+      intensity: 64,
+      paramA: 64,
+      paramB: 64,
+      paramC: 64,
+      playStop: true,
+      mode: 0
+    },
   launchControlMapping: {
     stripNumber: n,
     faderCC: 0,
@@ -441,7 +441,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
                 <div className="section-title">Controles MIDI</div>
                 <LaunchControlStrip
                   strip={controller?.channelStrips[track.trackNumber - 1] || null}
-                  labels={MODULE_KNOB_LABELS[track.trackType]}
+                  labels={MODULE_KNOB_LABELS[track.trackType].slice(1) as [string, string, string]}
                 />
 
                 <div className="section-divider" />
@@ -465,12 +465,13 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
                 >
                   <option value="off">Off</option>
                   <option value="euclidean">Euclidean</option>
-                  <option value="probabilistic">Probabilistic</option>
-                  <option value="markov">Markov</option>
-                  <option value="arpeggiator">Arpeggiator</option>
-                  <option value="chaos">Chaos</option>
-                  <option value="magenta">Magenta</option>
-                </select>
+                <option value="probabilistic">Probabilistic</option>
+                <option value="markov">Markov</option>
+                <option value="arpeggiator">Arpeggiator</option>
+                <option value="bassline">Bassline</option>
+                <option value="chaos">Chaos</option>
+                <option value="magenta">Magenta</option>
+              </select>
 
                 <GeneratorControls
                   track={track}

--- a/src/crealab/components/GeneratorControls.tsx
+++ b/src/crealab/components/GeneratorControls.tsx
@@ -22,7 +22,7 @@ export const GeneratorControls: React.FC<Props> = ({ track, onChange, mappingMod
     console.log(`MIDI mapping for ${field} not implemented`);
   };
 
-  const labels = MODULE_KNOB_LABELS[track.trackType] || ['Param A', 'Param B', 'Param C'];
+    const labels = MODULE_KNOB_LABELS[track.trackType] || ['Intensity', 'Param A', 'Param B', 'Param C'];
 
   const [noteActive, setNoteActive] = useState(false);
 
@@ -43,22 +43,22 @@ export const GeneratorControls: React.FC<Props> = ({ track, onChange, mappingMod
         <span>{track.trackType.toUpperCase()} Module</span>
         <span className={`activity-led ${noteActive ? 'on' : ''}`} />
       </div>
-      <div className="control-row" onClick={handleMap('intensity')}>
-        <label>Intensity</label>
-        <KnobControl value={track.controls.intensity} onChange={handleNumber('intensity')} />
-      </div>
-      <div className="control-row" onClick={handleMap('paramA')}>
-        <label>{labels[0]}</label>
-        <KnobControl value={track.controls.paramA} onChange={handleNumber('paramA')} />
-      </div>
-      <div className="control-row" onClick={handleMap('paramB')}>
-        <label>{labels[1]}</label>
-        <KnobControl value={track.controls.paramB} onChange={handleNumber('paramB')} />
-      </div>
-      <div className="control-row" onClick={handleMap('paramC')}>
-        <label>{labels[2]}</label>
-        <KnobControl value={track.controls.paramC} onChange={handleNumber('paramC')} />
-      </div>
+        <div className="control-row" onClick={handleMap('intensity')}>
+          <label>{labels[0]}</label>
+          <KnobControl value={track.controls.intensity} onChange={handleNumber('intensity')} />
+        </div>
+        <div className="control-row" onClick={handleMap('paramA')}>
+          <label>{labels[1]}</label>
+          <KnobControl value={track.controls.paramA} onChange={handleNumber('paramA')} />
+        </div>
+        <div className="control-row" onClick={handleMap('paramB')}>
+          <label>{labels[2]}</label>
+          <KnobControl value={track.controls.paramB} onChange={handleNumber('paramB')} />
+        </div>
+        <div className="control-row" onClick={handleMap('paramC')}>
+          <label>{labels[3]}</label>
+          <KnobControl value={track.controls.paramC} onChange={handleNumber('paramC')} />
+        </div>
     </div>
   );
 };

--- a/src/crealab/core/GeneratorEngine.ts
+++ b/src/crealab/core/GeneratorEngine.ts
@@ -8,6 +8,7 @@ import { MagentaGenerator } from '../generators/MagentaGenerator';
 import { LSystemGenerator } from '../generators/advanced/LSystemGenerator';
 import { CellularAutomataGenerator } from '../generators/advanced/CellularAutomataGenerator';
 import { NeuralNetworkGenerator } from '../generators/advanced/NeuralNetworkGenerator';
+import { BasslineGenerator } from '../generators/BasslineGenerator';
 import { MusicalIntelligence } from '../ai/MusicalIntelligence';
 import { MidiManager } from './MidiManager';
 
@@ -56,11 +57,12 @@ export class GeneratorEngine {
     this.generators.set('markov', new MarkovGenerator());
     this.generators.set('arpeggiator', new ArpeggiatorGenerator());
     this.generators.set('chaos', new ChaosGenerator());
-    this.generators.set('magenta', new MagentaGenerator());
-    this.generators.set('lsystem', new LSystemGenerator());
-    this.generators.set('cellular', new CellularAutomataGenerator());
-    this.generators.set('neural', new NeuralNetworkGenerator());
-  }
+      this.generators.set('magenta', new MagentaGenerator());
+      this.generators.set('lsystem', new LSystemGenerator());
+      this.generators.set('cellular', new CellularAutomataGenerator());
+      this.generators.set('neural', new NeuralNetworkGenerator());
+      this.generators.set('bassline', new BasslineGenerator());
+    }
 
   // Iniciar el motor generativo
   start(tracks: GenerativeTrack[], globalTempo: number, key: string, scale: string) {
@@ -129,7 +131,7 @@ export class GeneratorEngine {
         this.sendMidiClock(track, 6);
       }
 
-      if (track.generator.enabled && track.controls.playStop) {
+      if (track.generator.enabled) {
         this.processTrack(track, globalTempo, key, scale);
       }
     });
@@ -303,6 +305,9 @@ export class GeneratorEngine {
         break;
       case 'neural':
         track.generator.parameters = {};
+        break;
+      case 'bassline':
+        track.generator.parameters = { pattern: 'dub', variation: 0 };
         break;
       default:
         track.generator.parameters = {};

--- a/src/crealab/core/InstrumentProfileManager.ts
+++ b/src/crealab/core/InstrumentProfileManager.ts
@@ -67,13 +67,19 @@ export class InstrumentProfileManager {
           memory: 8
         };
         
-      case 'arpeggiator':
-        return {
-          pattern: baseParams.pattern || 'up',
-          octaves: baseParams.octaves || 2,
-          noteLength: 0.25,
-          swing: 0.1
-        };
+        case 'arpeggiator':
+          return {
+            pattern: baseParams.pattern || 'up',
+            octaves: baseParams.octaves || 2,
+            noteLength: 0.25,
+            swing: 0.1
+          };
+
+        case 'bassline':
+          return {
+            pattern: baseParams.pattern || 'dub',
+            variation: baseParams.variation || 0
+          };
         
       case 'chaos':
         return {

--- a/src/crealab/data/EurorackModules.ts
+++ b/src/crealab/data/EurorackModules.ts
@@ -4,60 +4,61 @@ export interface EurorackModule {
   id: TrackType;
   name: string;
   description: string;
-  controls: [string, string, string];
+  // Labels for [intensity, paramA, paramB, paramC]
+  controls: [string, string, string, string];
 }
 
 export const EURORACK_MODULES: EurorackModule[] = [
-  {
-    id: 'arp',
-    name: 'ARP Sequencer',
-    description: 'Secuenciador rítmico/melódico para líneas repetitivas.',
-    controls: ['Transpose', 'Swing', 'Humanize']
-  },
-  {
-    id: 'lead',
-    name: 'Lead Synth',
-    description: 'Sintetizador monofónico para melodías principales.',
-    controls: ['Transpose', 'Swing', 'Humanize']
-  },
-  {
-    id: 'bass',
-    name: 'Bass Synth',
-    description: 'Generador de bajos con cuerpo y pegada.',
-    controls: ['Transpose', 'Swing', 'Humanize']
-  },
-  {
-    id: 'kick',
-    name: 'Kick Drum',
-    description: 'Percusión grave y corta para bombo.',
-    controls: ['Transpose', 'Swing', 'Humanize']
-  },
-  {
-    id: 'perc',
-    name: 'Snare / Clap',
-    description: 'Percusión media con componente de ruido.',
-    controls: ['Transpose', 'Swing', 'Humanize']
-  },
-  {
-    id: 'fx',
-    name: 'FX Noise',
-    description: 'Generador de ruido y efectos.',
-    controls: ['Transpose', 'Swing', 'Humanize']
-  },
-  {
-    id: 'visual',
-    name: 'Visual',
-    description: 'Control de parámetros visuales.',
-    controls: ['Param A', 'Param B', 'Param C']
-  }
+    {
+      id: 'arp',
+      name: 'ARP Sequencer',
+      description: 'Secuenciador rítmico/melódico para líneas repetitivas.',
+      controls: ['Time', 'Transpose', 'Octaves', 'Swing']
+    },
+    {
+      id: 'lead',
+      name: 'Lead Synth',
+      description: 'Sintetizador monofónico para melodías principales.',
+      controls: ['Intensity', 'Param A', 'Param B', 'Param C']
+    },
+    {
+      id: 'bass',
+      name: 'Bass Synth',
+      description: 'Generador de bajos con cuerpo y pegada.',
+      controls: ['Velocity', 'Groove', 'Bass Type', 'Variation']
+    },
+    {
+      id: 'kick',
+      name: 'Kick Drum',
+      description: 'Percusión grave y corta para bombo.',
+      controls: ['Intensity', 'Param A', 'Param B', 'Param C']
+    },
+    {
+      id: 'perc',
+      name: 'Snare / Clap',
+      description: 'Percusión media con componente de ruido.',
+      controls: ['Intensity', 'Param A', 'Param B', 'Param C']
+    },
+    {
+      id: 'fx',
+      name: 'FX Noise',
+      description: 'Generador de ruido y efectos.',
+      controls: ['Intensity', 'Param A', 'Param B', 'Param C']
+    },
+    {
+      id: 'visual',
+      name: 'Visual',
+      description: 'Control de parámetros visuales.',
+      controls: ['Intensity', 'Param A', 'Param B', 'Param C']
+    }
 ];
 
-export const MODULE_KNOB_LABELS: Record<TrackType, [string, string, string]> = EURORACK_MODULES.reduce(
+export const MODULE_KNOB_LABELS: Record<TrackType, [string, string, string, string]> = EURORACK_MODULES.reduce(
   (acc, m) => {
     acc[m.id] = m.controls;
     return acc;
   },
-  {} as Record<TrackType, [string, string, string]>
+  {} as Record<TrackType, [string, string, string, string]>
 );
 
 export function getModule(id: TrackType) {

--- a/src/crealab/generators/BasslineGenerator.ts
+++ b/src/crealab/generators/BasslineGenerator.ts
@@ -1,0 +1,77 @@
+import { GeneratorInstance } from '../core/GeneratorEngine';
+import { GenerativeTrack, MidiNote } from '../types/CrealabTypes';
+import { generateEuclideanPattern } from '../utils/euclideanPatterns';
+import { getScaleNotes } from '../utils/MusicalMath';
+
+/**
+ * Simple bassline generator using predefined Euclidean patterns.
+ * Supports pattern style selection and small variation amount.
+ */
+export class BasslineGenerator implements GeneratorInstance {
+  private step = 0;
+  private cachedPattern: boolean[] = [];
+  private cachedStyle: string | null = null;
+
+  /** Update internal pattern cache when parameters change */
+  updateParameters(track: GenerativeTrack): void {
+    const params = track.generator.parameters as any;
+    const style: string = params.pattern || 'dub';
+    if (style !== this.cachedStyle) {
+      this.cachedPattern = generateEuclideanPattern('bass', style);
+      this.cachedStyle = style;
+      this.step = 0;
+    }
+  }
+
+  /** Reset generator state */
+  reset(): void {
+    this.step = 0;
+    this.cachedStyle = null;
+    this.cachedPattern = [];
+  }
+
+  /** Generate bassline notes for current step */
+  generate(
+    track: GenerativeTrack,
+    currentTime: number,
+    globalTempo: number,
+    key: string,
+    scale: string
+  ): MidiNote[] {
+    if (this.cachedPattern.length === 0) {
+      this.updateParameters(track);
+    }
+
+    const patternStep = this.cachedPattern[this.step % this.cachedPattern.length];
+    this.step++;
+
+    if (!patternStep) {
+      return [];
+    }
+
+    const sliderVariation = (track.generator.parameters as any).variation || 0;
+    const knobVariation = track.controls.paramC / 127;
+    const variation = Math.min(1, sliderVariation + knobVariation);
+    const scaleNotes = getScaleNotes(key, scale);
+    const baseIndex = Math.floor((track.controls.paramB / 127) * (scaleNotes.length - 1));
+    let note = scaleNotes[baseIndex];
+    if (variation > 0) {
+      const index = Math.floor(Math.random() * scaleNotes.length);
+      if (Math.random() < variation) {
+        note = scaleNotes[index];
+      }
+    }
+
+    const velocity = Math.floor(40 + (track.controls.intensity / 127) * 87); // intensity as velocity
+    const duration = 0.25 + (track.controls.paramA / 127) * 0.5; // paramA alters groove
+
+    return [
+      {
+        note,
+        time: currentTime,
+        velocity,
+        duration,
+      },
+    ];
+  }
+}

--- a/src/crealab/types/CrealabTypes.ts
+++ b/src/crealab/types/CrealabTypes.ts
@@ -16,13 +16,14 @@ export type GeneratorType =
   | 'euclidean'      // Ritmos euclidianos
   | 'probabilistic'  // Notas por probabilidad
   | 'markov'        // Cadenas de Markov
-  | 'arpeggiator'   // Arpegiador generativo
-  | 'chaos'         // Sistemas caóticos
-  | 'cellular'      // Autómatas celulares
-  | 'lsystem'       // L-Systems fractales
-  | 'neural'        // Redes neuronales simples
-  | 'magenta'       // Generador basado en Magenta.js
-  | 'off';          // Desactivado
+    | 'arpeggiator'   // Arpegiador generativo
+    | 'chaos'         // Sistemas caóticos
+    | 'cellular'      // Autómatas celulares
+    | 'lsystem'       // L-Systems fractales
+    | 'neural'        // Redes neuronales simples
+    | 'magenta'       // Generador basado en Magenta.js
+    | 'bassline'      // Generador específico de bajos
+    | 'off';          // Desactivado
 
 // Parámetros base para generadores
 export interface GeneratorParameters {

--- a/src/crealab/types/GeneratorTypes.ts
+++ b/src/crealab/types/GeneratorTypes.ts
@@ -6,11 +6,12 @@ export type GeneratorType =
   | 'probabilistic'   // Notas por probabilidad
   | 'arpeggiator'     // Arpegiador generativo
   | 'sequencer'       // Secuenciador con variaciones
-  | 'chaos'           // Sistemas caóticos
-  | 'cellular'        // Autómatas celulares
-  | 'lsystem'        // L-Systems fractales
-  | 'neural'        // Redes neuronales simples
-  | 'magenta';      // Generador basado en Magenta.js
+    | 'chaos'           // Sistemas caóticos
+    | 'cellular'        // Autómatas celulares
+    | 'lsystem'        // L-Systems fractales
+    | 'neural'        // Redes neuronales simples
+    | 'magenta'       // Generador basado en Magenta.js
+    | 'bassline';     // Generador específico de bajos
 
 export interface MidiGenerator {
   id: string;


### PR DESCRIPTION
## Summary
- add dedicated bassline MIDI generator using Euclidean patterns
- sync generators globally and expose bassline option in UI
- refine ARP controls and instrument-specific labels

## Testing
- `npx tsc --noEmit` *(fails: Property 'offset' does not exist on type 'never')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa35d6a73483339300272d2de78109