### PR TITLE
Fix className template in App container

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1260,8 +1260,7 @@ const App: React.FC = () => {
 
   return (
     <div
-      className={`app-container audiovisualizer-app ${isUiHidden ? 'ui-hidden' : ''} ${
-      }`}
+      className={`app-container audiovisualizer-app ${isUiHidden ? 'ui-hidden' : ''}`}
     >
       <TopBar
         midiActive={midiActive}


### PR DESCRIPTION
## Summary
- remove an empty template expression from the main app container className to restore valid JSX

## Testing
- npm run build *(fails: the package 'jungle-lab-studio' does not contain this feature: custom-protocol)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2b26a6e48333b77e1c5672ef7f19