### PR TITLE
Fix generative dub visuals and quiet Jungle grid logs

### DIFF
--- a/src/core/PresetLoader.ts
+++ b/src/core/PresetLoader.ts
@@ -412,9 +412,7 @@ export class PresetLoader {
       // Auto-configurar preset si es necesario
       // Auto-configurar preset si es necesario
       cfg = this.autoConfigurePreset(cfg, presetId);
-      console.log(`Jungle-Grid-Debug: Validating config for ${presetId}`, cfg);
       const isValid = validateConfig(cfg);
-      console.log(`Jungle-Grid-Debug: Is config valid for ${presetId}? ${isValid}`);
       if (!isValid) {
         console.warn(`Invalid config for ${presetId}, skipping`);
 

--- a/src/presets/generative-dub/preset.ts
+++ b/src/presets/generative-dub/preset.ts
@@ -61,6 +61,14 @@ class GenerativeDubPreset extends BasePreset {
   public init(): void {
     this.currentConfig = JSON.parse(JSON.stringify(this.config.defaultConfig));
     const geometry = new THREE.PlaneGeometry(2, 2);
+
+    // Ensure the plane fills the view even after other presets modify the camera
+    if (this.camera instanceof THREE.PerspectiveCamera) {
+      this.camera.position.set(0, 0, 1);
+      this.camera.lookAt(0, 0, 0);
+      this.camera.updateProjectionMatrix();
+    }
+
     this.currentPattern = Math.floor(Math.random() * 10);
     this.nextPattern = this.currentPattern;
     
@@ -194,6 +202,7 @@ class GenerativeDubPreset extends BasePreset {
     this.mesh = new THREE.Mesh(geometry, material);
     this.scene.add(this.mesh);
     this.lastChange = 0;
+    this.clock.start();
   }
 
   private randomize(material: THREE.ShaderMaterial): void {


### PR DESCRIPTION
## Summary
- Reset camera and start clock for generative-dub preset so visuals render again
- Remove verbose Jungle Grid debugging and log a single connection message
- Clean up preset loader by dropping leftover debug logs

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68bdaaa3c58c8333975a5f6562c48db8