### PR TITLE
Handle missing filesystem helpers in electron API

### DIFF
--- a/src/core/LayerManager.ts
+++ b/src/core/LayerManager.ts
@@ -672,9 +672,12 @@ export class LayerManager {
           }
         } else if ((window as any).electronAPI) {
           const api = (window as any).electronAPI;
-          if (await api.exists(cfgPath)) {
-            const content = await api.readTextFile(cfgPath);
-            return JSON.parse(content);
+          if (typeof api.exists === 'function' && (await api.exists(cfgPath))) {
+            const reader = api.readTextFile;
+            if (typeof reader === 'function') {
+              const content = await reader(cfgPath);
+              return JSON.parse(content);
+            }
           }
         }
       }
@@ -701,8 +704,12 @@ export class LayerManager {
           await writeFile({ path: cfgPath, contents: JSON.stringify(cfg, null, 2) });
         } else if ((window as any).electronAPI) {
           const api = (window as any).electronAPI;
-          await api.createDir(dir);
-          await api.writeTextFile(cfgPath, JSON.stringify(cfg, null, 2));
+          if (typeof api.createDir === 'function') {
+            await api.createDir(dir);
+          }
+          if (typeof api.writeTextFile === 'function') {
+            await api.writeTextFile(cfgPath, JSON.stringify(cfg, null, 2));
+          }
         }
       }
     } catch (err) {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -5,10 +5,10 @@ interface Window {
     applySettings: (settings: { maximize?: boolean; monitorId?: string | number }) => void;
     getDisplays: () => Promise<{ id: number; label: string; bounds: { x: number; y: number; width: number; height: number }; scaleFactor: number; primary: boolean; }[]>;
     toggleFullscreen: (ids: string[]) => Promise<void>;
-    readTextFile: (path: string) => Promise<string>;
-    writeTextFile: (path: string, contents: string) => Promise<void>;
-    createDir: (dir: string) => Promise<void>;
-    exists: (path: string) => Promise<boolean>;
+    readTextFile?: (path: string) => Promise<string>;
+    writeTextFile?: (path: string, contents: string) => Promise<void>;
+    createDir?: (dir: string) => Promise<void>;
+    exists?: (path: string) => Promise<boolean>;
     tcpRequest: (command: object, port?: number, host?: string) => Promise<any>;
   };
 }


### PR DESCRIPTION
## Summary
- guard layer preset load/save logic against missing filesystem helpers when running in Electron contexts without Node fs
- update Electron API typings so filesystem helper functions are optional

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc2dcf46ac83338e0eb7a3b5adc476