### PR TITLE
Fix Generative Dub initialization and add Instanced Demo config

### DIFF
--- a/src/presets/generative-dub/preset.ts
+++ b/src/presets/generative-dub/preset.ts
@@ -178,7 +178,8 @@ class GenerativeDubPreset extends BasePreset {
         }
       `
     });
-    this.randomizePalette(material);
+    // Inicializar con parámetros y paleta aleatorios desde el comienzo
+    this.randomize(material);
     this.mesh = new THREE.Mesh(geometry, material);
     this.scene.add(this.mesh);
     this.lastChange = 0;

--- a/src/presets/instanced-demo/config.json
+++ b/src/presets/instanced-demo/config.json
@@ -1,0 +1,14 @@
+{
+  "name": "Instanced Demo",
+  "description": "Simple instanced cubes showcasing InstancedMesh",
+  "author": "AI",
+  "version": "1.0.0",
+  "category": "demo",
+  "tags": ["instanced", "performance"],
+  "thumbnail": "instanced_demo_thumb.png",
+  "note": 0,
+  "defaultConfig": {},
+  "controls": [],
+  "audioMapping": {},
+  "performance": { "complexity": "low", "recommendedFPS": 60, "gpuIntensive": false }
+}


### PR DESCRIPTION
## Summary
- randomize Generative Dub parameters on init so pattern and palette start visible
- add missing config.json for Instanced Demo preset

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bd663c86548333b98ca13f19ea1c87