### PR TITLE
feat: debounce launchpad toggle and improve logging

### DIFF
--- a/src/hooks/useLaunchpad.ts
+++ b/src/hooks/useLaunchpad.ts
@@ -105,11 +105,18 @@ export function useLaunchpad(audioData: AudioData, canvasRef: React.RefObject<HT
   }, [audioData, launchpadRunning, launchpadPreset, launchpadOutput, launchpadSmoothness, launchpadText, canvasRef]);
 
   useEffect(() => {
-    console.log('LaunchPad state change:', {
-      running: launchpadRunning,
-      hasOutput: !!launchpadOutput,
-      outputId: launchpadOutput?.id,
-    });
+    console.log(
+      'LaunchPad state change:',
+      JSON.stringify(
+        {
+          running: launchpadRunning,
+          hasOutput: !!launchpadOutput,
+          outputId: launchpadOutput?.id,
+        },
+        null,
+        2,
+      ),
+    );
 
     if (launchpadRunning && launchpadOutput) {
       try {


### PR DESCRIPTION
## Summary
- debounce LaunchPad MIDI toggle to prevent rapid retriggers
- log LaunchPad state changes and triggers as JSON for clearer debugging

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bda3f6c1848333bb887b99289be6f0