### PR TITLE
Reorganizar la vista de visuales y controles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1485,17 +1485,19 @@ const App: React.FC = () => {
 
           {/* Seccion inferior con visuales y controles */}
           <div className="bottom-section">
-            <div
-              className="visual-wrapper"
-              style={{ background: canvasBackground }}
-            >
+            <div className="visual-stage">
               <div
-                ref={playgroundRef}
-                className={`playground ${activeEffectClasses}`}
-                style={{
-                  filter: `brightness(${canvasBrightness}) saturate(${canvasVibrance})`
-                }}
-              />
+                className="visual-wrapper"
+                style={{ background: canvasBackground }}
+              >
+                <div
+                  ref={playgroundRef}
+                  className={`playground ${activeEffectClasses}`}
+                  style={{
+                    filter: `brightness(${canvasBrightness}) saturate(${canvasVibrance})`
+                  }}
+                />
+              </div>
             </div>
             {!isResourcesOpen && (
               <div className={`controls-panel ${isControlsOpen ? '' : 'collapsed'}`}>
@@ -1511,35 +1513,39 @@ const App: React.FC = () => {
                 >
                   {isControlsOpen ? '✕' : '⚙️'}
                 </button>
-                {isControlsOpen && selectedVideo && selectedVideoLayer && (
-                  <VideoControls
-                    video={selectedVideo}
-                    settings={layerVideoSettings[selectedVideoLayer] || DEFAULT_VIDEO_PLAYBACK_SETTINGS}
-                    onChange={handleVideoSettingsChange}
-                  />
-                )}
-                {isControlsOpen && !selectedVideo && selectedPreset && (
-                  <Suspense fallback={<div>Loading controls...</div>}>
-                    <PresetControls
-                      preset={selectedPreset}
-                      config={layerPresetConfigs[selectedLayer!]?.[selectedPreset.id]}
-                      onChange={(path, value) => {
-                        if (engineRef.current && selectedLayer && selectedPreset) {
-                          engineRef.current.updateLayerPresetConfig(selectedLayer, path, value);
-                          setLayerPresetConfigs(prev => {
-                            const layerMap = { ...(prev[selectedLayer] || {}) };
-                            const cfg = { ...(layerMap[selectedPreset.id] || {}) };
-                            setNestedValue(cfg, path, value);
-                            layerMap[selectedPreset.id] = cfg;
-                            return { ...prev, [selectedLayer]: layerMap };
-                          });
-                        }
-                      }}
-                    />
-                  </Suspense>
-                )}
-                {isControlsOpen && !selectedPreset && !selectedVideo && (
-                  <div className="no-preset-selected">Selecciona un preset</div>
+                {isControlsOpen && (
+                  <div className="controls-panel-content">
+                    {selectedVideo && selectedVideoLayer && (
+                      <VideoControls
+                        video={selectedVideo}
+                        settings={layerVideoSettings[selectedVideoLayer] || DEFAULT_VIDEO_PLAYBACK_SETTINGS}
+                        onChange={handleVideoSettingsChange}
+                      />
+                    )}
+                    {!selectedVideo && selectedPreset && (
+                      <Suspense fallback={<div>Loading controls...</div>}>
+                        <PresetControls
+                          preset={selectedPreset}
+                          config={layerPresetConfigs[selectedLayer!]?.[selectedPreset.id]}
+                          onChange={(path, value) => {
+                            if (engineRef.current && selectedLayer && selectedPreset) {
+                              engineRef.current.updateLayerPresetConfig(selectedLayer, path, value);
+                              setLayerPresetConfigs(prev => {
+                                const layerMap = { ...(prev[selectedLayer] || {}) };
+                                const cfg = { ...(layerMap[selectedPreset.id] || {}) };
+                                setNestedValue(cfg, path, value);
+                                layerMap[selectedPreset.id] = cfg;
+                                return { ...prev, [selectedLayer]: layerMap };
+                              });
+                            }
+                          }}
+                        />
+                      </Suspense>
+                    )}
+                    {!selectedPreset && !selectedVideo && (
+                      <div className="no-preset-selected">Selecciona un preset</div>
+                    )}
+                  </div>
                 )}
               </div>
             )}

--- a/src/AppLayout.css
+++ b/src/AppLayout.css
@@ -16,6 +16,16 @@
   display: none;
 }
 
+.app-container.ui-hidden .bottom-section {
+  padding: 0;
+}
+
+.app-container.ui-hidden .visual-wrapper {
+  border-radius: 0;
+  box-shadow: none;
+  border: none;
+}
+
 .workspace {
   flex: 1;
   display: flex;
@@ -46,16 +56,28 @@
   width: 100%;
   flex: 1;
   min-height: 0;
+  padding: 16px 24px 24px;
+  box-sizing: border-box;
+  display: flex;
+  gap: 24px;
+  align-items: stretch;
+}
+
+.visual-stage {
+  flex: 1;
+  min-height: 0;
+  display: flex;
 }
 
 .visual-wrapper {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  position: relative;
+  flex: 1;
   overflow: hidden;
   z-index: 0;
+  border-radius: 16px;
+  background: #000;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
 }
 
 .playground {
@@ -81,29 +103,30 @@
 
 /* Controls Panel */
 .controls-panel {
-  position: fixed;
-  top: 10px;
-  right: 0;
-  width: 380px;
-  height: calc(100vh - 40px);
-  margin: 20px;
-  border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  position: relative;
+  flex: 0 0 360px;
+  max-width: 100%;
+  height: 100%;
+  border-radius: 16px;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
   backdrop-filter: blur(10px);
   background: rgba(0, 0, 0, 0.85);
-  border-left: 1px solid rgba(255, 255, 255, 0.1);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  z-index: 1000;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  opacity: 1;
+  padding: 48px 20px 20px;
+  box-sizing: border-box;
+  z-index: 1;
 }
 
 .controls-panel.collapsed {
-  width: 60px;
+  flex: 0 0 60px;
+  padding: 12px;
   background: rgba(0, 0, 0, 0.7);
+  align-items: center;
+  justify-content: center;
 }
 
 .controls-panel.visible {
@@ -116,10 +139,10 @@
 }
 
 .controls-panel.collapsed .toggle-sidebar {
-  position: relative;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  position: static;
+  top: auto;
+  right: auto;
+  transform: none;
 }
 
 .controls-panel-header {
@@ -133,7 +156,8 @@
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 20px;
+  padding-right: 8px;
+  position: relative;
   scroll-behavior: smooth;
   scrollbar-width: thin;
   scrollbar-color: rgba(255, 255, 255, 0.3) rgba(255, 255, 255, 0.1);
@@ -167,7 +191,7 @@
   position: absolute;
   bottom: 0;
   left: 0;
-  right: 8px;
+  right: 0;
   height: 20px;
   background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.8));
   pointer-events: none;
@@ -179,16 +203,16 @@
   opacity: 1;
 }
 
+
 .toggle-sidebar {
   position: absolute;
-  top: 15px;
-  right: 15px;
-  width: 30px;
-  height: 30px;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  top: 16px;
+  right: 16px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   color: #fff;
   cursor: pointer;
   display: flex;
@@ -196,7 +220,11 @@
   justify-content: center;
   font-size: 12px;
   transition: all 0.2s ease;
-  z-index: 1001;
+  z-index: 2;
+}
+
+.controls-panel.collapsed .toggle-sidebar {
+  margin: 0 auto;
 }
 
 .toggle-sidebar:hover {


### PR DESCRIPTION
## Resumen
- Añadí un contenedor "visual-stage" para que el playground se muestre como un panel incrustado bajo el grid cuando la UI está visible.
- Actualicé el panel de controles para que forme parte del layout principal, con contenido desplazable y un botón flotante de colapsado.
- Ajusté estilos en modo fullscreen para que los visuales ocupen el 100% de la pantalla sin bordes ni sombras.

## Pruebas
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc1ed33cb48333be0443f24907e05e