### PR TITLE
Fix LaunchPad auto-start, generative dub visuals, and Ableton Grid connection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' http://127.0.0.1:9888; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' http://127.0.0.1:9888 ws://127.0.0.1:9888 ws://localhost:9888; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" />
     <title>Jungle Lab Studio</title>
   </head>
   <body>

--- a/src/hooks/useMidi.ts
+++ b/src/hooks/useMidi.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { AudioVisualizerEngine } from '../core/AudioVisualizerEngine';
 import { LoadedPreset } from '../core/PresetLoader';
+import { isLaunchpadDevice } from '../utils/launchpad';
 
 interface MidiTrigger {
   layerId: string;
@@ -328,7 +329,9 @@ export function useMidi(options: MidiOptions) {
       (navigator as any)
         .requestMIDIAccess({ sysex: true })
         .then((access: any) => {
-          const inputs = Array.from(access.inputs.values());
+          const inputs = Array.from(access.inputs.values()).filter(
+            (i: any) => !isLaunchpadDevice(i)
+          );
           setMidiDevices(inputs);
 
           inputs.forEach((input: any) => {
@@ -340,7 +343,9 @@ export function useMidi(options: MidiOptions) {
           });
 
           access.onstatechange = () => {
-            const ins = Array.from(access.inputs.values());
+            const ins = Array.from(access.inputs.values()).filter(
+              (i: any) => !isLaunchpadDevice(i)
+            );
             setMidiDevices(ins);
             ins.forEach((input: any) => {
               if (!midiDeviceId || input.id === midiDeviceId) {

--- a/src/presets/generative-dub/preset.ts
+++ b/src/presets/generative-dub/preset.ts
@@ -89,7 +89,7 @@ class GenerativeDubPreset extends BasePreset {
         uColor3: { value: new THREE.Color('#5bc0be') }
       },
       vertexShader: `
-        out vec2 vUv;
+        varying vec2 vUv;
         void main() {
           vUv = uv;
           gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
@@ -97,7 +97,7 @@ class GenerativeDubPreset extends BasePreset {
       `,
       fragmentShader: `
         precision highp float;
-        in vec2 vUv;
+        varying vec2 vUv;
         uniform float uTime;
         uniform float uOpacity;
         uniform vec3 uParams;
@@ -110,10 +110,9 @@ class GenerativeDubPreset extends BasePreset {
         uniform vec3 uColor1;
         uniform vec3 uColor2;
         uniform vec3 uColor3;
-        out vec4 fragColor;
 
         float hash(vec2 p){ return fract(sin(dot(p, vec2(127.1,311.7))) * 43758.5453123); }
-        
+
         float noise(vec2 p){
           vec2 i = floor(p);
           vec2 f = fract(p);
@@ -124,7 +123,7 @@ class GenerativeDubPreset extends BasePreset {
           vec2 u = f * f * (3.0 - 2.0 * f);
           return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
         }
-        
+
         float fbm(vec2 p){
           float v = 0.0;
           float a = 0.5;
@@ -185,10 +184,9 @@ class GenerativeDubPreset extends BasePreset {
           float pattern = mix(pA, pB, uBlend);
           vec3 col = mix(uColor1, uColor2, pattern);
           col = mix(col, uColor3, pattern * pattern);
-          fragColor = vec4(col, uOpacity);
+          gl_FragColor = vec4(col, uOpacity);
         }
-      `,
-      glslVersion: THREE.GLSL3
+      `
     });
     
     // Inicializar con parámetros y paleta aleatorios desde el comienzo


### PR DESCRIPTION
## Summary
- prevent LaunchPad visualization from auto-starting by ignoring LaunchPad MIDI inputs
- rewrite Generative Dub shader for WebGL1 so it renders on per-layer canvases
- allow Ableton Grid WebSocket connections by updating CSP

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd99b44c388333b00fe2bfd4c0618e