### PR TITLE
Fix electron layer config handling and preset bug

### DIFF
--- a/preload.cjs
+++ b/preload.cjs
@@ -1,4 +1,5 @@
 const { contextBridge, ipcRenderer } = require('electron');
+const fs = require('fs');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   applySettings: (settings) => ipcRenderer.send('apply-settings', settings),
@@ -11,5 +12,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Notification when the main window exits fullscreen
   onMainLeaveFullscreen: (callback) => ipcRenderer.on('main-leave-fullscreen', callback),
   removeMainLeaveFullscreenListener: () => ipcRenderer.removeAllListeners('main-leave-fullscreen'),
-  tcpRequest: (command, port, host) => ipcRenderer.invoke('tcp-request', command, port, host)
+  tcpRequest: (command, port, host) => ipcRenderer.invoke('tcp-request', command, port, host),
+  // Basic filesystem helpers for renderer
+  readTextFile: (path) => fs.promises.readFile(path, 'utf-8'),
+  writeTextFile: (path, contents) => fs.promises.writeFile(path, contents),
+  createDir: (dir) => fs.promises.mkdir(dir, { recursive: true }),
+  exists: (path) => Promise.resolve(fs.existsSync(path))
 });

--- a/src/core/LayerManager.ts
+++ b/src/core/LayerManager.ts
@@ -198,9 +198,10 @@ export class LayerManager {
             return JSON.parse(await readTextFile(cfgPath));
           }
         } else if ((window as any).electronAPI) {
-          const fs = await import('fs');
-          if (fs.existsSync(cfgPath)) {
-            return JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+          const api = (window as any).electronAPI;
+          if (await api.exists(cfgPath)) {
+            const content = await api.readTextFile(cfgPath);
+            return JSON.parse(content);
           }
         }
       }
@@ -226,9 +227,9 @@ export class LayerManager {
           await createDir(dir, { recursive: true });
           await writeFile({ path: cfgPath, contents: JSON.stringify(cfg, null, 2) });
         } else if ((window as any).electronAPI) {
-          const fs = await import('fs');
-          await fs.promises.mkdir(dir, { recursive: true });
-          await fs.promises.writeFile(cfgPath, JSON.stringify(cfg, null, 2));
+          const api = (window as any).electronAPI;
+          await api.createDir(dir);
+          await api.writeTextFile(cfgPath, JSON.stringify(cfg, null, 2));
         }
       }
     } catch (err) {

--- a/src/presets/text-glitch/preset.ts
+++ b/src/presets/text-glitch/preset.ts
@@ -307,56 +307,6 @@ class RoboticaCinematicPreset extends BasePreset {
     const fontFamily = this.currentConfig.text.fontFamily;
     const scale = this.currentConfig.text.scale;
 
-    // Calculate total width of the text in normalized coordinates (-1 to 1)
-    // Assuming a base letter width of 0.1 units in normalized space
-    const baseLetterWidth = 0.1;
-    const baseLetterSpacing = 0.02;
-    const baseWordSpacing = 0.05;
-
-    let totalWidth = 0;
-    for (const char of rawText) {
-      if (char === ' ') {
-        totalWidth += baseWordSpacing;
-      } else {
-        totalWidth += baseLetterWidth + baseLetterSpacing;
-      }
-    }
-    totalWidth -= baseLetterSpacing;
-
-    const startX = -totalWidth / 2.0;
-    let currentX = startX;
-
-    for (let charIdx = 0; charIdx < rawText.length; charIdx++) {
-      const char = rawText[charIdx];
-      
-      if (char === ' ') {
-        currentX += baseWordSpacing;
-        continue;
-      }
-
-      const position = new THREE.Vector3(currentX + baseLetterWidth / 2, 0, 0);
-      const letter = new CinematicLetter(char, fontSize, fontFamily, position);
-      
-      this.letters.push(letter);
-      this.textGroup.add(letter.getMesh());
-
-      currentX += baseLetterWidth + baseLetterSpacing;
-    }
-
-    // Apply global scale from config
-    this.textGroup.scale.setScalar(scale);
-
-    // Posicionar el grupo en el centro de la pantalla
-    this.textGroup.position.set(0, 0, 0);
-  }
-
-  private createCinematicText(): void {
-    const rawText = this.currentConfig.text.content;
-    const letters = rawText.replace(/\s+/g, '').split('');
-    const fontSize = this.currentConfig.text.fontSize;
-    const fontFamily = this.currentConfig.text.fontFamily;
-    const scale = this.currentConfig.text.scale;
-
     const letterWidth = fontSize * 0.8; // Aproximacion del ancho de cada letra en px
     const availableWidth = (this.currentConfig.width || 1920) * 0.9375; // Usar el 94% del ancho
     const spacing = (availableWidth - letterWidth) / Math.max(letters.length - 1, 1);

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -5,6 +5,10 @@ interface Window {
     applySettings: (settings: { maximize?: boolean; monitorId?: number }) => void;
     getDisplays: () => Promise<{ id: number; label: string; bounds: { x: number; y: number; width: number; height: number }; scaleFactor: number; primary: boolean; }[]>;
     toggleFullscreen: (ids: number[]) => Promise<void>;
+    readTextFile: (path: string) => Promise<string>;
+    writeTextFile: (path: string, contents: string) => Promise<void>;
+    createDir: (dir: string) => Promise<void>;
+    exists: (path: string) => Promise<boolean>;
   };
 }
 


### PR DESCRIPTION
## Summary
- expose filesystem helpers via electron preload
- use electronAPI for reading/writing layer configs
- remove duplicate `createCinematicText` method in text-glitch preset
- extend global types for new electronAPI helpers

## Testing
- `npm run build` *(fails: Unable to find your web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd00350048333bb79a50123620f3e