### PR TITLE
Allow video domain in CSP connect-src

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src 'self' http://127.0.0.1:9888 ws://127.0.0.1:9888 ws://localhost:9888 https://api.pexels.com https://pixabay.com https://archive.org https://*.archive.org; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://images.pexels.com https://cdn.pixabay.com https://i.vimeocdn.com https://archive.org https://*.archive.org; media-src 'self' blob: data: https://player.vimeo.com https://vod-progressive.akamaized.net https://videos.pexels.com https://pixabay.com https://cdn.pixabay.com https://archive.org https://*.archive.org https://*.vimeocdn.com;"
+      content="default-src 'self'; connect-src 'self' http://127.0.0.1:9888 ws://127.0.0.1:9888 ws://localhost:9888 https://api.pexels.com https://videos.pexels.com https://pixabay.com https://archive.org https://*.archive.org; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://images.pexels.com https://cdn.pixabay.com https://i.vimeocdn.com https://archive.org https://*.archive.org; media-src 'self' blob: data: https://player.vimeo.com https://vod-progressive.akamaized.net https://videos.pexels.com https://pixabay.com https://cdn.pixabay.com https://archive.org https://*.archive.org https://*.vimeocdn.com;"
     />
     <title>Jungle Lab Studio</title>
   </head>


### PR DESCRIPTION
## Summary
- allow videos.pexels.com in the CSP connect-src directive so remote videos can be fetched

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbf32a74308333aadcf7addbd5bffe