### PR TITLE
feat: enhance analysis preset with burst particles

### DIFF
--- a/src/presets/analysis/config.json
+++ b/src/presets/analysis/config.json
@@ -1,8 +1,8 @@
 {
   "name": "ANALYSIS",
-  "description": "3D audio spectrum with pastel particles, starfield, pulsating rings and extended dB grid.",
+  "description": "3D audio spectrum with pastel particles, starfield, pulsating rings, glowing bursts and extended dB grid.",
   "author": "AudioVisualizer",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "category": "analysis",
   "tags": ["spectrum", "analysis", "particles", "grid", "rings"],
   "thumbnail": "analysis_thumb.png",
@@ -33,7 +33,8 @@
     "effects": [
       {"name": "flash", "label": "Flash"},
       {"name": "glitch", "label": "Glitch"},
-      {"name": "scanlines", "label": "Scanlines"}
+      {"name": "scanlines", "label": "Scanlines"},
+      {"name": "sparkle", "label": "Sparkle"}
     ]
   },
   "audioMapping": {

--- a/src/presets/analysis/vfx.ts
+++ b/src/presets/analysis/vfx.ts
@@ -12,4 +12,7 @@ export function applyVFX(canvas: HTMLCanvasElement, audio: AudioData): void {
     const cls = glitches[Math.floor(Math.random() * glitches.length)];
     triggerEffect(canvas, cls, 500);
   }
+  if (canvas.classList.contains('vfx-sparkle') && intensity > 0.8) {
+    triggerEffect(canvas, 'effect-sparkle', 400);
+  }
 }


### PR DESCRIPTION
## Summary
- extend ANALYSIS config with sparkle VFX and description update
- add gradient variation and burst particle effect
- trigger new sparkle post-processing effect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1efce78308333b3db44bc8857672a