### PR TITLE
Refine generator playback and logging

### DIFF
--- a/src/crealab/components/CreaLab.css
+++ b/src/crealab/components/CreaLab.css
@@ -84,26 +84,6 @@
   font-weight: 500;
 }
 
-.track-play-controls {
-  padding: 4px;
-  border-bottom: 1px solid #444;
-}
-
-.track-play-btn {
-  background: #3a3a3a;
-  border: 1px solid #555;
-  color: #fff;
-  padding: 4px 8px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.8rem;
-}
-
-.track-play-btn.active {
-  background: #4caf50;
-  color: #000;
-}
-
 .track-led {
   width: 8px;
   height: 8px;

--- a/src/crealab/components/CreaLab.tsx
+++ b/src/crealab/components/CreaLab.tsx
@@ -205,34 +205,6 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
     }));
   };
 
-  // Función auxiliar para activar/desactivar tracks individuales
-  const toggleTrackPlayStop = (trackNumber: number) => {
-    setProject(prev => {
-      const track = prev.tracks[trackNumber - 1];
-      if (!track.generator.enabled || track.generator.type === 'off') {
-        console.warn(`Track ${trackNumber} has no active generator`);
-        return prev;
-      }
-
-      const newTracks = prev.tracks.map(t =>
-        t.trackNumber === trackNumber
-          ? {
-              ...t,
-              controls: {
-                ...t.controls,
-                playStop: !t.controls.playStop
-              }
-            }
-          : t
-      ) as any;
-
-      const engine = GeneratorEngine.getInstance();
-      engine.updateTracks(newTracks);
-
-      return { ...prev, tracks: newTracks };
-    });
-  };
-
   const updateMidiChannel = (trackNumber: number, channel: number) => {
     setProject(prev => ({
       ...prev,
@@ -348,6 +320,8 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
       ) as any;
       const engine = GeneratorEngine.getInstance();
       engine.changeGeneratorType(newTracks[trackNumber - 1], type as GeneratorType);
+      // Actualizar el engine con los nuevos tracks
+      engine.updateTracks(newTracks);
       return { ...prev, tracks: newTracks };
     });
   };
@@ -411,15 +385,6 @@ export const CreaLab: React.FC<CreaLabProps> = ({ onSwitchToAudioVisualizer }) =
               </div>
 
               <div className="track-controls">
-                <div className="track-play-controls">
-                  <button
-                    className={`track-play-btn ${track.controls.playStop ? 'active' : ''}`}
-                    onClick={() => toggleTrackPlayStop(track.trackNumber)}
-                  >
-                    {track.controls.playStop ? '⏹️' : '▶️'}
-                  </button>
-                </div>
-
                 <select
                   className="device-selector"
                   value={track.inputDevice || ''}

--- a/src/crealab/generators/MarkovGenerator.ts
+++ b/src/crealab/generators/MarkovGenerator.ts
@@ -31,10 +31,13 @@ export class MarkovGenerator implements GeneratorInstance {
     }
 
     // Probability to trigger based on intensity and density
-    if (Math.random() > intensity * density) {
+    const triggerProbability = intensity * density;
+    console.log('🎲 Markov trigger probability:', triggerProbability);
+    if (Math.random() > triggerProbability) {
       return notes;
     }
 
+    console.log('🎵 Generating markov note');
     const nextNote = this.generateNextNote(scaleNotes, order, creativity);
     const velocity = Math.floor(60 + intensity * 60);
     const duration = 0.25;
@@ -82,6 +85,7 @@ export class MarkovGenerator implements GeneratorInstance {
 
     if (candidates.length === 0 || Math.random() < creativity) {
       // pick random from scale
+      if (scaleNotes.length === 0) return 60;
       return scaleNotes[Math.floor(Math.random() * scaleNotes.length)];
     }
 

--- a/src/crealab/generators/ProbabilisticGenerator.ts
+++ b/src/crealab/generators/ProbabilisticGenerator.ts
@@ -31,8 +31,10 @@ export class ProbabilisticGenerator implements GeneratorInstance {
 
     // Decisión probabilística de generar nota
     const shouldGenerateNote = Math.random() < (density * intensity);
+    console.log('🎲 Probabilistic decision:', shouldGenerateNote, 'density:', density, 'intensity:', intensity);
     
     if (shouldGenerateNote) {
+      console.log('🎵 Generating probabilistic note');
       const scaleNotes = getScaleNotes(key, scale);
       const note = this.selectWeightedNote(scaleNotes);
       const velocity = this.calculateVelocity(intensity, variation);
@@ -83,6 +85,7 @@ export class ProbabilisticGenerator implements GeneratorInstance {
 
   private selectWeightedNote(scaleNotes: number[]): number {
     const weights = scaleNotes.map(n => this.noteWeights.get(n) || 1);
+    if (weights.length === 0) return 60;
     const index = weightedRandomChoice(weights);
     return scaleNotes[index] || scaleNotes[0];
   }

--- a/src/crealab/utils/MusicalMath.ts
+++ b/src/crealab/utils/MusicalMath.ts
@@ -39,10 +39,18 @@ export function euclideanRhythm(pulses: number, steps: number): boolean[] {
 // Get MIDI notes for given key and scale using tonal
 export function getScaleNotes(key: string, scale: string): number[] {
   const tonalScale = Scale.get(`${key} ${scale}`);
-  return tonalScale.notes.map(n => {
+  
+  if (!tonalScale.notes || tonalScale.notes.length === 0) {
+    // Fallback to C major scale
+    console.warn('Failed to get scale notes, using C major fallback');
+    return [60, 62, 64, 65, 67, 69, 71]; // C major scale starting from middle C
+  }
+  
+  const notes = tonalScale.notes.map(n => {
     const midi = Note.midi(n);
     return midi != null ? midi : 60;
   });
+  return notes.length > 0 ? notes : [60, 62, 64, 65, 67, 69, 71];
 }
 
 // Weighted random choice returns index based on weights array


### PR DESCRIPTION
## Summary
- simplify playback toggle to sync play flags with generator state
- remove per-track play buttons and style
- add detailed logging, active track filtering, and default parameter tweaks for generators

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: multiple type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3e9101608333912efa8b90a5f537