### PR TITLE
feat: expand generative dub visuals

### DIFF
--- a/src/presets/generative-dub/config.json
+++ b/src/presets/generative-dub/config.json
@@ -1,10 +1,10 @@
 {
   "name": "Generative Dub",
-  "description": "Auto-evolving visuals that never repeat",
+  "description": "Generative fractals and particles that evolve forever",
   "author": "AudioVisualizer",
   "version": "1.0.0",
   "category": "generative",
-  "tags": ["auto", "infinite", "dub", "abstract", "audio-reactive"],
+  "tags": ["auto", "infinite", "dub", "abstract", "audio-reactive", "fractal", "particles"],
   "thumbnail": "generative_dub_thumb.png",
   "defaultConfig": {
     "opacity": 1.0


### PR DESCRIPTION
## Summary
- add 10 fractal and particle patterns to Generative Dub preset with smooth transitions
- smooth and amplify audio FFT response for gentler but more sensitive visuals
- tag preset as fractal and particles

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b43113cda48333b0ac85b4cace66ee