### PR TITLE
Fix default exports for lazily loaded components

### DIFF
--- a/src/components/FractalLabPresetModal.tsx
+++ b/src/components/FractalLabPresetModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { LoadedPreset } from '../core/PresetLoader';
-import { PresetControls } from './PresetControls';
+import PresetControls from './PresetControls';
 import { setNestedValue } from '../utils/objectPath';
 import './FractalLabPresetModal.css';
 

--- a/src/components/GenLabPresetModal.tsx
+++ b/src/components/GenLabPresetModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { LoadedPreset } from '../core/PresetLoader';
-import { PresetControls } from './PresetControls';
+import PresetControls from './PresetControls';
 import { setNestedValue } from '../utils/objectPath';
 import './GenLabPresetModal.css';
 

--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -92,7 +92,7 @@ interface GlobalSettingsModalProps {
   onVisualsPathChange: (value: string) => void;
 }
 
-export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
+const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
   isOpen,
   onClose,
   audioDevices,
@@ -287,4 +287,6 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
     </div>
   );
 };
+
+export default GlobalSettingsModal;
 

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -40,7 +40,7 @@ interface LayerGridProps {
   bpm: number | null;
 }
 
-export const LayerGrid: React.FC<LayerGridProps> = ({
+const LayerGrid: React.FC<LayerGridProps> = ({
   presets,
   onPresetActivate,
   onLayerClear,
@@ -448,3 +448,5 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
     </div>
   );
 };
+
+export default LayerGrid;

--- a/src/components/PresetControls.tsx
+++ b/src/components/PresetControls.tsx
@@ -35,7 +35,7 @@ interface PresetControlsProps {
   isReadOnly?: boolean;
 }
 
-export const PresetControls: React.FC<PresetControlsProps> = ({
+const PresetControls: React.FC<PresetControlsProps> = ({
   preset,
   config,
   onChange,
@@ -122,3 +122,5 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
     </div>
   );
 };
+
+export default PresetControls;

--- a/src/components/ResourcesModal.tsx
+++ b/src/components/ResourcesModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { LAUNCHPAD_PRESETS, LaunchpadPreset } from '../utils/launchpad';
 import { LoadedPreset } from '../core/PresetLoader';
 import { getPresetThumbnail } from '../utils/presetThumbnails';
-import { PresetControls } from './PresetControls';
+import PresetControls from './PresetControls';
 import { setNestedValue } from '../utils/objectPath';
 import { GenLabPresetModal } from './GenLabPresetModal';
 import { FractalLabPresetModal } from './FractalLabPresetModal';
@@ -55,7 +55,7 @@ interface TreeNode {
   fractalLabIndex?: number;
 }
 
-export const ResourcesModal: React.FC<ResourcesModalProps> = ({
+const ResourcesModal: React.FC<ResourcesModalProps> = ({
   isOpen,
   onClose,
   presets,
@@ -800,4 +800,6 @@ export const ResourcesModal: React.FC<ResourcesModalProps> = ({
     </>
   );
 };
+
+export default ResourcesModal;
 


### PR DESCRIPTION
## Summary
- switch LayerGrid, PresetControls, ResourcesModal, and GlobalSettingsModal to default exports
- update modal imports to use the new default PresetControls export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd484f58dc833399e77f6804a214d6