### PR TITLE
feat: add Euclidean Circles MIDI generator

### DIFF
--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -7,6 +7,7 @@ import { SessionMidiManager } from '../core/SessionMidiController';
 import { useMidiDevices } from '../hooks/useMidiDevices';
 import BassGeneratorControls from './BassGeneratorControls';
 import GeneratorControls from './GeneratorControls';
+import EuclideanCirclesModule from './EuclideanCirclesModule';
 import MidiConfiguration from './MidiConfiguration';
 import ProjectManager from './ProjectManager';
 import './CreaLab.css';
@@ -465,6 +466,7 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
                 >
                   <option value="off">Off</option>
                   <option value="euclidean">Euclidean</option>
+                  <option value="euclidean-circles">Euclidean Circles</option>
                 <option value="probabilistic">Probabilistic</option>
                 <option value="markov">Markov</option>
                 <option value="arpeggiator">Arpeggiator</option>
@@ -474,11 +476,20 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
                 <option value="pattern">Pattern</option>
               </select>
 
-                <GeneratorControls
-                  track={track}
-                  onChange={changes => updateTrackControls(track.trackNumber, changes)}
-                  mappingMode={midiMapping}
-                />
+                {track.generator.type === 'euclidean-circles' ? (
+                  <EuclideanCirclesModule
+                    track={track}
+                    onParametersChange={params =>
+                      updateGeneratorParameters(track.trackNumber, params)
+                    }
+                  />
+                ) : (
+                  <GeneratorControls
+                    track={track}
+                    onChange={changes => updateTrackControls(track.trackNumber, changes)}
+                    mappingMode={midiMapping}
+                  />
+                )}
 
                 {track.trackType === 'bass' && (
                   <BassGeneratorControls

--- a/src/crealab/components/EuclideanCirclesModule.css
+++ b/src/crealab/components/EuclideanCirclesModule.css
@@ -1,0 +1,44 @@
+.euclidean-circles-module {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.euclidean-circles-module .circle {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  margin-bottom: 8px;
+}
+
+.euclidean-circles-module .step {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 10px;
+  height: 10px;
+  margin: -5px;
+  border-radius: 50%;
+  background: #555;
+}
+
+.euclidean-circles-module .step.hit {
+  background: #2ecc71;
+}
+
+.euclidean-circles-module .controls {
+  display: flex;
+  gap: 8px;
+}
+
+.euclidean-circles-module .controls label {
+  display: flex;
+  flex-direction: column;
+  font-size: 12px;
+  align-items: center;
+}
+
+.euclidean-circles-module .controls input {
+  width: 50px;
+}

--- a/src/crealab/components/EuclideanCirclesModule.tsx
+++ b/src/crealab/components/EuclideanCirclesModule.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { GenerativeTrack } from '../types/CrealabTypes';
+import { euclideanRhythm } from '../utils/euclideanPatterns';
+import './EuclideanCirclesModule.css';
+
+interface Props {
+  track: GenerativeTrack;
+  onParametersChange: (params: Record<string, any>) => void;
+}
+
+const EuclideanCirclesModule: React.FC<Props> = ({ track, onParametersChange }) => {
+  const params = track.generator.parameters as any;
+  const pulses = params.pulses ?? 8;
+  const steps = params.steps ?? 16;
+  const offset = params.offset ?? 0;
+
+  const pattern = euclideanRhythm(pulses, steps, offset);
+
+  const handleChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    onParametersChange({ ...params, [field]: value });
+  };
+
+  return (
+    <div className="euclidean-circles-module">
+      <div className="circle">
+        {pattern.map((hit, idx) => {
+          const angle = (idx / steps) * 360;
+          return (
+            <div
+              key={idx}
+              className={`step ${hit ? 'hit' : ''}`}
+              style={{ transform: `rotate(${angle}deg) translate(40px) rotate(-${angle}deg)` }}
+            />
+          );
+        })}
+      </div>
+      <div className="controls">
+        <label>
+          Pulses
+          <input type="number" min={1} max={steps} value={pulses} onChange={handleChange('pulses')} />
+        </label>
+        <label>
+          Steps
+          <input type="number" min={1} max={32} value={steps} onChange={handleChange('steps')} />
+        </label>
+        <label>
+          Offset
+          <input type="number" min={0} max={steps - 1} value={offset} onChange={handleChange('offset')} />
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default EuclideanCirclesModule;

--- a/src/crealab/core/GeneratorEngine.ts
+++ b/src/crealab/core/GeneratorEngine.ts
@@ -54,6 +54,7 @@ export class GeneratorEngine {
   private initializeGenerators() {
     // Crear instancias de todos los generadores
     this.generators.set('euclidean', new EuclideanGenerator());
+    this.generators.set('euclidean-circles', new EuclideanGenerator());
     this.generators.set('probabilistic', new ProbabilisticGenerator());
     this.generators.set('markov', new MarkovGenerator());
     this.generators.set('arpeggiator', new ArpeggiatorGenerator());
@@ -282,6 +283,7 @@ export class GeneratorEngine {
   private setDefaultParameters(track: GenerativeTrack, type: GeneratorType) {
     switch (type) {
       case 'euclidean':
+      case 'euclidean-circles':
         track.generator.parameters = { pulses: 8, steps: 16, offset: 0, mutation: 0.1 };
         break;
       case 'probabilistic':

--- a/src/crealab/core/InstrumentProfileManager.ts
+++ b/src/crealab/core/InstrumentProfileManager.ts
@@ -46,6 +46,7 @@ export class InstrumentProfileManager {
     
     switch (generatorType) {
       case 'euclidean':
+      case 'euclidean-circles':
         return {
           pulses: baseParams.pulses || 8,
           steps: baseParams.steps || 16,

--- a/src/crealab/core/LegacyGeneratorEngine.ts
+++ b/src/crealab/core/LegacyGeneratorEngine.ts
@@ -81,6 +81,7 @@ export class LegacyGeneratorEngine {
   private generateNote(generator: MidiGenerator, currentTime: number): MidiNote | null {
     switch (generator.type) {
       case 'euclidean':
+      case 'euclidean-circles':
         return this.generateEuclideanNote(generator, currentTime);
       case 'markov':
         return this.generateMarkovNote(generator, currentTime);

--- a/src/crealab/types/CrealabTypes.ts
+++ b/src/crealab/types/CrealabTypes.ts
@@ -14,6 +14,7 @@ export interface MidiNote {
 // Tipos de generadores disponibles
 export type GeneratorType =
   | 'euclidean'      // Ritmos euclidianos
+  | 'euclidean-circles' // Euclidean Circles v2
   | 'probabilistic'  // Notas por probabilidad
   | 'markov'        // Cadenas de Markov
     | 'arpeggiator'   // Arpegiador generativo

--- a/src/crealab/types/GeneratorTypes.ts
+++ b/src/crealab/types/GeneratorTypes.ts
@@ -1,7 +1,8 @@
 import { MidiNote } from './CrealabTypes';
 
-export type GeneratorType = 
+export type GeneratorType =
   | 'euclidean'        // Patrones euclidianos dinámicos
+  | 'euclidean-circles' // Euclidean Circles v2
   | 'markov'          // Cadenas de Markov
   | 'probabilistic'   // Notas por probabilidad
   | 'arpeggiator'     // Arpegiador generativo

--- a/src/crealab/utils/JsonValidator.ts
+++ b/src/crealab/utils/JsonValidator.ts
@@ -103,7 +103,7 @@ export class JsonValidator {
     const warnings: string[] = [];
     const prefix = `Track ${trackNumber} Generator:`;
 
-    const validTypes = ['off', 'euclidean', 'probabilistic', 'markov', 'arpeggiator', 'chaos'];
+    const validTypes = ['off', 'euclidean', 'euclidean-circles', 'probabilistic', 'markov', 'arpeggiator', 'chaos'];
     if (!validTypes.includes(generator.type)) {
       errors.push(`${prefix} Invalid generator type '${generator.type}'`);
     }


### PR DESCRIPTION
## Summary
- add Euclidean Circles generator option and module with circular step UI
- wire generator type into engine and instrument profiles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Property errors in presets and utils)*

------
https://chatgpt.com/codex/tasks/task_e_68aa390755748333992572b6d72a235d