### PR TITLE
feat: isolate layers with independent cameras

### DIFF
--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { PresetLoader, LoadedPreset, AudioData } from './PresetLoader';
-import { LayerManager } from './LayerManager';
+import { LayerManager, LayerState } from './LayerManager';
 import { Compositor } from './Compositor';
 // Using simple path helpers instead of Node's `path` module which is not
 // available in the browser runtime. Node's `path.join` was causing errors
@@ -8,16 +8,6 @@ import { Compositor } from './Compositor';
 // For our use case we only need basic string concatenation to build and
 // inspect paths, so we implement lightweight helpers below.
 import { setNestedValue } from '../utils/objectPath';
-
-interface LayerState {
-  preset: LoadedPreset | null;
-  scene: THREE.Scene;
-  opacity: number;
-  fadeTime: number;
-  isActive: boolean;
-  renderTarget?: THREE.WebGLRenderTarget;
-  material?: THREE.Material;
-}
 
 
 export class AudioVisualizerEngine {
@@ -154,7 +144,8 @@ export class AudioVisualizerEngine {
         presetId,
         layer.scene,
         `${layerId}-${presetId}`,
-        loadedPresetConfig
+        loadedPresetConfig,
+        layer.camera
       );
       if (!presetInstance) {
         console.error(`No se pudo activar preset ${presetId}`);

--- a/src/core/PresetLoader.ts
+++ b/src/core/PresetLoader.ts
@@ -577,7 +577,8 @@ export class PresetLoader {
     presetId: string,
     scene: THREE.Scene,
     instanceId: string,
-    configOverride?: PresetConfig
+    configOverride?: PresetConfig,
+    cameraOverride?: THREE.Camera
   ): BasePreset | null {
     const loadedPreset = this.loadedPresets.get(presetId);
     if (!loadedPreset) {
@@ -590,7 +591,7 @@ export class PresetLoader {
 
       const presetInstance = loadedPreset.createPreset(
         scene,
-        this.camera,
+        cameraOverride ?? this.camera,
         this.renderer,
         configOverride ?? loadedPreset.config,
         loadedPreset.shaderCode


### PR DESCRIPTION
## Summary
- give each visual layer its own camera cloned from the base camera
- reset renderer state between layers and on resize for clean isolation
- allow presets to receive layer-specific cameras when activated

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unable to find your web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc84ff2ac8333be545c6cf5a6703d