### PR TITLE
feat: restyle UI with Proxmox-inspired sidebar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,61 @@
-/* Global variables and resets */
+/* Global Proxmox-inspired design tokens and resets */
 
 :root {
-  --accent-color: #FFB74D;
+  /* Core palette */
+  --proxmox-bg: #1e2327;
+  --proxmox-panel: #242b30;
+  --proxmox-panel-alt: #1b2024;
+  --proxmox-surface-elevated: #2f363c;
+  --proxmox-border: #3a444d;
+  --proxmox-border-strong: #4f5b65;
+  --proxmox-border-soft: #2a3035;
+  --proxmox-accent: #f08236;
+  --proxmox-accent-soft: rgba(240, 130, 54, 0.15);
+  --proxmox-accent-strong: #ff8f3f;
+  --proxmox-text: #d6dade;
+  --proxmox-text-strong: #f4f6f8;
+  --proxmox-text-muted: #9da7af;
+  --proxmox-text-subtle: #7d8790;
+
+  /* Typography */
+  --font-family-sans: 'Open Sans', 'Inter', 'Segoe UI', -apple-system, BlinkMacSystemFont,
+    'Helvetica Neue', Arial, sans-serif;
+  --font-weight-light: 300;
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+  --font-size-xs: 11px;
+  --font-size-sm: 12px;
+  --font-size-base: 14px;
+  --font-size-lg: 15px;
+  --font-size-xl: 18px;
+  --line-height-tight: 1.2;
+  --line-height-normal: 1.45;
+
+  /* Spacing scale */
+  --spacing-3xs: 2px;
+  --spacing-2xs: 4px;
+  --spacing-xs: 6px;
+  --spacing-sm: 8px;
+  --spacing-md: 12px;
+  --spacing-lg: 16px;
+  --spacing-xl: 20px;
+  --spacing-2xl: 28px;
+
+  /* Radii */
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+
+  /* Shadows */
+  --shadow-soft: 0 8px 20px rgba(0, 0, 0, 0.35);
+  --shadow-elevated: 0 18px 40px rgba(0, 0, 0, 0.45);
+
+  /* Animation */
+  --transition-fast: 150ms ease;
+  --transition-medium: 250ms ease;
 }
 
 * {
@@ -10,14 +64,67 @@
   box-sizing: border-box;
 }
 
-html, body, #root {
+html,
+body,
+#root {
   width: 100%;
   height: 100%;
-  background: var(--proxmox-bg, #000);
+  background: var(--proxmox-bg);
 }
 
 body {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: var(--proxmox-text, #fff);
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-normal);
+  color: var(--proxmox-text);
+  background: var(--proxmox-bg);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
   overflow: hidden;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: inherit;
+  font-weight: var(--font-weight-semibold);
+  color: var(--proxmox-text-strong);
+}
+
+p,
+ul,
+ol {
+  color: var(--proxmox-text);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: var(--radius-xs);
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.3);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import React, {
   useCallback,
   Suspense,
   lazy,
+  useMemo,
 } from 'react';
 import { AudioVisualizerEngine } from './core/AudioVisualizerEngine';
 import { StatusBar } from './components/StatusBar';
