### PR TITLE
Fix Proxmox layout header initialization order

### DIFF
--- a/src/components/layout/ProxmoxLayout.tsx
+++ b/src/components/layout/ProxmoxLayout.tsx
@@ -83,6 +83,52 @@ export const Sidebar: React.FC<SidebarProps> = ({
   );
 };
 
+interface MainChatHeaderProps {
+  title?: string;
+  subtitle?: string;
+  status?: React.ReactNode;
+  actions?: React.ReactNode;
+  toolbar?: React.ReactNode;
+  breadcrumbs?: React.ReactNode;
+  className?: string;
+}
+
+export const MainChatHeader: React.FC<MainChatHeaderProps> = ({
+  title,
+  subtitle,
+  status,
+  actions,
+  toolbar,
+  breadcrumbs,
+  className,
+}) => {
+  if (!title && !subtitle && !status && !toolbar && !actions && !breadcrumbs) {
+    return null;
+  }
+
+  const classes = ['mainchat-header__inner'];
+  if (className) {
+    classes.push(className);
+  }
+
+  return (
+    <div className={classes.join(' ')}>
+      <div className="mainchat-header__headline">
+        <div className="mainchat-header__titles">
+          {breadcrumbs && <div className="mainchat-header__breadcrumbs">{breadcrumbs}</div>}
+          {title && <h1 className="mainchat-header__title">{title}</h1>}
+          {subtitle && <p className="mainchat-header__subtitle">{subtitle}</p>}
+        </div>
+        <div className="mainchat-header__side">
+          {status && <div className="mainchat-header__status">{status}</div>}
+          {actions && <div className="mainchat-header__actions">{actions}</div>}
+        </div>
+      </div>
+      {toolbar && <div className="mainchat-header__toolbar">{toolbar}</div>}
+    </div>
+  );
+};
+
 interface MainChatProps {
   header?: React.ReactNode;
   title?: string;
@@ -129,52 +175,6 @@ export const MainChat: React.FC<MainChatProps> = ({
         {footer && <div className="mainchat-footer">{footer}</div>}
       </div>
     </section>
-  );
-};
-
-interface MainChatHeaderProps {
-  title?: string;
-  subtitle?: string;
-  status?: React.ReactNode;
-  actions?: React.ReactNode;
-  toolbar?: React.ReactNode;
-  breadcrumbs?: React.ReactNode;
-  className?: string;
-}
-
-export const MainChatHeader: React.FC<MainChatHeaderProps> = ({
-  title,
-  subtitle,
-  status,
-  actions,
-  toolbar,
-  breadcrumbs,
-  className,
-}) => {
-  if (!title && !subtitle && !status && !toolbar && !actions && !breadcrumbs) {
-    return null;
-  }
-
-  const classes = ['mainchat-header__inner'];
-  if (className) {
-    classes.push(className);
-  }
-
-  return (
-    <div className={classes.join(' ')}>
-      <div className="mainchat-header__headline">
-        <div className="mainchat-header__titles">
-          {breadcrumbs && <div className="mainchat-header__breadcrumbs">{breadcrumbs}</div>}
-          {title && <h1 className="mainchat-header__title">{title}</h1>}
-          {subtitle && <p className="mainchat-header__subtitle">{subtitle}</p>}
-        </div>
-        <div className="mainchat-header__side">
-          {status && <div className="mainchat-header__status">{status}</div>}
-          {actions && <div className="mainchat-header__actions">{actions}</div>}
-        </div>
-      </div>
-      {toolbar && <div className="mainchat-header__toolbar">{toolbar}</div>}
-    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- define the Proxmox main chat header before it is consumed to avoid runtime initialization errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d42edb7b9883338c257a79811dc6f8