### PR TITLE
feat: add global MIDI pattern generator

### DIFF
--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -8,6 +8,7 @@ import { VideoSettings } from './settings/VideoSettings';
 import { FullscreenSettings } from './settings/FullscreenSettings';
 import { VisualSettings } from './settings/VisualSettings';
 import { SystemSettings } from './settings/SystemSettings';
+import { PatternSettings } from './settings/PatternSettings';
 
 interface DeviceOption {
   id: string;
@@ -172,6 +173,7 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
               { id: 'fullscreen', label: 'Monitors', icon: '🖥️' },
               { id: 'visual', label: 'Visuals', icon: '🎨' },
               { id: 'system', label: 'System', icon: '🔧' },
+              { id: 'pattern', label: 'Patterns', icon: '🎹' },
             ].map((tab) => (
               <button
                 key={tab.id}
@@ -257,6 +259,8 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
                 onGlitchPadChange={onGlitchPadChange}
               />
             )}
+
+            {activeTab === 'pattern' && <PatternSettings />}
 
             {activeTab === 'system' && (
               <SystemSettings

--- a/src/components/settings/PatternSettings.tsx
+++ b/src/components/settings/PatternSettings.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { Note } from 'tonal';
+import PatternManager from '../../crealab/core/PatternManager';
+
+export const PatternSettings: React.FC = () => {
+  const manager = PatternManager.getInstance();
+  const [notes, setNotes] = useState<number[]>(manager.getPattern().notes);
+
+  const handleGenerate = () => {
+    const pattern = manager.generatePattern();
+    setNotes([...pattern.notes]);
+  };
+
+  return (
+    <div className="settings-section">
+      <h3>🎹 MIDI Pattern</h3>
+      <div className="setting-group">
+        <label className="setting-label">
+          <span>Active Pattern</span>
+          <div className="pattern-display">
+            {notes.map(n => Note.fromMidi(n)).join(', ')}
+          </div>
+        </label>
+      </div>
+      <div className="setting-group">
+        <button className="primary-button" onClick={handleGenerate}>
+          Generate Pattern
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PatternSettings;

--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -471,6 +471,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
                 <option value="bassline">Bassline</option>
                 <option value="chaos">Chaos</option>
                 <option value="magenta">Magenta</option>
+                <option value="pattern">Pattern</option>
               </select>
 
                 <GeneratorControls

--- a/src/crealab/core/GeneratorEngine.ts
+++ b/src/crealab/core/GeneratorEngine.ts
@@ -9,6 +9,7 @@ import { LSystemGenerator } from '../generators/advanced/LSystemGenerator';
 import { CellularAutomataGenerator } from '../generators/advanced/CellularAutomataGenerator';
 import { NeuralNetworkGenerator } from '../generators/advanced/NeuralNetworkGenerator';
 import { BasslineGenerator } from '../generators/BasslineGenerator';
+import { PatternGenerator } from '../generators/PatternGenerator';
 import { MusicalIntelligence } from '../ai/MusicalIntelligence';
 import { MidiManager } from './MidiManager';
 
@@ -62,6 +63,7 @@ export class GeneratorEngine {
       this.generators.set('cellular', new CellularAutomataGenerator());
       this.generators.set('neural', new NeuralNetworkGenerator());
       this.generators.set('bassline', new BasslineGenerator());
+      this.generators.set('pattern', new PatternGenerator());
     }
 
   // Iniciar el motor generativo
@@ -308,6 +310,9 @@ export class GeneratorEngine {
         break;
       case 'bassline':
         track.generator.parameters = { pattern: 'dub', variation: 0 };
+        break;
+      case 'pattern':
+        track.generator.parameters = {};
         break;
       default:
         track.generator.parameters = {};

--- a/src/crealab/core/PatternManager.ts
+++ b/src/crealab/core/PatternManager.ts
@@ -1,0 +1,57 @@
+import { Scale, Note } from 'tonal';
+
+export interface MidiPattern {
+  notes: number[];
+}
+
+/**
+ * Simple global manager for MIDI patterns used by generators.
+ * Provides a singleton instance storing the active pattern
+ * and utility methods to generate new ones.
+ */
+export class PatternManager {
+  private static instance: PatternManager;
+  private current: MidiPattern = {
+    // default C minor triad across one octave
+    notes: [48, 57, 64, 65],
+  };
+
+  static getInstance(): PatternManager {
+    if (!this.instance) {
+      this.instance = new PatternManager();
+    }
+    return this.instance;
+  }
+
+  getPattern(): MidiPattern {
+    return this.current;
+  }
+
+  setPattern(notes: number[]): void {
+    this.current = { notes };
+  }
+
+  /**
+   * Generate a new 4-note pattern inside a minor scale.
+   * Notes are generated around C2 to keep low registers.
+   */
+  generatePattern(key: string = 'C', scale: string = 'minor'): MidiPattern {
+    try {
+      const scaleNotes: string[] = Scale.get(`${key} ${scale}`).notes;
+      const pattern: number[] = [];
+      for (let i = 0; i < 4; i++) {
+        const name = scaleNotes[Math.floor(Math.random() * scaleNotes.length)];
+        // place notes around octave 2 (C2 ~ 36)
+        const midi = Note.midi(`${name}2`) ?? 36;
+        pattern.push(midi);
+      }
+      this.current = { notes: pattern };
+    } catch {
+      // fallback to a static minor pattern if tonal fails
+      this.current = { notes: [48, 51, 55, 60] };
+    }
+    return this.current;
+  }
+}
+
+export default PatternManager;

--- a/src/crealab/generators/PatternGenerator.ts
+++ b/src/crealab/generators/PatternGenerator.ts
@@ -1,0 +1,53 @@
+import { GeneratorInstance } from '../core/GeneratorEngine';
+import { GenerativeTrack, MidiNote } from '../types/CrealabTypes';
+import { PatternManager } from '../core/PatternManager';
+
+/**
+ * Generator that plays a global MIDI pattern across all tracks.
+ * Each track type interprets the pattern differently.
+ */
+export class PatternGenerator implements GeneratorInstance {
+  private step: number = 0;
+
+  generate(
+    track: GenerativeTrack,
+    currentTime: number,
+    _globalTempo: number,
+    _key: string,
+    _scale: string
+  ): MidiNote[] {
+    const pattern = PatternManager.getInstance().getPattern().notes;
+    if (pattern.length === 0) return [];
+
+    const beatIndex = Math.floor(this.step / 4) % pattern.length;
+    const baseNote = pattern[beatIndex];
+    const notes: MidiNote[] = [];
+
+    switch (track.trackType) {
+      case 'lead':
+        // play note each 16th
+        notes.push({ note: baseNote, time: currentTime, velocity: 100, duration: 0.25 });
+        break;
+      case 'bass':
+        // sub-bass style: trigger once per beat
+        if (this.step % 4 === 0) {
+          notes.push({ note: baseNote, time: currentTime, velocity: 100, duration: 1 });
+        }
+        break;
+      default:
+        // fallback: single note
+        notes.push({ note: baseNote, time: currentTime, velocity: 100, duration: 0.25 });
+    }
+
+    this.step = (this.step + 1) % (pattern.length * 4);
+    return notes;
+  }
+
+  updateParameters(_track: GenerativeTrack): void {}
+
+  reset(): void {
+    this.step = 0;
+  }
+}
+
+export default PatternGenerator;

--- a/src/crealab/types/CrealabTypes.ts
+++ b/src/crealab/types/CrealabTypes.ts
@@ -23,6 +23,7 @@ export type GeneratorType =
     | 'neural'        // Redes neuronales simples
     | 'magenta'       // Generador basado en Magenta.js
     | 'bassline'      // Generador específico de bajos
+    | 'pattern'       // Reproduce un patrón MIDI global
     | 'off';          // Desactivado
 
 // Parámetros base para generadores


### PR DESCRIPTION
## Summary
- add global PatternManager and PatternGenerator
- expose pattern controls in Settings modal
- allow tracks to use Pattern generator

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Unable to find web assets)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: existing TypeScript errors in presets)*

------
https://chatgpt.com/codex/tasks/task_e_68aa375dce248333a9f0fd706f383608