@@ -32,6 +33,8 @@ import {
   MainChat as ProxmoxMainArea,
   TaskActivityPanel,
   FooterPanel,
+  SidebarNavigation,
+  SidebarNavSection,
 } from './components/layout/ProxmoxLayout';
 import {
   VideoResource,
@@ -45,6 +48,51 @@ import {
   VideoProviderId,
 } from './utils/videoProviders';
 import { clearVideoCache } from './utils/videoCache';
+
+const NAV_ICONS = {
+  resources: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 7h6l1.8 2.5H21a1.5 1.5 0 0 1 1.5 1.6l-.7 8a2 2 0 0 1-2 1.9H4.2a2 2 0 0 1-2-1.8L2 8.8A2 2 0 0 1 3.9 7Z" />
+      <path d="M3 7V5.2A2.2 2.2 0 0 1 5.2 3h3.4a2 2 0 0 1 1.6.8L12 6.4" />
+    </svg>
+  ),
+  layers: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 4 4 8l8 4 8-4-8-4Z" />
+      <path d="m4 12 8 4 8-4" />
+      <path d="m4 16 8 4 8-4" />
+    </svg>
+  ),
+  routing: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="6" cy="6" r="2.5" />
+      <circle cx="18" cy="6" r="2.5" />
+      <circle cx="6" cy="18" r="2.5" />
+      <circle cx="18" cy="18" r="2.5" />
+      <path d="M8.8 6h6.4" />
+      <path d="M6 8.8v6.4" />
+      <path d="M18 8.8v6.4" />
+      <path d="M8.8 18h6.4" />
+    </svg>
+  ),
+} as const;
+
+type SidebarSectionId = 'resources' | 'layers' | 'routing';
+
+interface SidebarChipMeta {
+  label: string;
+  accent?: boolean;
+}
+
+interface SidebarCardEntry {
+  id: string;
+  title: string;
+  description: string;
+  meta?: string;
+  chips: SidebarChipMeta[];
+}
+
+const LAYER_IDS = ['A', 'B', 'C'] as const;
 
 interface MonitorInfo {
   id: string;
@@ -199,6 +247,8 @@ const App: React.FC = () => {
     };
   });
 
