### PR TITLE
Add empty preset template and fix beat handling

### DIFF
--- a/src/core/LayerManager.ts
+++ b/src/core/LayerManager.ts
@@ -275,8 +275,10 @@ export class LayerManager {
   }
 
   public triggerBeat(): void {
-    this.layers.forEach(layer => {
-      layer.preset?.onBeat();
+    this.layers.forEach((layer, layerId) => {
+      if (!layer.preset) return;
+      const active = this.presetLoader.getActivePreset(`${layerId}-${layer.preset.id}`);
+      active?.onBeat();
     });
   }
 

--- a/src/presets/empty/config.json
+++ b/src/presets/empty/config.json
@@ -1,0 +1,22 @@
+{
+  "name": "Empty",
+  "description": "Renders nothing; placeholder preset",
+  "author": "AudioVisualizer",
+  "version": "1.0.0",
+  "category": "utility",
+  "tags": ["empty", "placeholder"],
+  "defaultConfig": {
+    "opacity": 0
+  },
+  "controls": [],
+  "audioMapping": {
+    "low": {"description": "No effect", "frequency": "20-250 Hz", "effect": "None"},
+    "mid": {"description": "No effect", "frequency": "250-4000 Hz", "effect": "None"},
+    "high": {"description": "No effect", "frequency": "4000+ Hz", "effect": "None"}
+  },
+  "performance": {
+    "complexity": "low",
+    "recommendedFPS": 60,
+    "gpuIntensive": false
+  }
+}

--- a/src/presets/empty/preset.ts
+++ b/src/presets/empty/preset.ts
@@ -1,0 +1,41 @@
+import * as THREE from 'three';
+import { BasePreset, PresetConfig } from '../../core/PresetLoader';
+
+export const config: PresetConfig = {
+  name: 'Empty',
+  description: 'Renders nothing; placeholder preset',
+  author: 'AudioVisualizer',
+  version: '1.0.0',
+  category: 'utility',
+  tags: ['empty', 'placeholder'],
+  defaultConfig: {
+    opacity: 0
+  },
+  controls: [],
+  audioMapping: {
+    low: { description: 'No effect', frequency: '20-250 Hz', effect: 'None' },
+    mid: { description: 'No effect', frequency: '250-4000 Hz', effect: 'None' },
+    high: { description: 'No effect', frequency: '4000+ Hz', effect: 'None' }
+  },
+  performance: { complexity: 'low', recommendedFPS: 60, gpuIntensive: false }
+};
+
+class EmptyPreset extends BasePreset {
+  constructor(scene: THREE.Scene, camera: THREE.Camera, renderer: THREE.WebGLRenderer, cfg: PresetConfig) {
+    super(scene, camera, renderer, cfg);
+  }
+
+  public init(): void {}
+  public update(): void {}
+  public dispose(): void {}
+}
+
+export function createPreset(
+  scene: THREE.Scene,
+  camera: THREE.Camera,
+  renderer: THREE.WebGLRenderer,
+  cfg: PresetConfig,
+  shaderCode?: string
+): BasePreset {
+  return new EmptyPreset(scene, camera, renderer, cfg);
+}


### PR DESCRIPTION
## Summary
- add empty preset template for placeholder visuals
- fix beat trigger to call active preset instances

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json --noEmit` (fails: Property 'setBpm' does not exist on type 'LoadedPreset' and other type errors)


------
https://chatgpt.com/codex/tasks/task_e_68b440a5f72883339f8033d9d4062ae5