### PR TITLE
feat: enhance ROBOTICA preset visuals

### DIFF
--- a/src/presets/shot-text/config.json
+++ b/src/presets/shot-text/config.json
@@ -121,7 +121,9 @@
     "effects": [
       {"name": "flash", "label": "Flash"},
       {"name": "glitch", "label": "Glitch"},
-      {"name": "blur", "label": "Blur"}
+      {"name": "blur", "label": "Blur"},
+      {"name": "distortion", "label": "Distortion"},
+      {"name": "scanlines", "label": "Scanlines"}
     ]
   },
   "audioMapping": {

--- a/src/presets/shot-text/shader.wgsl
+++ b/src/presets/shot-text/shader.wgsl
@@ -49,7 +49,12 @@ fn fs_main(@builtin(position) frag_coord: vec4<f32>) -> @location(0) vec4<f32> {
     // Resplandor ambiental basado en audio
     if (audio_avg > 0.05) {
         let glow_intensity = uniforms.audio_high * 0.1;
-        let glow_color = vec3<f32>(0.2, 0.4, 0.8) * glow_intensity * vignette;
+        let hue = uniforms.time + uniforms.audio_mid * 5.0;
+        let glow_color = vec3<f32>(
+            0.5 + 0.5 * sin(hue),
+            0.5 + 0.5 * sin(hue + 2.094),
+            0.5 + 0.5 * sin(hue + 4.188)
+        ) * glow_intensity * vignette;
         color += glow_color;
         alpha = max(alpha, glow_intensity * 0.2);
     }

--- a/src/presets/shot-text/vfx.ts
+++ b/src/presets/shot-text/vfx.ts
@@ -15,4 +15,10 @@ export function applyVFX(canvas: HTMLCanvasElement, audio: AudioData): void {
   if (canvas.classList.contains('vfx-blur') && intensity > 0.8) {
     triggerEffect(canvas, 'effect-blur', 500);
   }
+  if (canvas.classList.contains('vfx-distortion') && intensity > 0.7) {
+    triggerEffect(canvas, 'effect-distortion', 600);
+  }
+  if (canvas.classList.contains('vfx-scanlines')) {
+    canvas.classList.add('effect-scanlines');
+  }
 }


### PR DESCRIPTION
## Summary
- add audio-driven hue shift to ROBOTICA intro glow
- support distortion and scanline VFX in ROBOTICA preset
- expose new VFX options in preset config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdddc31adc8333bc44ee3c8b91c410