### PR TITLE
Fix CSP for external video providers and add gallery layer selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' http://127.0.0.1:9888 ws://127.0.0.1:9888 ws://localhost:9888; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; connect-src 'self' http://127.0.0.1:9888 ws://127.0.0.1:9888 ws://localhost:9888 https://api.pexels.com https://pixabay.com https://archive.org https://*.archive.org; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://images.pexels.com https://cdn.pixabay.com https://i.vimeocdn.com https://archive.org https://*.archive.org; media-src 'self' blob: data: https://player.vimeo.com https://vod-progressive.akamaized.net https://videos.pexels.com https://pixabay.com https://cdn.pixabay.com https://archive.org https://*.archive.org https://*.vimeocdn.com;"
+    />
     <title>Jungle Lab Studio</title>
   </head>
   <body>

--- a/src/components/ResourcesModal.css
+++ b/src/components/ResourcesModal.css
@@ -737,6 +737,41 @@
   font-size: 12px;
 }
 
+.video-layer-select {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 12px;
+  color: #ddd;
+}
+
+.video-layer-select label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #f0f0f0;
+}
+
+.video-layer-select select {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  padding: 6px 12px;
+  color: #fff;
+  font-size: 13px;
+  outline: none;
+  cursor: pointer;
+}
+
+.video-layer-select select:focus {
+  border-color: rgba(255, 255, 255, 0.4);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.1);
+}
+
+.video-layer-hint {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
 .refresh-button {
   align-self: flex-start;
   padding: 6px 14px;


### PR DESCRIPTION
## Summary
- expand the CSP connect, image, and media sources so external video provider APIs and media assets can load without browser rejections
- refactor the resources modal layer assignment logic to reuse typed layer IDs and add a dropdown for assigning videos to layers A, B, or C
- style the new layer selector to match the gallery panel visuals and show guidance when multiple layers are active

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cbecbec6348333b97d2c882f5e8eb4