### PR TITLE
Fix BPM propagation and Ableton grid data parsing

### DIFF
--- a/src/core/LayerManager.ts
+++ b/src/core/LayerManager.ts
@@ -301,8 +301,10 @@ export class LayerManager {
   }
 
   public updateBpm(bpm: number): void {
-    this.layers.forEach(layer => {
-      layer.preset?.setBpm(bpm);
+    this.layers.forEach((layer, layerId) => {
+      if (!layer.preset) return;
+      const active = this.presetLoader.getActivePreset(`${layerId}-${layer.preset.id}`);
+      active?.setBpm(bpm);
     });
   }
 

--- a/src/presets/jungle-grid/preset.ts
+++ b/src/presets/jungle-grid/preset.ts
@@ -44,8 +44,15 @@ class AbletonRemoteClient {
     }
   }
 
-  getTracksInfo(): Promise<TrackInfo[]> {
-    return this.request<TrackInfo[]>({ type: "get_tracks_info" });
+  async getTracksInfo(): Promise<TrackInfo[]> {
+    const response = await this.request<{ status?: string; result?: TrackInfo[] }>({ type: "get_tracks_info" });
+    if (response && Array.isArray((response as any).result)) {
+      return (response as any).result as TrackInfo[];
+    }
+    if (Array.isArray(response as any)) {
+      return response as any;
+    }
+    return [];
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure layer BPM updates apply to active preset instances
- parse Ableton Remote Script responses to retrieve track data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd82f1115883338976609608d643d4