### PR TITLE
fix layering order and engine refactor

### DIFF
--- a/src/core/Compositor.ts
+++ b/src/core/Compositor.ts
@@ -42,6 +42,13 @@ export class Compositor {
         uniform float globalOpacity;
         varying vec2 vUv;
 
+        vec4 blend(vec4 top, vec4 bottom) {
+          return vec4(
+            top.rgb * top.a + bottom.rgb * bottom.a * (1.0 - top.a),
+            top.a + bottom.a * (1.0 - top.a)
+          );
+        }
+
         void main() {
           vec4 colorC = texture2D(layerC, vUv);
           vec4 colorB = texture2D(layerB, vUv);
@@ -51,12 +58,9 @@ export class Compositor {
           colorB.a *= opacityB;
           colorA.a *= opacityA;
 
-          vec4 result = vec4(0.0, 0.0, 0.0, 0.0);
-          result = mix(result, colorC, colorC.a);
-          result.rgb = mix(result.rgb, colorB.rgb, colorB.a);
-          result.a = max(result.a, colorB.a);
-          result.rgb = mix(result.rgb, colorA.rgb, colorA.a);
-          result.a = max(result.a, colorA.a);
+          vec4 result = colorC;
+          result = blend(colorB, result);
+          result = blend(colorA, result);
           result.a *= globalOpacity;
           gl_FragColor = result;
         }

--- a/src/core/LayerManager.ts
+++ b/src/core/LayerManager.ts
@@ -82,11 +82,10 @@ export class LayerManager {
     this.layers.forEach(layer => {
       if (!layer.isActive || !layer.preset || !layer.renderTarget) return;
 
-      this.renderer.setClearColor(0x000000, 0);
       this.renderer.setRenderTarget(layer.renderTarget);
-      this.renderer.clearDepth(); // Clear only depth buffer
-      this.renderer.clearStencil(); // Clear only stencil buffer
-      // Do NOT clear the color buffer (alpha channel)
+      this.renderer.setClearColor(0x000000, 0);
+      // Clear color, depth and stencil so each layer starts from a blank buffer
+      this.renderer.clear(true, true, true);
       this.renderer.render(layer.scene, layer.camera);
       // Reset state so next layer starts clean
       this.renderer.resetState();


### PR DESCRIPTION
## Summary
- clear render targets before each layer render to avoid cross-layer artifacts
- composite layers with proper alpha blending and order
- delegate layer preset handling to LayerManager for consistency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'uvs' has no initializer and other TypeScript errors in presets)*

------
https://chatgpt.com/codex/tasks/task_e_68bccd02a2b88333b6a802836b397e2e