### PR TITLE
feat: per-track playback controls

### DIFF
--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -84,6 +84,26 @@
   font-weight: 500;
 }
 
+.track-play-controls {
+  padding: 4px;
+  border-bottom: 1px solid #444;
+}
+
+.track-play-btn {
+  background: #3a3a3a;
+  border: 1px solid #555;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.track-play-btn.active {
+  background: #4caf50;
+  color: #000;
+}
+
 .track-led {
   width: 8px;
   height: 8px;


### PR DESCRIPTION
## Summary
- add play/stop toggle per track and update global play behavior
- filter inactive tracks in GeneratorEngine and reset steps on stop
- style and initialize engine with logging

## Testing
- `npx tsc --noEmit` (fails: numerous type errors)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68aa3c347c688333a6995925a3960b40