### PR TITLE
feat: integrate persistent vfx controls

### DIFF
--- a/src/components/ResourcesModal.tsx
+++ b/src/components/ResourcesModal.tsx
@@ -33,7 +33,13 @@ interface ResourcesModalProps {
   launchpadText?: string;
   onLaunchpadTextChange?: (text: string) => void;
   onTriggerVFX?: (layerId: string, effect: string) => void;
-  onSetVFX?: (layerId: string, effect: string, enabled: boolean) => void;
+  onSetVFX?: (
+    layerId: string,
+    presetId: string,
+    effect: string,
+    enabled: boolean
+  ) => void;
+  layerVFX?: Record<string, Record<string, string[]>>;
 }
 
 type NodeKind =
@@ -83,7 +89,8 @@ const ResourcesModal: React.FC<ResourcesModalProps> = ({
   launchpadText,
   onLaunchpadTextChange,
   onTriggerVFX,
-  onSetVFX
+  onSetVFX,
+  layerVFX
 }) => {
   const [selectedNode, setSelectedNode] = useState<TreeNode | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set([
@@ -484,6 +491,9 @@ const ResourcesModal: React.FC<ResourcesModalProps> = ({
     switch (selectedNode.kind) {
       case 'preset': {
         const preset = selectedNode.preset!;
+        const assigned = ['A', 'B', 'C'].filter(layer =>
+          layerAssignments[layer].has(preset.id)
+        );
         return (
           <div className="gallery-controls-panel">
             <div className="controls-header">
@@ -509,18 +519,33 @@ const ResourcesModal: React.FC<ResourcesModalProps> = ({
                 onChange={handleDefaultControlChange}
               />
             </div>
+            <VFXControls
+              preset={preset}
+              assignedLayers={assigned}
+              activeEffects={assigned.reduce((acc, layer) => {
+                acc[layer] = layerVFX?.[layer]?.[preset.id] || [];
+                return acc;
+              }, {} as Record<string, string[]>)}
+              onToggle={onSetVFX || (() => {})}
+            />
           </div>
         );
       }
       case 'vfx-preset': {
         const preset = selectedNode.preset!;
-        const assigned = ['A', 'B', 'C'].filter(layer => layerAssignments[layer].has(preset.id));
+        const assigned = ['A', 'B', 'C'].filter(layer =>
+          layerAssignments[layer].has(preset.id)
+        );
         return (
           <div className="gallery-controls-panel">
             <VFXControls
               preset={preset}
               assignedLayers={assigned}
-              onToggle={onSetVFX || (()=>{})}
+              activeEffects={assigned.reduce((acc, layer) => {
+                acc[layer] = layerVFX?.[layer]?.[preset.id] || [];
+                return acc;
+              }, {} as Record<string, string[]>)}
+              onToggle={onSetVFX || (() => {})}
             />
           </div>
         );

--- a/src/components/VFXControls.tsx
+++ b/src/components/VFXControls.tsx
@@ -1,36 +1,24 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { LoadedPreset } from '../core/PresetLoader';
 
 interface VFXControlsProps {
   preset: LoadedPreset;
   assignedLayers: string[];
-  onToggle: (layerId: string, effect: string, enabled: boolean) => void;
+  activeEffects: Record<string, string[]>;
+  onToggle: (
+    layerId: string,
+    presetId: string,
+    effect: string,
+    enabled: boolean
+  ) => void;
 }
 
-const VFXControls: React.FC<VFXControlsProps> = ({ preset, assignedLayers, onToggle }) => {
-  const [enabled, setEnabled] = useState<Record<string, Set<string>>>({});
-
-  useEffect(() => {
-    const initial: Record<string, Set<string>> = {};
-    assignedLayers.forEach(l => {
-      initial[l] = new Set();
-    });
-    setEnabled(initial);
-  }, [assignedLayers, preset]);
-
-  const handleToggle = (layer: string, effect: string, checked: boolean) => {
-    setEnabled(prev => {
-      const layerSet = new Set(prev[layer] || []);
-      if (checked) {
-        layerSet.add(effect);
-      } else {
-        layerSet.delete(effect);
-      }
-      return { ...prev, [layer]: layerSet };
-    });
-    onToggle(layer, effect, checked);
-  };
-
+const VFXControls: React.FC<VFXControlsProps> = ({
+  preset,
+  assignedLayers,
+  activeEffects,
+  onToggle
+}) => {
   const effects = preset.config.vfx?.effects || [];
 
   return (
@@ -47,8 +35,10 @@ const VFXControls: React.FC<VFXControlsProps> = ({ preset, assignedLayers, onTog
             <label key={layer} className="layer-toggle">
               <input
                 type="checkbox"
-                checked={enabled[layer]?.has(effect.name) || false}
-                onChange={e => handleToggle(layer, effect.name, e.target.checked)}
+                checked={activeEffects[layer]?.includes(effect.name) || false}
+                onChange={e =>
+                  onToggle(layer, preset.id, effect.name, e.target.checked)
+                }
               />
               {layer}
             </label>

--- a/src/core/LayerManager.ts
+++ b/src/core/LayerManager.ts
@@ -122,6 +122,13 @@ export class LayerManager {
         layer.scene.clear();
       }
 
+      const canvas = layer.renderer.domElement;
+      Array.from(canvas.classList).forEach(cls => {
+        if (cls.startsWith('vfx-') || cls.startsWith('effect-')) {
+          canvas.classList.remove(cls);
+        }
+      });
+
       const loadedPreset = this.presetLoader.getLoadedPresets().find(p => p.id === presetId);
       if (!loadedPreset) {
         console.error(`Loaded preset ${presetId} no encontrado`);

--- a/src/presets/abstract-lines/vfx.ts
+++ b/src/presets/abstract-lines/vfx.ts
@@ -1,9 +1,9 @@
 import { AudioData } from '../../core/PresetLoader';
+import { getIntensity, triggerEffect } from '../../utils/vfx';
 
 export function applyVFX(canvas: HTMLCanvasElement, audio: AudioData): void {
-  const intensity = (audio.low + audio.mid + audio.high) / 3;
+  const intensity = getIntensity(audio);
   if (intensity > 0.95) {
-    canvas.classList.add('effect-flash');
-    setTimeout(() => canvas.classList.remove('effect-flash'), 300);
+    triggerEffect(canvas, 'effect-flash', 300);
   }
 }

--- a/src/presets/analysis/vfx.ts
+++ b/src/presets/analysis/vfx.ts
@@ -1,15 +1,15 @@
 import { AudioData } from '../../core/PresetLoader';
+import { getIntensity, triggerEffect } from '../../utils/vfx';
+
+const glitches = ['effect-glitch1', 'effect-glitch2', 'effect-glitch3'];
 
 export function applyVFX(canvas: HTMLCanvasElement, audio: AudioData): void {
-  const intensity = (audio.low + audio.mid + audio.high) / 3;
+  const intensity = getIntensity(audio);
   if (canvas.classList.contains('vfx-flash') && intensity > 0.92) {
-    canvas.classList.add('effect-flash');
-    setTimeout(() => canvas.classList.remove('effect-flash'), 300);
+    triggerEffect(canvas, 'effect-flash', 300);
   }
   if (canvas.classList.contains('vfx-glitch') && audio.high > 0.85) {
-    const glitches = ['effect-glitch1', 'effect-glitch2', 'effect-glitch3'];
     const cls = glitches[Math.floor(Math.random() * glitches.length)];
-    canvas.classList.add(cls);
-    setTimeout(() => canvas.classList.remove(cls), 500);
+    triggerEffect(canvas, cls, 500);
   }
 }

--- a/src/presets/evolutive-particles/vfx.ts
+++ b/src/presets/evolutive-particles/vfx.ts
@@ -1,20 +1,18 @@
 import { AudioData } from '../../core/PresetLoader';
+import { getIntensity, triggerEffect } from '../../utils/vfx';
 
 const glitches = ['effect-glitch1', 'effect-glitch2', 'effect-glitch3'];
 
 export function applyVFX(canvas: HTMLCanvasElement, audio: AudioData): void {
-  const intensity = (audio.low + audio.mid + audio.high) / 3;
+  const intensity = getIntensity(audio);
   if (canvas.classList.contains('vfx-flash') && intensity > 0.95) {
-    canvas.classList.add('effect-flash');
-    setTimeout(() => canvas.classList.remove('effect-flash'), 300);
+    triggerEffect(canvas, 'effect-flash', 300);
   }
   if (canvas.classList.contains('vfx-glitch') && audio.high > 0.8) {
     const cls = glitches[Math.floor(Math.random() * glitches.length)];
-    canvas.classList.add(cls);
-    setTimeout(() => canvas.classList.remove(cls), 500);
+    triggerEffect(canvas, cls, 500);
   }
   if (canvas.classList.contains('vfx-blur') && intensity > 0.7) {
-    canvas.classList.add('effect-blur');
-    setTimeout(() => canvas.classList.remove('effect-blur'), 500);
+    triggerEffect(canvas, 'effect-blur', 500);
   }
 }

--- a/src/presets/generative-dub/vfx.ts
+++ b/src/presets/generative-dub/vfx.ts
@@ -1,20 +1,18 @@
 import { AudioData } from '../../core/PresetLoader';
+import { getIntensity, triggerEffect } from '../../utils/vfx';
 
 const glitches = ['effect-glitch1', 'effect-glitch2', 'effect-glitch3'];
 
 export function applyVFX(canvas: HTMLCanvasElement, audio: AudioData): void {
-  const intensity = (audio.low + audio.mid + audio.high) / 3;
+  const intensity = getIntensity(audio);
   if (canvas.classList.contains('vfx-flash') && intensity > 0.9) {
-    canvas.classList.add('effect-flash');
-    setTimeout(() => canvas.classList.remove('effect-flash'), 300);
+    triggerEffect(canvas, 'effect-flash', 300);
   }
   if (canvas.classList.contains('vfx-glitch') && audio.high > 0.8) {
     const cls = glitches[Math.floor(Math.random() * glitches.length)];
-    canvas.classList.add(cls);
-    setTimeout(() => canvas.classList.remove(cls), 500);
+    triggerEffect(canvas, cls, 500);
   }
   if (canvas.classList.contains('vfx-noise') && intensity > 0.85) {
-    canvas.classList.add('effect-noise');
-    setTimeout(() => canvas.classList.remove('effect-noise'), 500);
+    triggerEffect(canvas, 'effect-noise', 500);
   }
 }

--- a/src/presets/jungle-grid/vfx.ts
+++ b/src/presets/jungle-grid/vfx.ts
@@ -1,17 +1,16 @@
 import { AudioData } from '../../core/PresetLoader';
+import { triggerEffect } from '../../utils/vfx';
 
 const glitches = ['effect-glitch1', 'effect-glitch2', 'effect-glitch3'];
 
 export function triggerClipFlash(canvas: HTMLCanvasElement): void {
   if (!canvas.classList.contains('vfx-flash')) return;
-  canvas.classList.add('effect-flash');
-  setTimeout(() => canvas.classList.remove('effect-flash'), 300);
+  triggerEffect(canvas, 'effect-flash', 300);
 }
 
 export function applyVFX(canvas: HTMLCanvasElement, audio: AudioData): void {
   if (canvas.classList.contains('vfx-glitch') && audio.high > 0.8) {
     const cls = glitches[Math.floor(Math.random() * glitches.length)];
-    canvas.classList.add(cls);
-    setTimeout(() => canvas.classList.remove(cls), 500);
+    triggerEffect(canvas, cls, 500);
   }
 }

--- a/src/presets/neural_network/vfx.ts
+++ b/src/presets/neural_network/vfx.ts
@@ -1,20 +1,18 @@
 import { AudioData } from '../../core/PresetLoader';
+import { getIntensity, triggerEffect } from '../../utils/vfx';
 
 const glitches = ['effect-glitch1', 'effect-glitch2', 'effect-glitch3'];
 
 export function applyVFX(canvas: HTMLCanvasElement, audio: AudioData): void {
-  const intensity = (audio.low + audio.mid + audio.high) / 3;
+  const intensity = getIntensity(audio);
   if (canvas.classList.contains('vfx-flash') && intensity > 0.9) {
-    canvas.classList.add('effect-flash');
-    setTimeout(() => canvas.classList.remove('effect-flash'), 300);
+    triggerEffect(canvas, 'effect-flash', 300);
   }
   if (canvas.classList.contains('vfx-glitch') && audio.high > 0.85) {
     const cls = glitches[Math.floor(Math.random() * glitches.length)];
-    canvas.classList.add(cls);
-    setTimeout(() => canvas.classList.remove(cls), 500);
+    triggerEffect(canvas, cls, 500);
   }
   if (canvas.classList.contains('vfx-distortion') && audio.mid > 0.7) {
-    canvas.classList.add('effect-distortion');
-    setTimeout(() => canvas.classList.remove('effect-distortion'), 700);
+    triggerEffect(canvas, 'effect-distortion', 700);
   }
 }

--- a/src/presets/shot-text/vfx.ts
+++ b/src/presets/shot-text/vfx.ts
@@ -1,20 +1,18 @@
 import { AudioData } from '../../core/PresetLoader';
+import { getIntensity, triggerEffect } from '../../utils/vfx';
 
 const glitches = ['effect-glitch1', 'effect-glitch2', 'effect-glitch3'];
 
 export function applyVFX(canvas: HTMLCanvasElement, audio: AudioData): void {
-  const intensity = (audio.low + audio.mid + audio.high) / 3;
+  const intensity = getIntensity(audio);
   if (canvas.classList.contains('vfx-flash') && intensity > 0.9) {
-    canvas.classList.add('effect-flash');
-    setTimeout(() => canvas.classList.remove('effect-flash'), 300);
+    triggerEffect(canvas, 'effect-flash', 300);
   }
   if (canvas.classList.contains('vfx-glitch') && audio.high > 0.85) {
     const cls = glitches[Math.floor(Math.random() * glitches.length)];
-    canvas.classList.add(cls);
-    setTimeout(() => canvas.classList.remove(cls), 500);
+    triggerEffect(canvas, cls, 500);
   }
   if (canvas.classList.contains('vfx-blur') && intensity > 0.8) {
-    canvas.classList.add('effect-blur');
-    setTimeout(() => canvas.classList.remove('effect-blur'), 500);
+    triggerEffect(canvas, 'effect-blur', 500);
   }
 }

--- a/src/presets/text-glitch/vfx.ts
+++ b/src/presets/text-glitch/vfx.ts
@@ -1,8 +1,8 @@
 import { AudioData } from '../../core/PresetLoader';
+import { triggerEffect } from '../../utils/vfx';
 
 export function applyVFX(canvas: HTMLCanvasElement, audio: AudioData): void {
   if (audio.mid > 0.85) {
-    canvas.classList.add('effect-blur');
-    setTimeout(() => canvas.classList.remove('effect-blur'), 400);
+    triggerEffect(canvas, 'effect-blur', 400);
   }
 }

--- a/src/utils/vfx.ts
+++ b/src/utils/vfx.ts
@@ -1,0 +1,20 @@
+import { AudioData } from '../core/PresetLoader';
+
+/**
+ * Calculates average intensity of the audio spectrum.
+ */
+export function getIntensity(audio: AudioData): number {
+  return (audio.low + audio.mid + audio.high) / 3;
+}
+
+/**
+ * Adds an effect class to the canvas for a limited duration.
+ */
+export function triggerEffect(
+  canvas: HTMLCanvasElement,
+  effectClass: string,
+  duration: number
+): void {
+  canvas.classList.add(effectClass);
+  setTimeout(() => canvas.classList.remove(effectClass), duration);
+}


### PR DESCRIPTION
## Summary
- refactor VFX effect handlers into shared utilities and update presets
- persist per-layer VFX selections and expose controls alongside presets
- clear residual VFX classes when switching presets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdcc50d20483338251209cac5cef86