### PR TITLE
Add retractable resource explorer panel

### DIFF
--- a/src/AppLayout.css
+++ b/src/AppLayout.css
@@ -3,33 +3,49 @@
   width: 100vw;
   height: 100vh;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: #000;
 }
 
 .app-container.ui-hidden .top-bar,
 .app-container.ui-hidden .layer-grid-container,
+.app-container.ui-hidden .resource-explorer,
 .app-container.ui-hidden .controls-panel,
 .app-container.ui-hidden .status-bar {
   display: none;
+}
+
+.workspace {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.main-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
 }
 
 .layer-grid-container {
   overflow: visible;
   background: #0A0A0A;
   margin: 0;
-  padding: 0;
+  padding: 16px 24px 8px;
   box-sizing: border-box;
-  position: absolute;
-  top: 40px;
-  left: 0;
   width: 100%;
-  height: auto;
   z-index: 5;
+  flex: 0 0 auto;
 }
 
 .bottom-section {
   position: relative;
   width: 100%;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
 }
 
 .visual-wrapper {

--- a/src/components/ResourceExplorer.css
+++ b/src/components/ResourceExplorer.css
@@ -1,0 +1,236 @@
+.resource-explorer {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: rgba(10, 10, 10, 0.96);
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  transition: min-width 0.25s ease, width 0.25s ease, opacity 0.25s ease;
+  overflow: visible;
+  z-index: 15;
+}
+
+.resource-explorer.collapsed {
+  min-width: 0;
+  width: 0;
+  opacity: 0;
+}
+
+.resource-explorer__toggle {
+  position: absolute;
+  top: 16px;
+  right: -12px;
+  width: 24px;
+  height: 24px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+  z-index: 2;
+}
+
+.resource-explorer__toggle:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.resource-explorer.collapsed .resource-explorer__toggle {
+  right: -12px;
+}
+
+.resource-explorer__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 18px 18px 12px;
+  gap: 12px;
+  overflow: hidden;
+  opacity: 1;
+  transition: opacity 0.2s ease;
+}
+
+.resource-explorer.collapsed .resource-explorer__content {
+  pointer-events: none;
+}
+
+.resource-explorer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.resource-explorer__header h2 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.resource-explorer__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.resource-explorer__action {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(20, 20, 20, 0.85);
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.resource-explorer__action:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.resource-explorer__action:not(:disabled):hover {
+  background: rgba(255, 183, 77, 0.25);
+  transform: translateY(-1px);
+}
+
+.resource-explorer__search input {
+  width: 100%;
+  background: rgba(0, 0, 0, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 6px 10px;
+  color: #fff;
+  font-size: 12px;
+}
+
+.resource-explorer__search input::placeholder {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.resource-explorer__body {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.resource-explorer__tree,
+.resource-explorer__matches {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.resource-node {
+  display: flex;
+  flex-direction: column;
+  color: #fff;
+}
+
+.resource-node__label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  transition: background 0.2s ease;
+}
+
+.resource-node__label:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.resource-node__children {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.resource-node--item {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 6px;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.resource-node--item:hover {
+  background: rgba(255, 183, 77, 0.1);
+  transform: translateX(2px);
+}
+
+.resource-node__item,
+.resource-match {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
+.resource-match {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.resource-match:hover {
+  background: rgba(255, 183, 77, 0.15);
+  transform: translateX(2px);
+}
+
+.resource-node__icon {
+  width: 18px;
+  text-align: center;
+  opacity: 0.9;
+}
+
+.resource-node__title {
+  flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.resource-explorer__empty {
+  text-align: center;
+  padding: 12px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.resource-explorer__hint {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.45);
+  text-align: center;
+  padding-top: 4px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.resource-explorer__body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.resource-explorer__body::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 3px;
+}
+
+.resource-explorer__body::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 3px;
+}
+
+.resource-explorer__body::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.35);
+}

--- a/src/components/ResourceExplorer.tsx
+++ b/src/components/ResourceExplorer.tsx
@@ -1,0 +1,309 @@
+import React, { useMemo, useState } from 'react';
+import { LoadedPreset } from '../core/PresetLoader';
+import { VideoResource } from '../types/video';
+import { getPresetThumbnail } from '../utils/presetThumbnails';
+import './ResourceExplorer.css';
+
+interface ResourceExplorerProps {
+  isOpen: boolean;
+  width: number;
+  presets: LoadedPreset[];
+  videos: VideoResource[];
+  onToggle: () => void;
+  onOpenLibrary: () => void;
+  onRefreshVideos?: () => void;
+  isRefreshingVideos?: boolean;
+}
+
+type ResourceNodeKind = 'folder' | 'preset' | 'video';
+
+interface ResourceNodeBase {
+  id: string;
+  label: string;
+  kind: ResourceNodeKind;
+}
+
+interface ResourceFolderNode extends ResourceNodeBase {
+  kind: 'folder';
+  children: ResourceNode[];
+}
+
+interface ResourcePresetNode extends ResourceNodeBase {
+  kind: 'preset';
+  preset: LoadedPreset;
+}
+
+interface ResourceVideoNode extends ResourceNodeBase {
+  kind: 'video';
+  video: VideoResource;
+}
+
+type ResourceNode = ResourceFolderNode | ResourcePresetNode | ResourceVideoNode;
+
+const PANEL_MIN_WIDTH = 240;
+
+const ResourceExplorer: React.FC<ResourceExplorerProps> = ({
+  isOpen,
+  width,
+  presets,
+  videos,
+  onToggle,
+  onOpenLibrary,
+  onRefreshVideos,
+  isRefreshingVideos = false
+}) => {
+  const [expanded, setExpanded] = useState<Set<string>>(
+    () => new Set(['presets', 'main-presets', 'custom-presets', 'videos'])
+  );
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const { mainPresets, customPresets } = useMemo(() => {
+    const main: LoadedPreset[] = [];
+    const custom: LoadedPreset[] = [];
+    presets.forEach(preset => {
+      if (
+        preset.id.startsWith('custom-glitch-text') ||
+        preset.id.startsWith('gen-lab-') ||
+        preset.id.startsWith('fractal-lab-')
+      ) {
+        custom.push(preset);
+      } else {
+        main.push(preset);
+      }
+    });
+    return { mainPresets: main, customPresets: custom };
+  }, [presets]);
+
+  const tree = useMemo<ResourceNode[]>(() => {
+    const nodes: ResourceNode[] = [
+      {
+        id: 'presets',
+        label: 'Visual presets',
+        kind: 'folder',
+        children: [
+          {
+            id: 'main-presets',
+            label: 'Main presets',
+            kind: 'folder',
+            children: mainPresets
+              .sort((a, b) => a.config.name.localeCompare(b.config.name))
+              .map<ResourceNode>(preset => ({
+                id: preset.id,
+                label: preset.config.name,
+                kind: 'preset',
+                preset
+              }))
+          },
+          {
+            id: 'custom-presets',
+            label: 'Custom presets',
+            kind: 'folder',
+            children: customPresets
+              .sort((a, b) => a.config.name.localeCompare(b.config.name))
+              .map<ResourceNode>(preset => ({
+                id: preset.id,
+                label: preset.config.name,
+                kind: 'preset',
+                preset
+              }))
+          }
+        ]
+      }
+    ];
+
+    if (videos.length > 0) {
+      nodes.push({
+        id: 'videos',
+        label: 'Video gallery',
+        kind: 'folder',
+        children: videos
+          .slice()
+          .sort((a, b) => a.title.localeCompare(b.title))
+          .map<ResourceNode>(video => ({
+            id: `video-${video.id}`,
+            label: video.title,
+            kind: 'video',
+            video
+          }))
+      });
+    }
+
+    return nodes;
+  }, [mainPresets, customPresets, videos]);
+
+  const matches = useMemo(() => {
+    if (!searchTerm.trim()) {
+      return [];
+    }
+    const term = searchTerm.trim().toLowerCase();
+    const presetMatches = presets
+      .filter(preset => preset.config.name.toLowerCase().includes(term))
+      .map<ResourceNode>(preset => ({
+        id: preset.id,
+        label: preset.config.name,
+        kind: 'preset',
+        preset
+      }));
+    const videoMatches = videos
+      .filter(video => video.title.toLowerCase().includes(term))
+      .map<ResourceNode>(video => ({
+        id: `video-${video.id}`,
+        label: video.title,
+        kind: 'video',
+        video
+      }));
+    return [...presetMatches, ...videoMatches];
+  }, [presets, videos, searchTerm]);
+
+  const toggleExpand = (nodeId: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev);
+      if (next.has(nodeId)) {
+        next.delete(nodeId);
+      } else {
+        next.add(nodeId);
+      }
+      return next;
+    });
+  };
+
+  const handleDragStart = (
+    event: React.DragEvent<HTMLDivElement>,
+    node: ResourcePresetNode | ResourceVideoNode
+  ) => {
+    if (node.kind === 'preset') {
+      event.dataTransfer.setData('text/plain', node.preset.id);
+    } else {
+      event.dataTransfer.setData('text/plain', `video:${node.video.id}`);
+    }
+    event.dataTransfer.effectAllowed = 'copy';
+    document.body.classList.add('preset-dragging');
+  };
+
+  const handleDragEnd = () => {
+    document.body.classList.remove('preset-dragging');
+  };
+
+  const renderNode = (node: ResourceNode, depth = 0) => {
+    if (node.kind === 'folder') {
+      const isExpanded = expanded.has(node.id);
+      const hasChildren = node.children.length > 0;
+      return (
+        <div key={node.id} className="resource-node" style={{ paddingLeft: depth * 14 }}>
+          <button
+            type="button"
+            className="resource-node__label"
+            onClick={() => hasChildren && toggleExpand(node.id)}
+          >
+            <span className="resource-node__icon">{isExpanded ? '▼' : '▶'}</span>
+            <span>{node.label}</span>
+          </button>
+          {isExpanded && hasChildren && (
+            <div className="resource-node__children">
+              {node.children.map(child => renderNode(child, depth + 1))}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    const dragId = node.kind === 'preset' ? node.preset.id : `video:${node.video.id}`;
+    const icon = node.kind === 'preset' ? getPresetThumbnail(node.preset) : '🎬';
+
+    return (
+      <div
+        key={node.id}
+        className="resource-node resource-node--item"
+        style={{ paddingLeft: depth * 14 }}
+        draggable
+        onDragStart={event => handleDragStart(event, node)}
+        onDragEnd={handleDragEnd}
+        data-drag-id={dragId}
+      >
+        <div className="resource-node__item">
+          <span className="resource-node__icon">{icon}</span>
+          <span className="resource-node__title">{node.label}</span>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <aside
+      className={`resource-explorer ${isOpen ? 'open' : 'collapsed'}`}
+      style={{
+        width: isOpen ? Math.max(width, PANEL_MIN_WIDTH) : 0,
+        minWidth: isOpen ? Math.max(width, PANEL_MIN_WIDTH) : 0
+      }}
+    >
+      <button
+        type="button"
+        className="resource-explorer__toggle"
+        onClick={onToggle}
+        aria-label={isOpen ? 'Ocultar explorador de recursos' : 'Mostrar explorador de recursos'}
+      >
+        {isOpen ? '⮜' : '⮞'}
+      </button>
+      <div className="resource-explorer__content">
+        <div className="resource-explorer__header">
+          <h2>Recursos</h2>
+          <div className="resource-explorer__actions">
+            <button type="button" onClick={onOpenLibrary} className="resource-explorer__action">
+              🗂️
+            </button>
+            <button
+              type="button"
+              onClick={onRefreshVideos}
+              className="resource-explorer__action"
+              disabled={isRefreshingVideos}
+              title="Actualizar videos"
+            >
+              {isRefreshingVideos ? '⏳' : '🔄'}
+            </button>
+          </div>
+        </div>
+        <div className="resource-explorer__search">
+          <input
+            type="search"
+            placeholder="Buscar presets o videos"
+            value={searchTerm}
+            onChange={event => setSearchTerm(event.target.value)}
+          />
+        </div>
+        <div className="resource-explorer__body">
+          {searchTerm ? (
+            matches.length > 0 ? (
+              <div className="resource-explorer__matches">
+                {matches.map(match => (
+                  <div
+                    key={match.id}
+                    className="resource-match"
+                    draggable
+                    onDragStart={event => handleDragStart(event, match as ResourcePresetNode | ResourceVideoNode)}
+                    onDragEnd={handleDragEnd}
+                  >
+                    <span className="resource-node__icon">
+                      {match.kind === 'preset' ? getPresetThumbnail((match as ResourcePresetNode).preset) : '🎬'}
+                    </span>
+                    <span className="resource-node__title">{match.label}</span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="resource-explorer__empty">Sin resultados</div>
+            )
+          ) : (
+            <div className="resource-explorer__tree">
+              {tree.map(node => renderNode(node))}
+            </div>
+          )}
+        </div>
+        <div className="resource-explorer__hint">
+          Arrastra cualquier recurso al grid para asignarlo a un slot.
+        </div>
+      </div>
+    </aside>
+  );
+};
+
+export default ResourceExplorer;

--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -1,9 +1,7 @@
 .top-bar {
-  position: absolute;
-  top: 0;
-  left: 0;
+  position: relative;
   width: 100%;
-  height: 40px;
+  height: 48px;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -141,6 +139,11 @@
   align-items: center;
   justify-content: center;
   transition: all 0.2s ease;
+}
+
+.action-button.active {
+  background: rgba(255, 183, 77, 0.85);
+  color: #111;
 }
 
 @keyframes pulse-green {

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -18,6 +18,8 @@ interface TopBarProps {
   onClearAll: () => void;
   onOpenSettings: () => void;
   onOpenResources: () => void;
+  onToggleExplorer: () => void;
+  isExplorerOpen: boolean;
   launchpadAvailable: boolean;
   launchpadOutput: any | null;
   launchpadRunning: boolean;
@@ -44,6 +46,8 @@ export const TopBar: React.FC<TopBarProps> = ({
   onClearAll,
   onOpenSettings,
   onOpenResources,
+  onToggleExplorer,
+  isExplorerOpen,
   launchpadAvailable,
   launchpadOutput,
   launchpadRunning,
@@ -109,11 +113,17 @@ export const TopBar: React.FC<TopBarProps> = ({
         {/* Center section - Actions and resources */}
         <div className="actions-section">
           <button
+            onClick={onToggleExplorer}
+            className={`action-button ${isExplorerOpen ? 'active' : ''}`}
+            title={isExplorerOpen ? 'Ocultar explorador de recursos' : 'Mostrar explorador de recursos'}
+            aria-label="Toggle resource explorer"
+          >📂</button>
+          <button
             onClick={onOpenResources}
             className="action-button"
-            title="Open resources"
-            aria-label="Open resources"
-          >📂</button>
+            title="Abrir galería completa"
+            aria-label="Open resource library"
+          >🗂️</button>
           <button
             onClick={onClearAll}
             className="action-button"

--- a/src/hooks/usePresetGrid.ts
+++ b/src/hooks/usePresetGrid.ts
@@ -5,12 +5,22 @@ interface DragTarget {
   index: number;
 }
 
+const getExplorerWidth = () => {
+  if (typeof document === 'undefined') {
+    return 0;
+  }
+  const widthAttr = document.body?.getAttribute('data-explorer-width');
+  const parsed = widthAttr ? parseInt(widthAttr, 10) : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
 export const usePresetGrid = () => {
   const SLOT_WIDTH = 98;
   const SIDEBAR_WIDTH = 100;
 
   const calculateSlots = () => {
-    const available = window.innerWidth - SIDEBAR_WIDTH - 40; // padding
+    const explorerWidth = getExplorerWidth();
+    const available = window.innerWidth - SIDEBAR_WIDTH - explorerWidth - 40; // padding
     return Math.max(1, Math.floor(available / SLOT_WIDTH));
   };
 


### PR DESCRIPTION
## Summary
- add a retractable resource explorer panel that surfaces presets and videos for drag-and-drop use
- reorganize the main workspace layout and top bar so the layer grid and visuals share space with the explorer
- adjust preset grid sizing logic and styling to react to the explorer width and provide active button states

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc03cce54c8333bb49bb713c8184fa