+  const [activeSidebarSection, setActiveSidebarSection] = useState<SidebarSectionId>('resources');
+
   const [layerVFX, setLayerVFX] = useState<Record<string, Record<string, string[]>>>(() => {
     try {
       const stored = localStorage.getItem('layerVFX');
@@ -206,6 +256,169 @@ const App: React.FC = () => {
     } catch {}
     return { A: {}, B: {}, C: {} };
   });
+
+  const resolveResourceLabel = useCallback(
+    (resourceId: string | null | undefined) => {
+      if (!resourceId) {
+        return 'Sin asignar';
+      }
+      if (resourceId.startsWith('video:')) {
+        const videoId = resourceId.replace(/^video:/, '');
+        const video = videoGallery.find(item => item.id === videoId);
+        return video ? video.title : 'Video no disponible';
+      }
+      const preset = availablePresets.find(item => item.id === resourceId);
+      return preset ? preset.config.name : 'Preset no disponible';
+    },
+    [availablePresets, videoGallery]
+  );
+
+  const activeLayerSummaries = useMemo<SidebarCardEntry[]>(() => {
+    return LAYER_IDS.map(layerId => {
+      const presetId = activeLayers[layerId] || null;
+      const layerEffect = layerEffects[layerId] || { effect: 'none', alwaysOn: false, active: false };
+      const midiChannel = layerChannels[layerId];
+      const chips: SidebarChipMeta[] = [];
+      const metaParts: string[] = [];
+
+      if (presetId) {
+        const isVideo = presetId.startsWith('video:');
+        chips.push({ label: isVideo ? 'Video' : 'Preset', accent: isVideo });
+        metaParts.push(isVideo ? 'Video activo' : 'Preset activo');
+      } else {
+        metaParts.push('Sin contenido asignado');
+      }
+
+      if (typeof midiChannel === 'number') {
+        chips.push({ label: `Canal ${midiChannel}` });
+        metaParts.push(`Canal MIDI ${midiChannel}`);
+      } else {
+        chips.push({ label: 'Canal —' });
+      }
+
+      if (layerEffect.effect && layerEffect.effect !== 'none') {
+        const label = layerEffect.alwaysOn ? `FX ${layerEffect.effect} · Auto` : `FX ${layerEffect.effect}`;
+        chips.push({ label, accent: layerEffect.active || layerEffect.alwaysOn });
+      }
+
+      return {
+        id: layerId,
+        title: presetId ? `${layerId} · ${resolveResourceLabel(presetId)}` : `${layerId} · Disponible`,
+        description: metaParts.join(' · '),
+        chips,
+      };
+    });
+  }, [activeLayers, layerChannels, layerEffects, resolveResourceLabel]);
+
+  const activeLayerCount = useMemo(
+    () => LAYER_IDS.filter(layerId => Boolean(activeLayers[layerId])).length,
+    [activeLayers]
+  );
+
+  const routingSummaries = useMemo<SidebarCardEntry[]>(() => {
+    const midiDescription = midiActive
+      ? midiDeviceName || 'Dispositivo MIDI activo'
+      : 'Sin dispositivo conectado';
+    const midiChips: SidebarChipMeta[] = [
+      { label: midiActive ? 'Activo' : 'Inactivo', accent: midiActive },
+      { label: `${midiDevices.length} detectados` },
+    ];
+
+    const audioDescription = audioDeviceName || 'Salida por defecto del sistema';
+    const audioChips: SidebarChipMeta[] = [
+      { label: `Ganancia ${Math.round(audioGain * 100)}%` },
+      { label: `${audioDevices.length} dispositivos` },
+    ];
+
+    const launchpadDescription = launchpadRunning
+      ? (launchpadOutput as any)?.name || 'Launchpad activo'
+      : 'Launchpad inactivo';
+    const launchpadChips: SidebarChipMeta[] = [
+      {
+        label: launchpadRunning ? `Preset ${launchpadPreset || 'Default'}` : 'No sincronizado',
+        accent: launchpadRunning,
+      },
+    ];
+
+    return [
+      { id: 'midi', title: 'MIDI', description: midiDescription, chips: midiChips },
+      { id: 'audio', title: 'Audio', description: audioDescription, chips: audioChips },
+      { id: 'launchpad', title: 'Launchpad', description: launchpadDescription, chips: launchpadChips },
+    ];
+  }, [
+    midiActive,
+    midiDeviceName,
+    midiDevices.length,
+    audioDeviceName,
+    audioDevices.length,
+    audioGain,
+    launchpadRunning,
+    launchpadOutput,
+    launchpadPreset,
+  ]);
+
+  const videoProviderSummary = useMemo<SidebarCardEntry>(
+    () => ({
+      id: 'video-provider',
+      title: 'Proveedor de video',
+      description: `Actualización cada ${videoProviderSettings.refreshMinutes} min`,
+      meta: `Consulta: "${videoProviderSettings.query || 'vj loop'}"`,
+      chips: [
+        { label: videoProviderSettings.provider.toUpperCase(), accent: true },
+        { label: isRefreshingVideos ? 'Actualizando…' : `${videoGallery.length} videos` },
+      ],
+    }),
+    [videoProviderSettings, isRefreshingVideos, videoGallery.length]
+  );
+
+  const sidebarNavSections = useMemo<SidebarNavSection[]>(
+    () => [
+      {
+        id: 'library',
+        title: 'Biblioteca',
+        items: [
+          {
+            id: 'resources',
+            icon: NAV_ICONS.resources,
+            label: 'Recursos',
+            description: `${availablePresets.length} presets · ${videoGallery.length} videos`,
+            badge: availablePresets.length + videoGallery.length,
+          },
+        ],
+      },
+      {
+        id: 'monitoring',
+        title: 'Monitoreo',
+        items: [
+          {
+            id: 'layers',
+            icon: NAV_ICONS.layers,
+            label: 'Capas activas',
+            description:
+              activeLayerCount > 0
+                ? `${activeLayerCount} capa${activeLayerCount !== 1 ? 's' : ''} activas`
+                : 'Sin capas activas',
+            badge: activeLayerCount,
+          },
+          {
+            id: 'routing',
+            icon: NAV_ICONS.routing,
+            label: 'Routing',
+            description: `${midiActive ? 'MIDI ON' : 'MIDI OFF'} · ${launchpadRunning ? 'Launchpad ON' : 'Launchpad OFF'}`,
+            badge: midiActive ? 'SYNC' : 'IDLE',
+          },
+        ],
+      },
+    ],
+    [availablePresets.length, videoGallery.length, activeLayerCount, midiActive, launchpadRunning]
+  );
+
+  const handleSidebarSectionSelect = useCallback((sectionId: string) => {
+    if (sectionId === 'resources' || sectionId === 'layers' || sectionId === 'routing') {
+      setActiveSidebarSection(sectionId);
+    }
+  }, []);
+
 
   const [isFullscreenMode, setIsFullscreenMode] = useState(
     () => new URLSearchParams(window.location.search).get('fullscreen') === 'true'
@@ -1271,20 +1484,121 @@ const App: React.FC = () => {
       <ProxmoxSidebar
         title="Jungle Lab Studio"
         subtitle="Proxmox Edition"
+        navigation={(
+          <SidebarNavigation
+            sections={sidebarNavSections}
+            activeId={activeSidebarSection}
+            onSelect={handleSidebarSectionSelect}
+          />
+        )}
         footer={(
           <span>
             <strong>Preset</strong> · {getCurrentPresetName()}
           </span>
         )}
       >
-        <ResourceExplorer
-          width={RESOURCE_EXPLORER_WIDTH}
-          presets={availablePresets}
-          videos={videoGallery}
-          onOpenLibrary={() => setResourcesOpen(true)}
-          onRefreshVideos={() => refreshVideoGallery(true)}
-          isRefreshingVideos={isRefreshingVideos}
-        />
+        {activeSidebarSection === 'resources' && (
+          <ResourceExplorer
+            width={RESOURCE_EXPLORER_WIDTH}
+            presets={availablePresets}
+            videos={videoGallery}
+            onOpenLibrary={() => setResourcesOpen(true)}
+            onRefreshVideos={() => refreshVideoGallery(true)}
+            isRefreshingVideos={isRefreshingVideos}
+          />
+        )}
+
+        {activeSidebarSection === 'layers' && (
+          <div className="sidebar-panel">
+            <div className="sidebar-card">
+              <div className="sidebar-card__header">
+                <span className="sidebar-card__subtitle">Estado en vivo</span>
+                <span className="sidebar-card__title">Capas activas</span>
+              </div>
+              <div className="sidebar-card__body">
+                <p className="sidebar-card__meta">
+                  Monitoriza qué preset o video está cargado en cada capa del motor visual en tiempo real.
+                </p>
+                <div className="sidebar-card__list">
+                  {activeLayerSummaries.map(summary => (
+                    <div key={summary.id} className="sidebar-card__list-item">
+                      <strong>{summary.title}</strong>
+                      <span>{summary.description}</span>
+                      {summary.chips.length > 0 && (
+                        <div className="sidebar-card__chips">
+                          {summary.chips.map(chip => (
+                            <span
+                              key={`${summary.id}-${chip.label}`}
+                              className={`sidebar-chip${chip.accent ? ' sidebar-chip--accent' : ''}`}
+                            >
+                              {chip.label}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {activeSidebarSection === 'routing' && (
+          <div className="sidebar-panel">
+            <div className="sidebar-card">
+              <div className="sidebar-card__header">
+                <span className="sidebar-card__subtitle">Sincronización</span>
+                <span className="sidebar-card__title">Routing en tiempo real</span>
+              </div>
+              <div className="sidebar-card__body">
+                <div className="sidebar-card__list">
+                  {routingSummaries.map(entry => (
+                    <div key={entry.id} className="sidebar-card__list-item">
+                      <strong>{entry.title}</strong>
+                      <span>{entry.description}</span>
+                      {entry.chips.length > 0 && (
+                        <div className="sidebar-card__chips">
+                          {entry.chips.map(chip => (
+                            <span
+                              key={`${entry.id}-${chip.label}`}
+                              className={`sidebar-chip${chip.accent ? ' sidebar-chip--accent' : ''}`}
+                            >
+                              {chip.label}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            <div className="sidebar-card">
+              <div className="sidebar-card__header">
+                <span className="sidebar-card__subtitle">Librería multimedia</span>
+                <span className="sidebar-card__title">Proveedor de video</span>
+              </div>
+              <div className="sidebar-card__body">
+                <p className="sidebar-card__meta">{videoProviderSummary.description}</p>
+                {videoProviderSummary.meta && (
+                  <p className="sidebar-card__meta">{videoProviderSummary.meta}</p>
+                )}
+                <div className="sidebar-card__chips">
+                  {videoProviderSummary.chips.map(chip => (
+                    <span
+                      key={`video-${chip.label}`}
+                      className={`sidebar-chip${chip.accent ? ' sidebar-chip--accent' : ''}`}
+                    >
+                      {chip.label}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
       </ProxmoxSidebar>
 
       <ProxmoxMainArea

--- a/src/components/layout/ProxmoxLayout.css
+++ b/src/components/layout/ProxmoxLayout.css
@@ -1,13 +1,4 @@
-:root {
-  --proxmox-bg: #1f2428;
-  --proxmox-panel: #2b333a;
-  --proxmox-panel-alt: #252c32;
-  --proxmox-border: #3a444d;
-  --proxmox-border-strong: #4d5862;
-  --proxmox-accent: #f08236;
-  --proxmox-text: #d5d9dc;
-  --proxmox-text-muted: #aab4bc;
-}
+/* Proxmox-inspired layout styles */
 
 .proxmox-shell {
   display: grid;
@@ -30,7 +21,7 @@
 .proxmox-shell.ui-hidden .proxmox-task-panel,
 .proxmox-shell.ui-hidden .proxmox-footer,
 .proxmox-shell.ui-hidden .sidebar-header,
-.proxmox-shell.ui-hidden .sidebar-content,
+.proxmox-shell.ui-hidden .sidebar-scroll,
 .proxmox-shell.ui-hidden .sidebar-footer {
   display: none !important;
 }
@@ -56,6 +47,14 @@
   box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.25);
 }
 
+.sidebar-scroll {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .sidebar-header {
   display: flex;
   align-items: center;
@@ -76,7 +75,7 @@
   font-weight: 600;
   letter-spacing: 0.02em;
   text-transform: uppercase;
-  color: #ffffff;
+  color: var(--proxmox-text-strong);
 }
 
 .sidebar-subtitle {
@@ -100,7 +99,8 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+  transition: border-color var(--transition-fast), color var(--transition-fast),
+    background var(--transition-fast);
 }
 
 .sidebar-toolbar button:hover {
@@ -109,9 +109,223 @@
   background: rgba(240, 130, 54, 0.1);
 }
 
+.sidebar-navigation {
+  border-bottom: 1px solid var(--proxmox-border);
+  background: rgba(21, 26, 30, 0.9);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.35);
+}
+
+.sidebar-navigation__inner {
+  padding: 18px 16px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.sidebar-nav__section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sidebar-nav__title {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--proxmox-text-muted);
+}
+
+.sidebar-nav__items {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sidebar-nav__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--proxmox-text);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast),
+    box-shadow var(--transition-fast), transform var(--transition-fast);
+  text-align: left;
+}
+
+.sidebar-nav__item:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.08);
+  transform: translateX(2px);
+}
+
+.sidebar-nav__item.is-active {
+  background: var(--proxmox-accent-soft);
+  border-color: rgba(240, 130, 54, 0.45);
+  box-shadow: 0 0 0 1px rgba(240, 130, 54, 0.35);
+  color: var(--proxmox-text-strong);
+}
+
+.sidebar-nav__item.is-active .sidebar-nav__icon {
+  color: var(--proxmox-accent-strong);
+}
+
+.sidebar-nav__icon {
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--proxmox-text-muted);
+}
+
+.sidebar-nav__icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.sidebar-nav__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sidebar-nav__label {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  color: inherit;
+}
+
+.sidebar-nav__description {
+  font-size: var(--font-size-xs);
+  color: var(--proxmox-text-muted);
+}
+
+.sidebar-nav__badge {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--proxmox-text-muted);
+}
+
+.sidebar-nav__item.is-active .sidebar-nav__badge {
+  background: rgba(240, 130, 54, 0.22);
+  color: var(--proxmox-text-strong);
+}
+
 .sidebar-content {
   flex: 1;
   overflow: hidden auto;
+}
+
+.sidebar-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px 18px 24px;
+}
+
+.sidebar-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: var(--proxmox-panel-alt);
+  border: 1px solid var(--proxmox-border);
+  border-radius: var(--radius-md);
+  padding: 16px 18px;
+  box-shadow: var(--shadow-soft);
+}
+
+.sidebar-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebar-card__title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--proxmox-text-strong);
+}
+
+.sidebar-card__subtitle {
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--proxmox-text-muted);
+}
+
+.sidebar-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sidebar-card__meta {
+  font-size: var(--font-size-sm);
+  color: var(--proxmox-text-muted);
+}
+
+.sidebar-card__list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sidebar-card__list-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--proxmox-border-soft);
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.sidebar-card__list-item strong {
+  font-size: var(--font-size-sm);
+  color: var(--proxmox-text-strong);
+}
+
+.sidebar-card__list-item span {
+  font-size: var(--font-size-xs);
+  color: var(--proxmox-text-muted);
+}
+
+.sidebar-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.sidebar-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: var(--font-size-xs);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--proxmox-text-muted);
+}
+
+.sidebar-chip--accent {
+  background: rgba(240, 130, 54, 0.18);
+  color: var(--proxmox-text-strong);
 }
 
 .sidebar-footer {
@@ -399,7 +613,7 @@
     min-width: 220px;
   }
 
-  .sidebar-content {
+  .sidebar-scroll {
     flex: 1;
     max-height: 260px;
   }
@@ -438,7 +652,7 @@
     flex-direction: column;
   }
 
-  .sidebar-content {
+  .sidebar-scroll {
     max-height: none;
   }
 }

--- a/src/components/layout/ProxmoxLayout.tsx
+++ b/src/components/layout/ProxmoxLayout.tsx
@@ -22,6 +22,7 @@ interface SidebarProps {
   footer?: React.ReactNode;
   children: React.ReactNode;
   className?: string;
+  navigation?: React.ReactNode;
 }
 
 export const Sidebar: React.FC<SidebarProps> = ({
@@ -31,6 +32,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   footer,
   children,
   className,
+  navigation,
 }) => {
   const classes = ['proxmox-sidebar'];
   if (className) {
@@ -46,7 +48,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
         </div>
         {toolbar && <div className="sidebar-toolbar">{toolbar}</div>}
       </div>
-      <div className="sidebar-content">{children}</div>
+      <div className="sidebar-scroll">
+        {navigation && (
+          <div className="sidebar-navigation">
+            <div className="sidebar-navigation__inner">{navigation}</div>
+          </div>
+        )}
+        <div className="sidebar-content">{children}</div>
+      </div>
       {footer && <div className="sidebar-footer">{footer}</div>}
     </aside>
   );
@@ -167,5 +176,75 @@ export const FooterPanel: React.FC<FooterPanelProps> = ({
       </div>
       <div className="panel-body">{children}</div>
     </footer>
+  );
+};
+
+export interface SidebarNavItem {
+  id: string;
+  icon: React.ReactNode;
+  label: string;
+  description?: string;
+  badge?: string | number;
+}
+
+export interface SidebarNavSection {
+  id: string;
+  title?: string;
+  items: SidebarNavItem[];
+}
+
+interface SidebarNavigationProps {
+  sections: SidebarNavSection[];
+  activeId: string;
+  onSelect: (itemId: string) => void;
+  className?: string;
+}
+
+export const SidebarNavigation: React.FC<SidebarNavigationProps> = ({
+  sections,
+  activeId,
+  onSelect,
+  className,
+}) => {
+  const classes = ['sidebar-nav'];
+  if (className) {
+    classes.push(className);
+  }
+
+  return (
+    <nav className={classes.join(' ')}>
+      {sections.map(section => (
+        <div key={section.id} className="sidebar-nav__section">
+          {section.title && <span className="sidebar-nav__title">{section.title}</span>}
+          <div className="sidebar-nav__items">
+            {section.items.map(item => {
+              const itemClasses = ['sidebar-nav__item'];
+              if (item.id === activeId) {
+                itemClasses.push('is-active');
+              }
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  className={itemClasses.join(' ')}
+                  onClick={() => onSelect(item.id)}
+                >
+                  <span className="sidebar-nav__icon">{item.icon}</span>
+                  <span className="sidebar-nav__content">
+                    <span className="sidebar-nav__label">{item.label}</span>
+                    {item.description && (
+                      <span className="sidebar-nav__description">{item.description}</span>
+                    )}
+                  </span>
+                  {item.badge !== undefined && item.badge !== null && (
+                    <span className="sidebar-nav__badge">{item.badge}</span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </nav>
   );
 };


### PR DESCRIPTION
## Summary
- update the global design tokens and typography to match a Proxmox-inspired theme
- enhance the layout components and styles to support sidebar navigation cards
- add grouped sidebar navigation with resource, layer, and routing panels in the main app

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d41ecaced08333b67ca37834d6a2eb