### PR TITLE
feat: enhance analysis preset visuals

### DIFF
--- a/src/presets/analysis/config.json
+++ b/src/presets/analysis/config.json
@@ -1,8 +1,8 @@
 {
   "name": "ANALYSIS",
-  "description": "3D audio spectrum with pastel particles, starfield and pulsating rings.",
+  "description": "3D audio spectrum with pastel particles, starfield, pulsating rings and extended dB grid.",
   "author": "AudioVisualizer",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "category": "analysis",
   "tags": ["spectrum", "analysis", "particles", "grid", "rings"],
   "thumbnail": "analysis_thumb.png",


### PR DESCRIPTION
## Summary
- extend ANALYSIS preset dB grid to -60dB..+5dB with labels
- add abstract audio-reactive rings and particle swirl
- update preset metadata to version 2.3.0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bde01e48dc83338980cbe304e1c798