### PR TITLE
Display video resolution in gallery and controls

### DIFF
--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -582,6 +582,25 @@ body.preset-dragging .preset-grid {
   overflow: hidden;
 }
 
+.video-thumb-wrapper {
+  position: relative;
+  flex: 1;
+  display: flex;
+}
+
+.video-resolution-badge {
+  position: absolute;
+  top: 6px;
+  left: 8px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.65);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: #fff;
+}
+
 .video-thumb {
   flex: 1;
   background-size: cover;

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -429,7 +429,14 @@ const LayerGrid: React.FC<LayerGridProps> = ({
                       '--layer-color-alpha': layer.color + '20'
                     } as React.CSSProperties}
                   >
-                    <div className="video-thumb" style={{ backgroundImage: `url(${video.thumbnail})` }} />
+                    <div className="video-thumb-wrapper">
+                      {video.width != null && video.height != null && (
+                        <span className="video-resolution-badge">
+                          {video.width}×{video.height}
+                        </span>
+                      )}
+                      <div className="video-thumb" style={{ backgroundImage: `url(${video.thumbnail})` }} />
+                    </div>
                     <div className="preset-info">
                       <div className="preset-name">{video.title}</div>
                       <div className="preset-details">

--- a/src/components/ResourcesModal.tsx
+++ b/src/components/ResourcesModal.tsx
@@ -721,6 +721,11 @@ const ResourcesModal: React.FC<ResourcesModalProps> = ({
                 <li><strong>Provider:</strong> {video.provider}</li>
                 {video.author && <li><strong>Author:</strong> {video.author}</li>}
                 {video.duration && <li><strong>Duration:</strong> {Math.round(video.duration)}s</li>}
+                {video.width != null && video.height != null && (
+                  <li>
+                    <strong>Resolution:</strong> {video.width}×{video.height}
+                  </li>
+                )}
               </ul>
               <button
                 className="refresh-button"

--- a/src/components/VideoControls.css
+++ b/src/components/VideoControls.css
@@ -11,6 +11,12 @@
   font-weight: 500;
 }
 
+.video-controls-meta {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.75);
+}
+
 .video-controls-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/src/components/VideoControls.tsx
+++ b/src/components/VideoControls.tsx
@@ -12,6 +12,9 @@ const VideoControls: React.FC<VideoControlsProps> = ({ video, settings, onChange
   return (
     <div className="video-controls">
       <h3 className="video-controls-title">🎬 {video.title}</h3>
+      {video.width != null && video.height != null && (
+        <p className="video-controls-meta">{video.width}×{video.height}</p>
+      )}
       <div className="video-controls-grid">
         <label className="video-control checkbox">
           <input

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -10,6 +10,8 @@ export interface VideoResource {
   duration?: number;
   provider: string;
   author?: string;
+  width?: number;
+  height?: number;
 }
 
 export interface VideoPlaybackSettings {

--- a/src/utils/videoProviders.ts
+++ b/src/utils/videoProviders.ts
@@ -45,6 +45,8 @@ const fetchFromPexels = async (settings: VideoProviderSettings): Promise<VideoRe
       duration: video.duration,
       provider: 'pexels',
       author: video.user?.name,
+      width: file?.width,
+      height: file?.height,
     };
   });
 };
@@ -73,6 +75,8 @@ const fetchFromPixabay = async (settings: VideoProviderSettings): Promise<VideoR
       duration: hit.duration,
       provider: 'pixabay',
       author: hit.user,
+      width: hd?.width || hit.videos?.tiny?.width,
+      height: hd?.height || hit.videos?.tiny?.height,
     };
   });
 };
@@ -96,6 +100,8 @@ const fetchFromArchive = async (settings: VideoProviderSettings): Promise<VideoR
       previewUrl: base,
       downloadUrl: base,
       provider: 'archive',
+      width: doc.width,
+      height: doc.height,
     };
   });
 };


### PR DESCRIPTION
## Summary
- extend the VideoResource type to include optional width and height metadata from providers
- surface the resolution on video thumbnails within the layer grid and inside the resource modal
- show resolution details in the video playback controls for quick reference

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc1ad234388333ab715d0e4711ee5d