### PR TITLE
Fix preset orientation and JungleGrid connectivity

### DIFF
--- a/src/presets/analysis/preset.ts
+++ b/src/presets/analysis/preset.ts
@@ -84,14 +84,7 @@ class AnalysisSpectrum extends BasePreset {
   private ambient?: THREE.AmbientLight;
   private pointLight?: THREE.PointLight;
   private starField?: THREE.Points;
-  private rings: Record<BandName, THREE.Mesh> = {
-    band1: new THREE.Mesh(),
-    band2: new THREE.Mesh(),
-    band3: new THREE.Mesh(),
-    band4: new THREE.Mesh(),
-    band5: new THREE.Mesh(),
-    band6: new THREE.Mesh()
-  };
+  private rings: Partial<Record<BandName, THREE.Mesh>> = {};
   private currentConfig: any;
   private initialCameraPosition = this.camera.position.clone();
   private initialCameraQuaternion = this.camera.quaternion.clone();
@@ -156,21 +149,7 @@ class AnalysisSpectrum extends BasePreset {
     this.starField = new THREE.Points(starGeometry, starMaterial);
     this.scene.add(this.starField);
 
-    // Crear anillos para cada banda de frecuencia
-    (Object.keys(this.rings) as BandName[]).forEach((band, i) => {
-      const ringGeo = new THREE.RingGeometry(0.5, 0.6, 64);
-      const ringMat = new THREE.MeshBasicMaterial({
-        color: this.currentConfig.colors[band],
-        transparent: true,
-        opacity: 0.4,
-        side: THREE.DoubleSide
-      });
-      const ring = new THREE.Mesh(ringGeo, ringMat);
-      ring.rotation.x = Math.PI / 2;
-      ring.position.y = 1 + i * 0.3;
-      this.group.add(ring);
-      this.rings[band] = ring;
-    });
+    // Removed frequency rings in favor of particle-only visualization
   }
 
   private createFrequencyGrid(): void {
@@ -243,15 +222,16 @@ class AnalysisSpectrum extends BasePreset {
 
   private createDbLabels(): void {
     this.dbLabels = new THREE.Group();
-    const canvas = document.createElement('canvas');
-    const context = canvas.getContext('2d')!;
-    canvas.width = 64;
-    canvas.height = 32;
 
     const dbLevels = ['-60dB', '-40dB', '-20dB', '0dB'];
     const yPositions = [0.5, 1.5, 2.5, 3.5];
 
     dbLevels.forEach((db, i) => {
+      const canvas = document.createElement('canvas');
+      const context = canvas.getContext('2d')!;
+      canvas.width = 64;
+      canvas.height = 32;
+
       context.clearRect(0, 0, 64, 32);
       context.shadowColor = '#884C3A';
       context.shadowBlur = 8;
@@ -467,10 +447,12 @@ class AnalysisSpectrum extends BasePreset {
     if (this.pointLight) this.scene.remove(this.pointLight);
     if (this.starField) this.scene.remove(this.starField);
 
-    (Object.values(this.rings) as THREE.Mesh[]).forEach(r => {
-      this.group.remove(r);
-      r.geometry.dispose();
-      (r.material as THREE.Material).dispose();
+    Object.values(this.rings).forEach(r => {
+      if (r) {
+        this.group.remove(r);
+        r.geometry.dispose();
+        (r.material as THREE.Material).dispose();
+      }
     });
 
     this.camera.position.copy(this.initialCameraPosition);

--- a/src/presets/jungle-grid/preset.ts
+++ b/src/presets/jungle-grid/preset.ts
@@ -22,14 +22,23 @@ type TrackInfo = {
 class AbletonRemoteClient {
   async request<T = any>(command: object, port = 9888, host = "127.0.0.1"): Promise<T> {
     if ((window as any).electronAPI?.tcpRequest) {
-        try {
-            const result = await (window as any).electronAPI.tcpRequest(command, port, host);
-            return result;
-        } catch (error) {
-            console.error("JungleGrid: TCP request failed:", error);
-            return Promise.reject(error);
-        }
-    } else {
+      try {
+        const result = await (window as any).electronAPI.tcpRequest(command, port, host);
+        return result;
+      } catch (error) {
+        console.error("JungleGrid: TCP request failed:", error);
+        return Promise.reject(error);
+      }
+    }
+
+    // Fallback attempt using HTTP when running outside Electron
+    try {
+      const response = await fetch(`http://${host}:${port}`, {
+        method: 'POST',
+        body: JSON.stringify(command)
+      });
+      return (await response.json()) as T;
+    } catch (error) {
       console.warn("JungleGrid: electronAPI.tcpRequest not found. Using stub data.");
       return Promise.resolve<any>([]);
     }

--- a/src/presets/neural_network/preset.ts
+++ b/src/presets/neural_network/preset.ts
@@ -126,8 +126,8 @@ export class InfiniteNeuralNetwork extends BasePreset {
   private nodes: Node[] = [];
   private connections: Connection[] = [];
   private currentConfig: any;
-  // Track next Z position where a node will be spawned so we can
-  // simulate travelling forward instead of sideways
+  // Track next negative Z position where a node will be spawned so we can
+  // simulate traveling inward along the network
   private nextSpawnZ = 0;
   private initialCameraPosition = new THREE.Vector3();
   private initialCameraQuaternion = new THREE.Quaternion();
@@ -154,8 +154,8 @@ export class InfiniteNeuralNetwork extends BasePreset {
     // this.camera.position.set(0, 0, 0);
     // this.camera.lookAt(1, 0, 0);
 
-    // Generar nodos iniciales
-    while (this.nextSpawnZ < 50) {
+    // Generar nodos iniciales delante de la camara
+    while (this.nextSpawnZ > -50) {
       this.spawnNode();
     }
   }
@@ -165,8 +165,8 @@ export class InfiniteNeuralNetwork extends BasePreset {
 
     // Reduce spacing between nodes for higher density
     // Instead of moving along the X axis we spawn nodes further down
-    // the Z axis so the network appears to approach the camera
-    const z = this.nextSpawnZ + Math.random() * 1 + 0.5;
+    // the negative Z axis so the network appears to approach the camera
+    const z = this.nextSpawnZ - Math.random() * 1 - 0.5;
     const x = (Math.random() - 0.5) * 4;
     const y = (Math.random() - 0.5) * 4;
     const node = new Node(new THREE.Vector3(x, y, z), this.createNodeMaterial(), size);
@@ -191,7 +191,7 @@ export class InfiniteNeuralNetwork extends BasePreset {
       }
     }
 
-    // Record last spawn position
+    // Record last spawn position (more negative)
     this.nextSpawnZ = z;
   }
 
@@ -237,15 +237,15 @@ export class InfiniteNeuralNetwork extends BasePreset {
 
     const speed = this.currentConfig.speed * (0.5 + this.audioData.high);
     // Move the entire scene content instead of the camera
-    // Move the scene backwards on Z so the viewer travels through it
-    this.scene.position.z -= delta * speed;
+    // Move the scene forward on Z so the viewer travels inward
+    this.scene.position.z += delta * speed;
     // Continuously spawn nodes ahead of the camera
-    while (this.nextSpawnZ < this.scene.position.z + 50) {
+    while (this.nextSpawnZ > -50 - this.scene.position.z) {
       this.spawnNode();
     }
 
     // Remove nodes that are far behind the camera to keep memory usage stable
-    while (this.nodes.length && this.nodes[0].position.z < this.scene.position.z - 20) {
+    while (this.nodes.length && this.nodes[0].position.z + this.scene.position.z > 20) {
       const old = this.nodes.shift()!;
       this.removeNode(old);
     }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -9,6 +9,7 @@ interface Window {
     writeTextFile: (path: string, contents: string) => Promise<void>;
     createDir: (dir: string) => Promise<void>;
     exists: (path: string) => Promise<boolean>;
+    tcpRequest: (command: object, port?: number, host?: string) => Promise<any>;
   };
 }
 


### PR DESCRIPTION
## Summary
- Reverse travel direction in neural network preset
- Drop frequency rings and correct dB labels in analysis preset
- Add HTTP fallback for JungleGrid remote client
- Expose tcpRequest in global window typings

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68bd5dee63ec8333a0a7e74e7ae1acd0