### PR TITLE
Revamp Proxmox chat layout components

### DIFF
--- a/src/components/layout/ProxmoxLayout.css
+++ b/src/components/layout/ProxmoxLayout.css
@@ -362,8 +362,361 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  gap: 16px;
   overflow: hidden;
-  padding: 16px 20px 0;
+  padding: 16px 20px 20px;
+}
+
+.mainchat-header__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px 20px 16px;
+}
+
+.mainchat-header__headline {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.mainchat-header__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mainchat-header__breadcrumbs {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--proxmox-text-muted);
+}
+
+.mainchat-header__title {
+  font-size: 22px;
+  font-weight: var(--font-weight-semibold);
+  color: var(--proxmox-text-strong);
+  line-height: 1.1;
+}
+
+.mainchat-header__subtitle {
+  font-size: var(--font-size-sm);
+  color: var(--proxmox-text-muted);
+}
+
+.mainchat-header__side {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.mainchat-header__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(240, 130, 54, 0.28);
+  background: rgba(240, 130, 54, 0.12);
+  color: var(--proxmox-accent-strong);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.mainchat-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mainchat-header__actions .action-button,
+.mainchat-header__actions button {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--proxmox-border);
+  border-radius: var(--radius-sm);
+  color: var(--proxmox-text);
+  padding: 6px 10px;
+  font-size: var(--font-size-sm);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: border var(--transition-fast), background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.mainchat-header__actions .action-button:hover,
+.mainchat-header__actions button:hover {
+  border-color: var(--proxmox-accent);
+  background: rgba(240, 130, 54, 0.2);
+  color: var(--proxmox-text-strong);
+}
+
+.mainchat-header__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.chat-search {
+  flex: 1;
+  min-width: 220px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--proxmox-border);
+  background: rgba(0, 0, 0, 0.22);
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.chat-search:focus-within {
+  border-color: var(--proxmox-accent);
+  background: rgba(240, 130, 54, 0.08);
+}
+
+.chat-search__icon,
+.chat-search__suffix {
+  color: var(--proxmox-text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-base);
+}
+
+.chat-search__input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--proxmox-text);
+  font-size: var(--font-size-sm);
+}
+
+.mainchat-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden auto;
+  padding-right: 4px;
+}
+
+.mainchat-footer {
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--proxmox-border);
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.chat-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding-bottom: 12px;
+}
+
+.chat-marker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  align-self: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--proxmox-border);
+  background: rgba(255, 255, 255, 0.06);
+  font-size: var(--font-size-xs);
+  color: var(--proxmox-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.chat-marker__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-base);
+}
+
+.chat-marker__label {
+  letter-spacing: inherit;
+}
+
+.chat-message {
+  display: flex;
+  gap: 12px;
+  max-width: 720px;
+}
+
+.chat-message--outbound {
+  margin-left: auto;
+  flex-direction: row-reverse;
+}
+
+.chat-message__avatar {
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--proxmox-text);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.chat-message__bubble {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--proxmox-border);
+  background: rgba(18, 22, 26, 0.88);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+.chat-message--outbound .chat-message__bubble {
+  background: rgba(240, 130, 54, 0.15);
+  border-color: rgba(240, 130, 54, 0.35);
+}
+
+.chat-message__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.chat-message__identity {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.chat-message__author {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--proxmox-text-strong);
+}
+
+.chat-message__timestamp {
+  font-size: var(--font-size-xs);
+  color: var(--proxmox-text-muted);
+}
+
+.chat-message__meta {
+  font-size: var(--font-size-xs);
+  color: var(--proxmox-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.chat-message__actions {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.chat-message__actions button {
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-xs);
+  color: var(--proxmox-text);
+  padding: 4px 6px;
+  cursor: pointer;
+  font-size: var(--font-size-xs);
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.chat-message__actions button:hover {
+  background: rgba(240, 130, 54, 0.2);
+  color: var(--proxmox-text-strong);
+}
+
+.chat-message__content {
+  font-size: var(--font-size-base);
+  line-height: 1.6;
+  color: var(--proxmox-text);
+  white-space: pre-wrap;
+}
+
+.chat-message__attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.chat-message__status {
+  font-size: var(--font-size-xs);
+  color: var(--proxmox-text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.panel-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+}
+
+.panel-tablist {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.panel-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--proxmox-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--proxmox-text);
+  cursor: pointer;
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  transition: border var(--transition-fast), background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.panel-tab:hover {
+  border-color: var(--proxmox-accent);
+  color: var(--proxmox-accent-strong);
+}
+
+.panel-tab.is-active {
+  background: rgba(240, 130, 54, 0.2);
+  border-color: rgba(240, 130, 54, 0.38);
+  color: var(--proxmox-text-strong);
+}
+
+.panel-tab__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--proxmox-text-muted);
+  font-size: 10px;
+}
+
+.panel-tabpanes {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden auto;
+  padding-right: 4px;
 }
 
 .proxmox-task-panel {
@@ -618,8 +971,13 @@
     max-height: 260px;
   }
 
+  .mainchat-header__inner {
+    padding: 14px 16px 12px;
+  }
+
   .mainchat-body {
-    padding: 12px 16px 0;
+    padding: 12px 16px 16px;
+    gap: 12px;
   }
 
   .bottom-section {
@@ -644,6 +1002,30 @@
 
   .controls-panel {
     padding: 20px 14px;
+  }
+
+  .mainchat-header__headline {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .mainchat-header__actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .mainchat-header__toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .chat-search {
+    width: 100%;
+  }
+
+  .chat-message {
+    max-width: 100%;
   }
 }
 

--- a/src/components/layout/ProxmoxLayout.tsx
+++ b/src/components/layout/ProxmoxLayout.tsx
@@ -63,23 +63,193 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
 interface MainChatProps {
   header?: React.ReactNode;
+  title?: string;
+  subtitle?: string;
+  status?: React.ReactNode;
+  toolbar?: React.ReactNode;
+  actions?: React.ReactNode;
   children: React.ReactNode;
+  footer?: React.ReactNode;
   className?: string;
 }
 
-export const MainChat: React.FC<MainChatProps> = ({ header, children, className }) => {
+export const MainChat: React.FC<MainChatProps> = ({
+  header,
+  title,
+  subtitle,
+  status,
+  toolbar,
+  actions,
+  children,
+  footer,
+  className,
+}) => {
   const classes = ['proxmox-mainchat'];
   if (className) {
     classes.push(className);
   }
 
+  const resolvedHeader = header ?? (
+    <MainChatHeader
+      title={title}
+      subtitle={subtitle}
+      status={status}
+      toolbar={toolbar}
+      actions={actions}
+    />
+  );
+
   return (
     <section className={classes.join(' ')}>
-      {header && <div className="mainchat-header">{header}</div>}
-      <div className="mainchat-body">{children}</div>
+      {resolvedHeader && <div className="mainchat-header">{resolvedHeader}</div>}
+      <div className="mainchat-body">
+        <div className="mainchat-scroll">{children}</div>
+        {footer && <div className="mainchat-footer">{footer}</div>}
+      </div>
     </section>
   );
 };
+
+interface MainChatHeaderProps {
+  title?: string;
+  subtitle?: string;
+  status?: React.ReactNode;
+  actions?: React.ReactNode;
+  toolbar?: React.ReactNode;
+  breadcrumbs?: React.ReactNode;
+  className?: string;
+}
+
+export const MainChatHeader: React.FC<MainChatHeaderProps> = ({
+  title,
+  subtitle,
+  status,
+  actions,
+  toolbar,
+  breadcrumbs,
+  className,
+}) => {
+  if (!title && !subtitle && !status && !toolbar && !actions && !breadcrumbs) {
+    return null;
+  }
+
+  const classes = ['mainchat-header__inner'];
+  if (className) {
+    classes.push(className);
+  }
+
+  return (
+    <div className={classes.join(' ')}>
+      <div className="mainchat-header__headline">
+        <div className="mainchat-header__titles">
+          {breadcrumbs && <div className="mainchat-header__breadcrumbs">{breadcrumbs}</div>}
+          {title && <h1 className="mainchat-header__title">{title}</h1>}
+          {subtitle && <p className="mainchat-header__subtitle">{subtitle}</p>}
+        </div>
+        <div className="mainchat-header__side">
+          {status && <div className="mainchat-header__status">{status}</div>}
+          {actions && <div className="mainchat-header__actions">{actions}</div>}
+        </div>
+      </div>
+      {toolbar && <div className="mainchat-header__toolbar">{toolbar}</div>}
+    </div>
+  );
+};
+
+interface ChatSearchBarProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  icon?: React.ReactNode;
+  suffix?: React.ReactNode;
+}
+
+export const ChatSearchBar: React.FC<ChatSearchBarProps> = ({ icon, suffix, ...props }) => {
+  return (
+    <div className="chat-search">
+      {icon && <span className="chat-search__icon">{icon}</span>}
+      <input className="chat-search__input" {...props} />
+      {suffix && <span className="chat-search__suffix">{suffix}</span>}
+    </div>
+  );
+};
+
+interface ChatMessageListProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const ChatMessageList: React.FC<ChatMessageListProps> = ({ children, className }) => {
+  const classes = ['chat-thread'];
+  if (className) {
+    classes.push(className);
+  }
+
+  return <div className={classes.join(' ')}>{children}</div>;
+};
+
+interface ChatMessageProps {
+  author: string;
+  role?: 'user' | 'assistant' | 'system';
+  timestamp: string;
+  content: React.ReactNode;
+  variant?: 'inbound' | 'outbound';
+  avatar?: React.ReactNode;
+  meta?: React.ReactNode;
+  actions?: React.ReactNode;
+  status?: React.ReactNode;
+  attachments?: React.ReactNode;
+}
+
+export const ChatMessage: React.FC<ChatMessageProps> = ({
+  author,
+  role = 'user',
+  timestamp,
+  content,
+  variant = 'inbound',
+  avatar,
+  meta,
+  actions,
+  status,
+  attachments,
+}) => {
+  const classes = ['chat-message', `chat-message--${variant}`, `chat-message--${role}`];
+
+  return (
+    <article className={classes.join(' ')}>
+      {avatar && <div className="chat-message__avatar">{avatar}</div>}
+      <div className="chat-message__bubble">
+        <header className="chat-message__header">
+          <div className="chat-message__identity">
+            <span className="chat-message__author">{author}</span>
+            <span className="chat-message__timestamp">{timestamp}</span>
+            {meta && <span className="chat-message__meta">{meta}</span>}
+          </div>
+          {actions && <div className="chat-message__actions">{actions}</div>}
+        </header>
+        <div className="chat-message__content">{content}</div>
+        {attachments && <div className="chat-message__attachments">{attachments}</div>}
+        {status && <footer className="chat-message__status">{status}</footer>}
+      </div>
+    </article>
+  );
+};
+
+interface ChatTimelineMarkerProps {
+  label: string;
+  icon?: React.ReactNode;
+}
+
+export const ChatTimelineMarker: React.FC<ChatTimelineMarkerProps> = ({ label, icon }) => (
+  <div className="chat-marker">
+    {icon && <span className="chat-marker__icon">{icon}</span>}
+    <span className="chat-marker__label">{label}</span>
+  </div>
+);
+
+export interface PanelTabDescriptor {
+  id: string;
+  label: string;
+  badge?: string | number;
+  content: React.ReactNode;
+}
 
 interface CollapsiblePanelProps {
   title: string;
@@ -88,6 +258,9 @@ interface CollapsiblePanelProps {
   toolbar?: React.ReactNode;
   children?: React.ReactNode;
   className?: string;
+  tabs?: PanelTabDescriptor[];
+  defaultTabId?: string;
+  onTabChange?: (tabId: string) => void;
 }
 
 export const TaskActivityPanel: React.FC<CollapsiblePanelProps> = ({
@@ -97,6 +270,9 @@ export const TaskActivityPanel: React.FC<CollapsiblePanelProps> = ({
   toolbar,
   children,
   className,
+  tabs,
+  defaultTabId,
+  onTabChange,
 }) => {
   const classes = ['proxmox-task-panel'];
   if (collapsed) {
@@ -105,6 +281,69 @@ export const TaskActivityPanel: React.FC<CollapsiblePanelProps> = ({
   if (className) {
     classes.push(className);
   }
+
+  const [activeTab, setActiveTab] = React.useState(() => {
+    if (tabs && tabs.length > 0) {
+      return defaultTabId && tabs.some(tab => tab.id === defaultTabId)
+        ? defaultTabId
+        : tabs[0].id;
+    }
+    return '';
+  });
+
+  React.useEffect(() => {
+    if (!tabs || tabs.length === 0) return;
+    const fallback = defaultTabId && tabs.some(tab => tab.id === defaultTabId)
+      ? defaultTabId
+      : tabs[0].id;
+    if (!activeTab || !tabs.some(tab => tab.id === activeTab)) {
+      setActiveTab(fallback);
+    }
+  }, [tabs, defaultTabId, activeTab]);
+
+  const handleTabClick = (tabId: string) => {
+    setActiveTab(tabId);
+    onTabChange?.(tabId);
+  };
+
+  const renderPanelBody = () => {
+    if (!tabs || tabs.length === 0) {
+      return children;
+    }
+
+    const current = tabs.find(tab => tab.id === activeTab) ?? tabs[0];
+
+    return (
+      <div className="panel-tabs">
+        <div className="panel-tablist" role="tablist" aria-label={title}>
+          {tabs.map(tab => {
+            const tabClasses = ['panel-tab'];
+            if (tab.id === current.id) {
+              tabClasses.push('is-active');
+            }
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                className={tabClasses.join(' ')}
+                aria-selected={tab.id === current.id}
+                onClick={() => handleTabClick(tab.id)}
+              >
+                <span className="panel-tab__label">{tab.label}</span>
+                {tab.badge !== undefined && tab.badge !== null && (
+                  <span className="panel-tab__badge">{tab.badge}</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+        <div className="panel-tabpanes" role="tabpanel">
+          {current.content}
+        </div>
+      </div>
+    );
+  };
 
   return (
     <aside className={classes.join(' ')}>
@@ -125,7 +364,7 @@ export const TaskActivityPanel: React.FC<CollapsiblePanelProps> = ({
           )}
         </div>
       </div>
-      <div className="panel-body">{children}</div>
+      <div className="panel-body">{renderPanelBody()}</div>
     </aside>
   );
 };


### PR DESCRIPTION
## Summary
- extend the MainChat layout to accept proxmox-like metadata, toolbars and footer slots while providing dedicated chat header, search and message helpers
- add timeline markers and tab-enabled task/activity panels so the right rail can mimic Proxmox task logs
- refresh Proxmox layout styles with chat bubble alignment, search, footer, and responsive tweaks for the new components

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d4279329208333842a10e7cca2cb48