### PR TITLE
Fix missing presets by permitting VFX config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ A comprehensive music production suite featuring the **AudioVisualizer**: real-t
 2. Include a `config.json` file that follows the schema defined in [`presets/schema.json`](presets/schema.json).
 3. Create a `preset.ts` file that exports `config` and `createPreset`.
 4. Optionally add `shader.wgsl` if the preset uses custom shaders.
+5. Presets can declare optional visual effects under a `vfx` section in their `config.json`.
 
 The configuration is automatically validated when the application loads using [Ajv](https://ajv.js.org/). If the `config.json` file does not match the schema, the preset will be skipped and an error will be shown in the console.

--- a/presets/schema.json
+++ b/presets/schema.json
@@ -51,6 +51,24 @@
         }
       }
     },
+    "vfx": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "effects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "label"],
+            "properties": {
+              "name": {"type": "string"},
+              "label": {"type": "string"}
+            }
+          }
+        }
+      }
+    },
     "audioMapping": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
## Summary
- allow `vfx` section in preset schema so presets with visual effects load correctly
- document optional `vfx` field for presets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc750c54083338433960e6cac2d18