### PR TITLE
fix: handle monitor ids as strings for fullscreen

### DIFF
--- a/electron.cjs
+++ b/electron.cjs
@@ -76,7 +76,8 @@ ipcMain.on('apply-settings', (event, settings) => {
   if (!mainWindow) return;
   if (settings.monitorId) {
     const displays = screen.getAllDisplays();
-    const target = displays.find(d => d.id === settings.monitorId);
+    // Allow monitor identifiers as strings to avoid precision issues
+    const target = displays.find(d => d.id.toString() === settings.monitorId.toString());
     if (target) {
       mainWindow.setBounds(target.bounds);
     }
@@ -113,7 +114,8 @@ ipcMain.handle('toggle-fullscreen', (event, ids = []) => {
   const displays = screen.getAllDisplays();
 
   ids.forEach((id, index) => {
-    const display = displays.find(d => d.id === id);
+    // Compare using string values to support large identifiers
+    const display = displays.find(d => d.id.toString() === id.toString());
     if (!display) return;
 
     if (index === 0 && mainWindow) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -318,7 +318,7 @@ const App: React.FC = () => {
   useEffect(() => {
     (window as any).electronAPI?.applySettings({
       maximize: startMaximized,
-      monitorId: startMonitor ? parseInt(startMonitor, 10) : undefined
+      monitorId: startMonitor || undefined
     });
   }, [startMaximized, startMonitor]);
 
@@ -618,9 +618,9 @@ const App: React.FC = () => {
         .filter(([, role]) => role === 'secondary')
         .map(([id]) => id);
       const ids = [
-        ...(mainId !== undefined ? [parseInt(mainId, 10)] : []),
-        ...secondaryIds.map(id => parseInt(id, 10))
-      ].filter(id => !Number.isNaN(id));
+        ...(mainId ? [mainId] : []),
+        ...secondaryIds
+      ];
       if (ids.length === 0) {
         setStatus('Error: No monitors selected');
         return;

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -2,9 +2,9 @@
 interface Window {
   __TAURI__?: any;
   electronAPI?: {
-    applySettings: (settings: { maximize?: boolean; monitorId?: number }) => void;
+    applySettings: (settings: { maximize?: boolean; monitorId?: string | number }) => void;
     getDisplays: () => Promise<{ id: number; label: string; bounds: { x: number; y: number; width: number; height: number }; scaleFactor: number; primary: boolean; }[]>;
-    toggleFullscreen: (ids: number[]) => Promise<void>;
+    toggleFullscreen: (ids: string[]) => Promise<void>;
     readTextFile: (path: string) => Promise<string>;
     writeTextFile: (path: string, contents: string) => Promise<void>;
     createDir: (dir: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- handle monitor identifiers as strings in electron main process
- send string IDs from renderer when toggling fullscreen
- update global types accordingly

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c697d8264c83339de0166d6cbdeec5