### PR TITLE
Fix drop effect when dragging resources into grid

### DIFF
--- a/src/hooks/usePresetGrid.ts
+++ b/src/hooks/usePresetGrid.ts
@@ -184,6 +184,23 @@ export const usePresetGrid = () => {
 
   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
+
+    const effectAllowed = e.dataTransfer.effectAllowed?.toLowerCase() || '';
+
+    if (
+      effectAllowed === 'uninitialized' ||
+      effectAllowed === 'all' ||
+      effectAllowed.includes('move')
+    ) {
+      e.dataTransfer.dropEffect = 'move';
+      return;
+    }
+
+    if (effectAllowed.includes('copy')) {
+      e.dataTransfer.dropEffect = 'copy';
+      return;
+    }
+
     e.dataTransfer.dropEffect = 'move';
   };
 


### PR DESCRIPTION
## Summary
- adjust preset grid drag-over handler to respect the allowed drag effect
- ensure drops from the resource explorer display a valid cursor while supporting grid moves

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cc0da6f86483338fc89bae04acc049