### PR TITLE
chore: remove MIDI message debug log

### DIFF
--- a/src/hooks/useMidi.ts
+++ b/src/hooks/useMidi.ts
@@ -232,15 +232,6 @@ export function useMidi(options: MidiOptions) {
       const channel = (status & 0x0f) + 1;
       const messageType = status & 0xf0;
 
-      // Debug MIDI messages
-      console.log('MIDI Message:', {
-        status,
-        note,
-        velocity,
-        channel,
-        messageType,
-      });
-
       // Solo procesar LaunchPad toggle si es exactamente el canal y nota configurados
       if (
         channel === launchpadChannel &&


### PR DESCRIPTION
## Summary
- remove verbose console.log from MIDI handler to avoid console spam

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bd95a9ccf483339c7fa18c71d15726