### PR TITLE
Fix Electron startup when Tauri APIs missing

### DIFF
--- a/preload.cjs
+++ b/preload.cjs
@@ -1,5 +1,11 @@
 const { contextBridge, ipcRenderer } = require('electron');
-const fs = require('fs');
+
+let fs;
+try {
+  fs = require('fs');
+} catch {
+  fs = null;
+}
 
 contextBridge.exposeInMainWorld('electronAPI', {
   applySettings: (settings) => ipcRenderer.send('apply-settings', settings),
@@ -13,9 +19,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onMainLeaveFullscreen: (callback) => ipcRenderer.on('main-leave-fullscreen', callback),
   removeMainLeaveFullscreenListener: () => ipcRenderer.removeAllListeners('main-leave-fullscreen'),
   tcpRequest: (command, port, host) => ipcRenderer.invoke('tcp-request', command, port, host),
-  // Basic filesystem helpers for renderer
-  readTextFile: (path) => fs.promises.readFile(path, 'utf-8'),
-  writeTextFile: (path, contents) => fs.promises.writeFile(path, contents),
-  createDir: (dir) => fs.promises.mkdir(dir, { recursive: true }),
-  exists: (path) => Promise.resolve(fs.existsSync(path))
+  // Basic filesystem helpers for renderer. These will be undefined if the fs
+  // module is not available in the preload context (e.g. in sandboxed
+  // environments). Callers should check for their presence before use.
+  readTextFile: fs ? (path) => fs.promises.readFile(path, 'utf-8') : undefined,
+  writeTextFile: fs ? (path, contents) => fs.promises.writeFile(path, contents) : undefined,
+  createDir: fs ? (dir) => fs.promises.mkdir(dir, { recursive: true }) : undefined,
+  exists: fs ? (path) => Promise.resolve(fs.existsSync(path)) : undefined
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,6 @@ import { useMidi } from './hooks/useMidi';
 import { useLaunchpad } from './hooks/useLaunchpad';
 import './App.css';
 import './AppLayout.css';
-import { availableMonitors, primaryMonitor } from '@tauri-apps/api/window';
 
 interface MonitorInfo {
   id: string;
@@ -383,7 +382,8 @@ const App: React.FC = () => {
             scaleFactor: scale
           };
         });
-      } else {
+      } else if ((window as any).__TAURI__) {
+        const { availableMonitors, primaryMonitor } = await import('@tauri-apps/api/window');
         const [displays, primary] = await Promise.all([
           availableMonitors(),
           primaryMonitor()
@@ -401,6 +401,17 @@ const App: React.FC = () => {
             scaleFactor: d.scaleFactor || 1
           };
         });
+      } else {
+        const width = window.screen.width;
+        const height = window.screen.height;
+        mapped = [{
+          id: 'screen',
+          label: `Screen (${width}x${height})`,
+          position: { x: 0, y: 0 },
+          size: { width, height },
+          isPrimary: true,
+          scaleFactor: window.devicePixelRatio || 1
+        }];
       }
 
       mapped.sort((a, b) => {


### PR DESCRIPTION
## Summary
- avoid failing preload when `fs` module unavailable
- load monitor info dynamically and fall back when Tauri APIs missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6a5f8cb648333900044d669f6160e