### PR TITLE
Add automation cron engine and GitHub project settings

### DIFF
--- a/src/components/GlobalSettingsModal.css
+++ b/src/components/GlobalSettingsModal.css
@@ -93,7 +93,7 @@
 
 /* Sidebar */
 .settings-sidebar {
-  width: 180px;
+  width: 200px;
   background: rgba(0, 0, 0, 0.2);
   border-right: 1px solid rgba(255, 255, 255, 0.1);
   display: flex;
@@ -106,36 +106,61 @@
   display: none;
 }
 
-.tab-button {
-  background: transparent;
-  border: none;
-  color: #ccc;
-  padding: 6px 12px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  border-left: 2px solid transparent;
+.preferences-tree {
+  list-style: none;
+  margin: 0;
+  padding: 8px 0;
   display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  font-weight: 500;
-  width: 100%;
-  text-align: left;
+  flex-direction: column;
+  gap: 4px;
 }
 
-.tab-button:hover {
+.preferences-node {
+  display: flex;
+  flex-direction: column;
+}
+
+.preferences-node__label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border: none;
+  background: transparent;
+  color: #ccc;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.2s ease;
+  border-left: 2px solid transparent;
+}
+
+.preferences-node__label:hover {
   color: #fff;
   background: rgba(255, 255, 255, 0.05);
 }
 
-.tab-button.active {
+.preferences-node.leaf .preferences-node__label.active {
   color: var(--accent-color);
   border-left-color: var(--accent-color);
   background: rgba(255, 183, 77, 0.1);
 }
 
-.tab-icon {
+.preferences-node__icon {
   font-size: 16px;
+}
+
+.preferences-children {
+  margin-left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.preferences-expander {
+  font-size: 10px;
+  opacity: 0.6;
 }
 
 /* Content */

--- a/src/components/settings/AutomationSettings.css
+++ b/src/components/settings/AutomationSettings.css
@@ -1,0 +1,310 @@
+.automation-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.automation-layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 20px;
+}
+
+.automation-sidebar {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.automation-sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #bbb;
+}
+
+.automation-sidebar-header button {
+  background: rgba(255, 183, 77, 0.15);
+  border: 1px solid rgba(255, 183, 77, 0.4);
+  border-radius: 8px;
+  color: var(--accent-color);
+  font-weight: 600;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.automation-empty {
+  padding: 24px 12px;
+  text-align: center;
+  color: #888;
+  font-size: 13px;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+}
+
+.automation-job-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.automation-job-list li {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.25);
+}
+
+.automation-job-list li.active {
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 1px rgba(255, 183, 77, 0.3);
+}
+
+.automation-job-list li button {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  background: transparent;
+  border: none;
+  padding: 10px 12px;
+  cursor: pointer;
+  color: #fff;
+  text-align: left;
+}
+
+.job-actions {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.job-actions button {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  color: #ddd;
+  padding: 4px 8px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.job-actions button:hover {
+  border-color: var(--accent-color);
+  color: var(--accent-color);
+}
+
+.job-name {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.job-status {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.job-status.enabled {
+  color: var(--accent-color);
+}
+
+.job-status.disabled {
+  color: #ff6b6b;
+}
+
+.job-expression {
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+  color: #bbb;
+}
+
+.job-next-run {
+  font-size: 11px;
+  color: #888;
+}
+
+.automation-projects {
+  margin-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.automation-projects h4 {
+  margin: 0;
+  font-size: 13px;
+  color: var(--accent-color);
+}
+
+.automation-projects p {
+  margin: 0;
+  font-size: 12px;
+  color: #aaa;
+}
+
+.automation-projects ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.automation-projects li {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 8px 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.automation-projects li span {
+  display: block;
+  font-size: 12px;
+  color: #bbb;
+}
+
+.project-job-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.project-job-actions button {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  cursor: pointer;
+  color: #ddd;
+}
+
+.project-job-actions button:hover {
+  border-color: var(--accent-color);
+  color: var(--accent-color);
+}
+
+.automation-form {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 20px;
+  overflow-y: auto;
+  max-height: 420px;
+}
+
+.automation-form-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.setting-input,
+.setting-textarea {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 6px 10px;
+  color: #fff;
+  font-size: 13px;
+}
+
+.setting-textarea {
+  resize: vertical;
+}
+
+.setting-input.has-error {
+  border-color: #ff6b6b;
+}
+
+.form-error {
+  margin-top: 6px;
+  color: #ff6b6b;
+  font-size: 12px;
+}
+
+.automation-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  color: #bbb;
+}
+
+.automation-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.primary-button,
+.secondary-button {
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.primary-button {
+  background: var(--accent-color);
+  color: #1b1b1b;
+  font-weight: 600;
+}
+
+.secondary-button {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #ddd;
+}
+
+.secondary-button:hover {
+  border-color: var(--accent-color);
+  color: var(--accent-color);
+}
+
+.save-message {
+  color: var(--accent-color);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.setting-group.inline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+@media (max-width: 900px) {
+  .automation-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .automation-form,
+  .automation-sidebar {
+    max-height: none;
+  }
+}

--- a/src/components/settings/AutomationSettings.tsx
+++ b/src/components/settings/AutomationSettings.tsx
@@ -1,0 +1,367 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { CronJob } from '../../types/automation';
+import { getNextRun, validateCronExpression } from '../../utils/cron';
+import './AutomationSettings.css';
+
+interface AutomationSettingsProps {
+  cronJobs: CronJob[];
+  onSaveJob: (job: CronJob) => void;
+  onDeleteJob: (jobId: string) => void;
+  onToggleJob: (jobId: string, enabled: boolean) => void;
+  onRunJob: (jobId: string) => void;
+}
+
+type FormState = {
+  id?: string;
+  name: string;
+  cronExpression: string;
+  command: string;
+  workingDirectory: string;
+  enabled: boolean;
+};
+
+const defaultFormState: FormState = {
+  name: '',
+  cronExpression: '*/5 * * * *',
+  command: '',
+  workingDirectory: '',
+  enabled: true
+};
+
+function createId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `cron-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+}
+
+function formatDate(value?: string): string {
+  if (!value) {
+    return '—';
+  }
+  try {
+    return new Date(value).toLocaleString();
+  } catch (error) {
+    return value;
+  }
+}
+
+function formatNextRun(expression: string): string {
+  const next = getNextRun(expression);
+  if (!next) {
+    return 'Not scheduled';
+  }
+  return next.toLocaleString();
+}
+
+export const AutomationSettings: React.FC<AutomationSettingsProps> = ({
+  cronJobs,
+  onSaveJob,
+  onDeleteJob,
+  onToggleJob,
+  onRunJob
+}) => {
+  const userJobs = useMemo(
+    () => cronJobs.filter((job) => job.source !== 'project'),
+    [cronJobs]
+  );
+
+  const projectJobs = useMemo(
+    () => cronJobs.filter((job) => job.source === 'project'),
+    [cronJobs]
+  );
+
+  const [selectedId, setSelectedId] = useState<string | null>(
+    userJobs.length > 0 ? userJobs[0].id : null
+  );
+  const [formState, setFormState] = useState<FormState>(defaultFormState);
+  const [cronError, setCronError] = useState<string | null>(null);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setFormState(defaultFormState);
+      setCronError(null);
+      return;
+    }
+    const job = userJobs.find((item) => item.id === selectedId);
+    if (job) {
+      setFormState({
+        id: job.id,
+        name: job.name,
+        cronExpression: job.cronExpression,
+        command: job.command,
+        workingDirectory: job.workingDirectory || '',
+        enabled: job.enabled
+      });
+      setCronError(null);
+    }
+  }, [selectedId, userJobs]);
+
+  useEffect(() => {
+    if (userJobs.length === 0) {
+      setSelectedId(null);
+    }
+  }, [userJobs.length]);
+
+  const handleFieldChange = <K extends keyof FormState>(
+    key: K,
+    value: FormState[K]
+  ) => {
+    setFormState((prev) => ({ ...prev, [key]: value }));
+    if (key === 'cronExpression') {
+      setCronError(null);
+    }
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const error = validateCronExpression(formState.cronExpression);
+    if (error) {
+      setCronError(error);
+      return;
+    }
+
+    const id = formState.id || createId();
+    const job: CronJob = {
+      id,
+      name: formState.name.trim() || `Cron ${id.slice(-4)}`,
+      cronExpression: formState.cronExpression.trim(),
+      command: formState.command.trim(),
+      workingDirectory: formState.workingDirectory.trim() || undefined,
+      enabled: formState.enabled,
+      source: 'user'
+    };
+
+    const existing = cronJobs.find((item) => item.id === id);
+    if (existing) {
+      job.lastRunAt = existing.lastRunAt;
+      job.lastStatus = existing.lastStatus;
+      job.lastOutput = existing.lastOutput;
+      job.lastError = existing.lastError;
+    }
+
+    onSaveJob(job);
+    setSelectedId(id);
+    setSaveMessage('Cron job saved');
+    window.setTimeout(() => setSaveMessage(null), 2500);
+  };
+
+  const handleAddNew = () => {
+    setSelectedId(null);
+    setFormState(defaultFormState);
+    setCronError(null);
+  };
+
+  const handleDelete = (jobId: string) => {
+    if (!window.confirm('Delete this cron job?')) {
+      return;
+    }
+    onDeleteJob(jobId);
+    if (selectedId === jobId) {
+      setSelectedId(null);
+    }
+  };
+
+  return (
+    <div className="automation-settings">
+      <h3>🕒 Automation & Cron Jobs</h3>
+      <p className="setting-description">
+        Configure recurring tasks that will execute shell commands on schedule. The
+        scheduler runs in the background while the application is open.
+      </p>
+
+      <div className="automation-layout">
+        <div className="automation-sidebar">
+          <div className="automation-sidebar-header">
+            <span>Custom jobs</span>
+            <button type="button" onClick={handleAddNew}>
+              ＋ Add
+            </button>
+          </div>
+
+          {userJobs.length === 0 ? (
+            <div className="automation-empty">No cron jobs yet</div>
+          ) : (
+            <ul className="automation-job-list">
+              {userJobs.map((job) => (
+                <li
+                  key={job.id}
+                  className={job.id === selectedId ? 'active' : ''}
+                >
+                  <button type="button" onClick={() => setSelectedId(job.id)}>
+                    <span className="job-name">{job.name}</span>
+                    <span className={`job-status ${job.enabled ? 'enabled' : 'disabled'}`}>
+                      {job.enabled ? 'Enabled' : 'Disabled'}
+                    </span>
+                    <span className="job-expression">{job.cronExpression}</span>
+                    <span className="job-next-run">
+                      Next run: {formatNextRun(job.cronExpression)}
+                    </span>
+                  </button>
+                  <div className="job-actions">
+                    <button type="button" onClick={() => onRunJob(job.id)}>
+                      Run now
+                    </button>
+                    <button type="button" onClick={() => handleDelete(job.id)}>
+                      Delete
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {projectJobs.length > 0 && (
+            <div className="automation-projects">
+              <h4>Project jobs</h4>
+              <p>
+                Managed automatically from project settings. They stay enabled while
+                the project has auto-sync configured.
+              </p>
+              <ul>
+                {projectJobs.map((job) => (
+                  <li key={job.id}>
+                    <div>
+                      <strong>{job.name}</strong>
+                      <span>{job.cronExpression}</span>
+                    </div>
+                    <div className="project-job-actions">
+                      <button type="button" onClick={() => onRunJob(job.id)}>
+                        Run now
+                      </button>
+                      <span className={`job-status ${job.enabled ? 'enabled' : 'disabled'}`}>
+                        {job.enabled ? 'Enabled' : 'Disabled'}
+                      </span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        <div className="automation-form">
+          <form onSubmit={handleSubmit} className="automation-form-fields">
+            <div className="setting-group">
+              <label className="setting-label">
+                <span>Name</span>
+                <input
+                  type="text"
+                  value={formState.name}
+                  onChange={(event) => handleFieldChange('name', event.target.value)}
+                  className="setting-input"
+                  placeholder="Describe this job"
+                />
+              </label>
+            </div>
+
+            <div className="setting-group">
+              <label className="setting-label">
+                <span>Cron expression</span>
+                <input
+                  type="text"
+                  value={formState.cronExpression}
+                  onChange={(event) => handleFieldChange('cronExpression', event.target.value)}
+                  className={`setting-input ${cronError ? 'has-error' : ''}`}
+                />
+              </label>
+              <small className="setting-hint">
+                Format: minute hour day month weekday. Example every 15 minutes:
+                <code>*/15 * * * *</code>
+              </small>
+              {cronError && <div className="form-error">{cronError}</div>}
+            </div>
+
+            <div className="setting-group">
+              <label className="setting-label">
+                <span>Command</span>
+                <textarea
+                  value={formState.command}
+                  onChange={(event) => handleFieldChange('command', event.target.value)}
+                  className="setting-textarea"
+                  placeholder="Command to execute"
+                  rows={3}
+                />
+              </label>
+              <small className="setting-hint">
+                Commands run using the system shell when available. In preview builds
+                the execution is simulated.
+              </small>
+            </div>
+
+            <div className="setting-group">
+              <label className="setting-label">
+                <span>Working directory</span>
+                <input
+                  type="text"
+                  value={formState.workingDirectory}
+                  onChange={(event) =>
+                    handleFieldChange('workingDirectory', event.target.value)
+                  }
+                  className="setting-input"
+                  placeholder="Optional path"
+                />
+              </label>
+              <small className="setting-hint">
+                Leave empty to run the command in the application directory.
+              </small>
+            </div>
+
+            <div className="setting-group inline">
+              <label className="setting-checkbox">
+                <input
+                  type="checkbox"
+                  checked={formState.enabled}
+                  onChange={(event) =>
+                    handleFieldChange('enabled', event.target.checked)
+                  }
+                />
+                <span>Enable job</span>
+              </label>
+              {saveMessage && <span className="save-message">{saveMessage}</span>}
+            </div>
+
+            <div className="setting-group">
+              <div className="automation-meta">
+                <div>
+                  <strong>Last run:</strong> {formatDate(formState.id ? cronJobs.find((job) => job.id === formState.id)?.lastRunAt : undefined)}
+                </div>
+                <div>
+                  <strong>Next run:</strong>{' '}
+                  {formState.cronExpression
+                    ? formatNextRun(formState.cronExpression)
+                    : 'Not scheduled'}
+                </div>
+              </div>
+            </div>
+
+            <div className="automation-actions">
+              <button type="submit" className="primary-button">
+                Save changes
+              </button>
+              {formState.id && (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => onRunJob(formState.id!)}
+                    className="secondary-button"
+                  >
+                    Run now
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onToggleJob(formState.id!, !formState.enabled)}
+                    className="secondary-button"
+                  >
+                    {formState.enabled ? 'Disable' : 'Enable'}
+                  </button>
+                </>
+              )}
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/settings/ProjectSettings.css
+++ b/src/components/settings/ProjectSettings.css
@@ -1,0 +1,218 @@
+.project-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.project-layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 20px;
+}
+
+.project-list {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.project-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #bbb;
+}
+
+.project-list-header button {
+  background: rgba(129, 199, 132, 0.15);
+  border: 1px solid rgba(129, 199, 132, 0.4);
+  color: #81c784;
+  border-radius: 8px;
+  font-weight: 600;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.project-empty {
+  padding: 24px 12px;
+  text-align: center;
+  color: #888;
+  font-size: 13px;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+}
+
+.project-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.project-list li {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+}
+
+.project-list li.active {
+  border-color: #81c784;
+  box-shadow: 0 0 0 1px rgba(129, 199, 132, 0.35);
+}
+
+.project-list li button {
+  background: transparent;
+  border: none;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: #fff;
+  padding: 10px 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.project-list li strong {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.project-list li span {
+  font-size: 12px;
+  color: #bbb;
+}
+
+.project-branch {
+  font-family: 'Courier New', monospace;
+}
+
+.project-sync-status {
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+}
+
+.project-actions {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.project-actions button {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  color: #ddd;
+  padding: 4px 8px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.project-actions button:hover {
+  border-color: #81c784;
+  color: #81c784;
+}
+
+.project-form {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 20px;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.project-form-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.setting-input,
+.setting-textarea {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 6px 10px;
+  color: #fff;
+  font-size: 13px;
+}
+
+.setting-textarea {
+  resize: vertical;
+}
+
+.setting-input.has-error {
+  border-color: #ff6b6b;
+}
+
+.form-error {
+  margin-top: 6px;
+  color: #ff6b6b;
+  font-size: 12px;
+}
+
+.project-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  color: #bbb;
+}
+
+.project-link {
+  color: var(--accent-color);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.project-link:hover {
+  text-decoration: underline;
+}
+
+.project-feedback {
+  background: rgba(129, 199, 132, 0.15);
+  border: 1px solid rgba(129, 199, 132, 0.35);
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: #d8ffd8;
+  font-size: 12px;
+}
+
+.project-actions-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.project-next-run {
+  margin-top: 6px;
+  font-size: 12px;
+  color: #ccc;
+}
+
+@media (max-width: 900px) {
+  .project-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .project-list,
+  .project-form {
+    max-height: none;
+  }
+}

--- a/src/components/settings/ProjectSettings.tsx
+++ b/src/components/settings/ProjectSettings.tsx
@@ -1,0 +1,425 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  ProjectConfig,
+  ProjectValidationResult
+} from '../../types/projects';
+import { validateCronExpression, getNextRun } from '../../utils/cron';
+import { CommandRunResult } from '../../utils/commandRunner';
+import './ProjectSettings.css';
+
+interface ProjectSettingsProps {
+  projects: ProjectConfig[];
+  onSaveProject: (project: ProjectConfig) => void;
+  onDeleteProject: (projectId: string) => void;
+  onSyncProject: (projectId: string) => Promise<CommandRunResult>;
+  onCloneProject: (project: ProjectConfig) => Promise<CommandRunResult>;
+  onValidateProject: (project: ProjectConfig) => Promise<ProjectValidationResult>;
+}
+
+type ProjectFormState = ProjectConfig;
+
+const emptyProject: ProjectFormState = {
+  id: '',
+  name: '',
+  localPath: '',
+  repoUrl: '',
+  defaultBranch: 'main',
+  personalAccessToken: '',
+  autoSyncCron: '',
+  description: ''
+};
+
+function createProjectId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `project-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+}
+
+function formatSyncStatus(project?: ProjectConfig): string {
+  if (!project?.lastSyncStatus || !project.lastSyncAt) {
+    return 'Never synced';
+  }
+  const date = project.lastSyncAt
+    ? new Date(project.lastSyncAt).toLocaleString()
+    : 'unknown time';
+  const message = project.lastSyncMessage ? ` – ${project.lastSyncMessage}` : '';
+  return `${project.lastSyncStatus.toUpperCase()} (${date})${message}`;
+}
+
+export const ProjectSettings: React.FC<ProjectSettingsProps> = ({
+  projects,
+  onSaveProject,
+  onDeleteProject,
+  onSyncProject,
+  onCloneProject,
+  onValidateProject
+}) => {
+  const sortedProjects = useMemo(
+    () => [...projects].sort((a, b) => a.name.localeCompare(b.name)),
+    [projects]
+  );
+
+  const [selectedId, setSelectedId] = useState<string | null>(
+    sortedProjects[0]?.id ?? null
+  );
+  const [formState, setFormState] = useState<ProjectFormState>(emptyProject);
+  const [cronError, setCronError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setFormState(emptyProject);
+      setCronError(null);
+      return;
+    }
+    const project = projects.find((item) => item.id === selectedId);
+    if (project) {
+      setFormState({
+        ...project,
+        personalAccessToken: project.personalAccessToken || ''
+      });
+      setCronError(null);
+    }
+  }, [selectedId, projects]);
+
+  useEffect(() => {
+    if (projects.length === 0) {
+      setSelectedId(null);
+    }
+  }, [projects.length]);
+
+  const handleChange = <K extends keyof ProjectFormState>(
+    key: K,
+    value: ProjectFormState[K]
+  ) => {
+    setFormState((prev) => ({ ...prev, [key]: value }));
+    if (key === 'autoSyncCron') {
+      setCronError(null);
+    }
+  };
+
+  const ensureProjectId = () => {
+    const id = formState.id || createProjectId();
+    if (!formState.id) {
+      setFormState((prev) => ({ ...prev, id }));
+    }
+    return id;
+  };
+
+  const handleSave = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!formState.name.trim()) {
+      setFeedback('Please provide a project name');
+      return;
+    }
+    if (!formState.repoUrl.trim()) {
+      setFeedback('Repository URL is required');
+      return;
+    }
+    if (!formState.localPath.trim()) {
+      setFeedback('Local path is required');
+      return;
+    }
+
+    if (formState.autoSyncCron) {
+      const error = validateCronExpression(formState.autoSyncCron);
+      if (error) {
+        setCronError(error);
+        return;
+      }
+    }
+
+    const id = ensureProjectId();
+    const payload: ProjectConfig = {
+      ...formState,
+      id,
+      name: formState.name.trim(),
+      repoUrl: formState.repoUrl.trim(),
+      localPath: formState.localPath.trim(),
+      defaultBranch: formState.defaultBranch.trim() || 'main',
+      personalAccessToken: formState.personalAccessToken?.trim() || undefined,
+      autoSyncCron: formState.autoSyncCron?.trim() || undefined,
+      description: formState.description?.trim() || undefined
+    };
+
+    onSaveProject(payload);
+    setSelectedId(id);
+    setFeedback('Project saved');
+    window.setTimeout(() => setFeedback(null), 3000);
+  };
+
+  const handleDeleteProject = (projectId: string) => {
+    if (!window.confirm('Remove this project configuration?')) {
+      return;
+    }
+    onDeleteProject(projectId);
+    if (selectedId === projectId) {
+      setSelectedId(null);
+    }
+  };
+
+  const handleValidate = async () => {
+    setIsBusy(true);
+    try {
+      const result = await onValidateProject(formState);
+      setFeedback(result.message);
+      if (result.success && result.defaultBranch) {
+        setFormState((prev) => ({ ...prev, defaultBranch: result.defaultBranch! }));
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setFeedback(`Validation error: ${message}`);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleClone = async () => {
+    setIsBusy(true);
+    try {
+      const result = await onCloneProject({
+        ...formState,
+        id: ensureProjectId()
+      });
+      setFeedback(result.success ? result.stdout || 'Clone complete' : result.errorMessage || result.stderr);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setFeedback(`Clone error: ${message}`);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleSync = async (id?: string) => {
+    const projectId = id ?? formState.id;
+    if (!projectId) {
+      return;
+    }
+    setIsBusy(true);
+    try {
+      const result = await onSyncProject(projectId);
+      setFeedback(result.success ? result.stdout || 'Sync complete' : result.errorMessage || result.stderr);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setFeedback(`Sync error: ${message}`);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const nextSync = formState.autoSyncCron
+    ? getNextRun(formState.autoSyncCron)
+    : null;
+
+  return (
+    <div className="project-settings">
+      <h3>🐙 GitHub Projects</h3>
+      <p className="setting-description">
+        Centralize the configuration of local projects linked to GitHub repositories.
+        You can validate connectivity, clone repositories and trigger synchronisation
+        without leaving Jungle Lab Studio.
+      </p>
+
+      <div className="project-layout">
+        <aside className="project-list">
+          <div className="project-list-header">
+            <span>Configured projects</span>
+            <button type="button" onClick={() => setSelectedId(null)}>
+              ＋ New
+            </button>
+          </div>
+
+          {sortedProjects.length === 0 ? (
+            <div className="project-empty">No projects configured yet</div>
+          ) : (
+            <ul>
+              {sortedProjects.map((project) => (
+                <li
+                  key={project.id}
+                  className={selectedId === project.id ? 'active' : ''}
+                >
+                  <button type="button" onClick={() => setSelectedId(project.id)}>
+                    <strong>{project.name}</strong>
+                    <span>{project.repoUrl}</span>
+                    <span className="project-branch">{project.defaultBranch}</span>
+                    <span className="project-sync-status">
+                      {project.lastSyncStatus || 'idle'}
+                    </span>
+                  </button>
+                  <div className="project-actions">
+                    <button type="button" onClick={() => handleSync(project.id)} disabled={isBusy}>
+                      Sync
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteProject(project.id)}
+                      disabled={isBusy}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </aside>
+
+        <section className="project-form">
+          <form onSubmit={handleSave} className="project-form-fields">
+            <div className="setting-group">
+              <label className="setting-label">
+                <span>Project name</span>
+                <input
+                  type="text"
+                  className="setting-input"
+                  value={formState.name}
+                  onChange={(event) => handleChange('name', event.target.value)}
+                />
+              </label>
+            </div>
+
+            <div className="setting-group">
+              <label className="setting-label">
+                <span>Repository URL</span>
+                <input
+                  type="text"
+                  className="setting-input"
+                  value={formState.repoUrl}
+                  onChange={(event) => handleChange('repoUrl', event.target.value)}
+                  placeholder="https://github.com/owner/repo.git"
+                />
+              </label>
+            </div>
+
+            <div className="setting-group">
+              <label className="setting-label">
+                <span>Local path</span>
+                <input
+                  type="text"
+                  className="setting-input"
+                  value={formState.localPath}
+                  onChange={(event) => handleChange('localPath', event.target.value)}
+                  placeholder="/projects/repo"
+                />
+              </label>
+              <small className="setting-hint">
+                Path on disk where the repository is or will be cloned.
+              </small>
+            </div>
+
+            <div className="setting-group">
+              <label className="setting-label">
+                <span>Default branch</span>
+                <input
+                  type="text"
+                  className="setting-input"
+                  value={formState.defaultBranch}
+                  onChange={(event) => handleChange('defaultBranch', event.target.value)}
+                />
+              </label>
+            </div>
+
+            <div className="setting-group">
+              <label className="setting-label">
+                <span>Personal access token</span>
+                <input
+                  type="password"
+                  className="setting-input"
+                  value={formState.personalAccessToken || ''}
+                  onChange={(event) =>
+                    handleChange('personalAccessToken', event.target.value)
+                  }
+                  placeholder="Optional, used for private repositories"
+                />
+              </label>
+            </div>
+
+            <div className="setting-group">
+              <label className="setting-label">
+                <span>Auto sync cron</span>
+                <input
+                  type="text"
+                  className={`setting-input ${cronError ? 'has-error' : ''}`}
+                  value={formState.autoSyncCron || ''}
+                  onChange={(event) => handleChange('autoSyncCron', event.target.value)}
+                  placeholder="e.g. 0 */2 * * *"
+                />
+              </label>
+              <small className="setting-hint">
+                Optional. Automatically pulls the repository using the cron engine.
+              </small>
+              {cronError && <div className="form-error">{cronError}</div>}
+              {nextSync && (
+                <div className="project-next-run">
+                  Next scheduled sync: {nextSync.toLocaleString()}
+                </div>
+              )}
+            </div>
+
+            <div className="setting-group">
+              <label className="setting-label">
+                <span>Description</span>
+                <textarea
+                  className="setting-textarea"
+                  value={formState.description || ''}
+                  onChange={(event) => handleChange('description', event.target.value)}
+                  rows={3}
+                />
+              </label>
+            </div>
+
+            <div className="project-meta">
+              <div>
+                <strong>Last sync:</strong> {formatSyncStatus(projects.find((p) => p.id === formState.id))}
+              </div>
+              {formState.repoUrl && (
+                <a
+                  href={formState.repoUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="project-link"
+                >
+                  Open repository ↗
+                </a>
+              )}
+            </div>
+
+            {feedback && <div className="project-feedback">{feedback}</div>}
+
+            <div className="project-actions-row">
+              <button type="submit" className="primary-button" disabled={isBusy}>
+                Save project
+              </button>
+              <button
+                type="button"
+                className="secondary-button"
+                onClick={handleValidate}
+                disabled={isBusy || !formState.repoUrl}
+              >
+                Validate
+              </button>
+              <button
+                type="button"
+                className="secondary-button"
+                onClick={handleClone}
+                disabled={isBusy || !formState.repoUrl || !formState.localPath}
+              >
+                Clone
+              </button>
+              <button
+                type="button"
+                className="secondary-button"
+                onClick={handleSync}
+                disabled={isBusy || !formState.id}
+              >
+                Sync now
+              </button>
+            </div>
+          </form>
+        </section>
+      </div>
+    </div>
+  );
+};

--- a/src/hooks/useCronEngine.ts
+++ b/src/hooks/useCronEngine.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { CronJob, CronJobRunResult } from '../types/automation';
+import { cronMatches, validateCronExpression } from '../utils/cron';
+import { runCommand } from '../utils/commandRunner';
+
+interface UseCronEngineOptions {
+  onJobRun: (jobId: string, result: CronJobRunResult) => void;
+}
+
+interface UseCronEngineReturn {
+  runJobNow: (jobId: string) => Promise<void>;
+}
+
+export function useCronEngine(
+  jobs: CronJob[],
+  { onJobRun }: UseCronEngineOptions
+): UseCronEngineReturn {
+  const jobsRef = useRef<CronJob[]>(jobs);
+  const lastExecutionRef = useRef<Record<string, string>>({});
+
+  useEffect(() => {
+    jobsRef.current = jobs;
+  }, [jobs]);
+
+  const executeJob = useCallback(
+    async (job: CronJob, trigger: CronJobRunResult['trigger']) => {
+      const timestamp = new Date().toISOString();
+      const result = await runCommand(job.command, {
+        cwd: job.workingDirectory
+      });
+
+      onJobRun(job.id, {
+        ranAt: timestamp,
+        success: result.success,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        code: result.code,
+        trigger,
+        errorMessage: result.errorMessage
+      });
+    },
+    [onJobRun]
+  );
+
+  const checkJobs = useCallback(() => {
+    const now = new Date();
+    const minuteKey = now.toISOString().slice(0, 16);
+
+    for (const job of jobsRef.current) {
+      if (!job.enabled) {
+        continue;
+      }
+
+      if (validateCronExpression(job.cronExpression)) {
+        continue;
+      }
+
+      if (!cronMatches(now, job.cronExpression)) {
+        continue;
+      }
+
+      if (lastExecutionRef.current[job.id] === minuteKey) {
+        continue;
+      }
+
+      lastExecutionRef.current[job.id] = minuteKey;
+      executeJob(job, 'schedule');
+    }
+  }, [executeJob]);
+
+  useEffect(() => {
+    checkJobs();
+    const interval = window.setInterval(checkJobs, 30_000);
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [checkJobs]);
+
+  const runJobNow = useCallback(
+    async (jobId: string) => {
+      const job = jobsRef.current.find((item) => item.id === jobId);
+      if (!job) {
+        return;
+      }
+      await executeJob(job, 'manual');
+    },
+    [executeJob]
+  );
+
+  return { runJobNow };
+}

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -1,0 +1,26 @@
+export type CronJobSource = 'user' | 'project';
+
+export interface CronJob {
+  id: string;
+  name: string;
+  cronExpression: string;
+  command: string;
+  enabled: boolean;
+  workingDirectory?: string;
+  lastRunAt?: string;
+  lastStatus?: 'success' | 'error';
+  lastOutput?: string;
+  lastError?: string;
+  source?: CronJobSource;
+  projectId?: string;
+}
+
+export interface CronJobRunResult {
+  ranAt: string;
+  success: boolean;
+  stdout: string;
+  stderr: string;
+  code: number;
+  trigger: 'schedule' | 'manual';
+  errorMessage?: string;
+}

--- a/src/types/projects.ts
+++ b/src/types/projects.ts
@@ -1,0 +1,21 @@
+export interface ProjectConfig {
+  id: string;
+  name: string;
+  localPath: string;
+  repoUrl: string;
+  defaultBranch: string;
+  personalAccessToken?: string;
+  autoSyncCron?: string;
+  description?: string;
+  lastSyncAt?: string;
+  lastSyncStatus?: 'idle' | 'success' | 'error';
+  lastSyncMessage?: string;
+}
+
+export interface ProjectValidationResult {
+  success: boolean;
+  message: string;
+  defaultBranch?: string;
+  stars?: number;
+  repoExists?: boolean;
+}

--- a/src/utils/commandRunner.ts
+++ b/src/utils/commandRunner.ts
@@ -1,0 +1,140 @@
+export interface CommandRunOptions {
+  cwd?: string;
+}
+
+export interface CommandRunResult {
+  success: boolean;
+  stdout: string;
+  stderr: string;
+  code: number;
+  executedCommand: string;
+  simulated: boolean;
+  errorMessage?: string;
+}
+
+function splitCommandLine(command: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  let quoteChar: '"' | "'" | null = null;
+  let escapeNext = false;
+
+  for (let i = 0; i < command.length; i += 1) {
+    const char = command[i];
+
+    if (escapeNext) {
+      current += char;
+      escapeNext = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      escapeNext = true;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      if (!inQuotes) {
+        inQuotes = true;
+        quoteChar = char as '"' | "'";
+        continue;
+      }
+      if (quoteChar === char) {
+        inQuotes = false;
+        quoteChar = null;
+        continue;
+      }
+    }
+
+    if (!inQuotes && /\s/.test(char)) {
+      if (current) {
+        result.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current) {
+    result.push(current);
+  }
+
+  return result;
+}
+
+export async function runCommand(
+  command: string,
+  options: CommandRunOptions = {}
+): Promise<CommandRunResult> {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return {
+      success: false,
+      stdout: '',
+      stderr: 'Empty command',
+      code: -1,
+      executedCommand: '',
+      simulated: true,
+      errorMessage: 'Empty command'
+    };
+  }
+
+  const args = splitCommandLine(trimmed);
+  if (args.length === 0) {
+    return {
+      success: false,
+      stdout: '',
+      stderr: 'Unable to parse command',
+      code: -1,
+      executedCommand: trimmed,
+      simulated: true,
+      errorMessage: 'Unable to parse command'
+    };
+  }
+
+  const [binary, ...rest] = args;
+  const hasTauri = typeof window !== 'undefined' && Boolean((window as any).__TAURI__);
+
+  if (hasTauri) {
+    try {
+      const shellModule = await import('@tauri-apps/api/shell');
+      const commandInstance = new shellModule.Command(binary, rest, {
+        cwd: options.cwd
+      });
+      const result = await commandInstance.execute();
+
+      return {
+        success: result.code === 0,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        code: result.code,
+        executedCommand: trimmed,
+        simulated: false,
+        errorMessage:
+          result.code === 0 ? undefined : result.stderr || 'Command returned a non-zero exit code'
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        stdout: '',
+        stderr: message,
+        code: -1,
+        executedCommand: trimmed,
+        simulated: false,
+        errorMessage: message
+      };
+    }
+  }
+
+  return {
+    success: true,
+    stdout: `Simulated execution: ${trimmed}`,
+    stderr: '',
+    code: 0,
+    executedCommand: trimmed,
+    simulated: true
+  };
+}

--- a/src/utils/cron.ts
+++ b/src/utils/cron.ts
@@ -1,0 +1,219 @@
+const CRON_RANGES = [
+  { min: 0, max: 59 },
+  { min: 0, max: 23 },
+  { min: 1, max: 31 },
+  { min: 1, max: 12 },
+  { min: 0, max: 6 }
+] as const;
+
+type CronFieldRange = (typeof CRON_RANGES)[number];
+
+const WHITESPACE_REGEX = /\s+/;
+
+function normalize(field: string): string {
+  return field.trim();
+}
+
+function matchCronToken(
+  token: string,
+  value: number,
+  range: CronFieldRange
+): boolean {
+  const normalized = token.trim();
+  if (!normalized) {
+    return false;
+  }
+
+  if (normalized === '*') {
+    return true;
+  }
+
+  const [rangePart, stepPart] = normalized.split('/');
+  const step = stepPart ? parseInt(stepPart, 10) : 1;
+  if (Number.isNaN(step) || step <= 0) {
+    return false;
+  }
+
+  let start = range.min;
+  let end = range.max;
+
+  if (rangePart && rangePart !== '*') {
+    if (rangePart.includes('-')) {
+      const [startStr, endStr] = rangePart.split('-');
+      start = parseInt(startStr, 10);
+      end = parseInt(endStr, 10);
+      if (
+        Number.isNaN(start) ||
+        Number.isNaN(end) ||
+        start < range.min ||
+        end > range.max ||
+        start > end
+      ) {
+        return false;
+      }
+    } else {
+      const exact = parseInt(rangePart, 10);
+      if (
+        Number.isNaN(exact) ||
+        exact < range.min ||
+        exact > range.max
+      ) {
+        return false;
+      }
+      start = exact;
+      end = exact;
+    }
+  }
+
+  if (value < start || value > end) {
+    return false;
+  }
+
+  if (!rangePart || rangePart === '*') {
+    return ((value - range.min) % step) === 0;
+  }
+
+  return ((value - start) % step) === 0;
+}
+
+function matchCronField(
+  field: string,
+  value: number,
+  range: CronFieldRange
+): boolean {
+  const normalized = normalize(field);
+  if (!normalized) {
+    return false;
+  }
+
+  return normalized
+    .split(',')
+    .some(token => matchCronToken(token, value, range));
+}
+
+function validateCronField(field: string, range: CronFieldRange): string | null {
+  const normalized = normalize(field);
+  if (!normalized) {
+    return 'Field cannot be empty';
+  }
+
+  const tokens = normalized.split(',');
+  if (tokens.length === 0) {
+    return 'Field must contain at least one value';
+  }
+
+  for (const token of tokens) {
+    const trimmed = token.trim();
+    if (!trimmed) {
+      return 'Invalid empty token';
+    }
+
+    const [rangePart, stepPart] = trimmed.split('/');
+    if (stepPart) {
+      const step = parseInt(stepPart, 10);
+      if (Number.isNaN(step) || step <= 0) {
+        return `Invalid step value "${stepPart}"`;
+      }
+    }
+
+    if (!rangePart || rangePart === '*') {
+      continue;
+    }
+
+    if (rangePart.includes('-')) {
+      const [startStr, endStr] = rangePart.split('-');
+      const start = parseInt(startStr, 10);
+      const end = parseInt(endStr, 10);
+      if (Number.isNaN(start) || Number.isNaN(end)) {
+        return `Invalid range "${rangePart}"`;
+      }
+      if (start < range.min || end > range.max || start > end) {
+        return `Range "${rangePart}" outside allowed values`;
+      }
+    } else {
+      const exact = parseInt(rangePart, 10);
+      if (Number.isNaN(exact)) {
+        return `Invalid value "${rangePart}"`;
+      }
+      if (exact < range.min || exact > range.max) {
+        return `Value "${rangePart}" out of range`;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function validateCronExpression(expression: string): string | null {
+  if (!expression || !expression.trim()) {
+    return 'Cron expression cannot be empty';
+  }
+
+  const parts = expression.trim().split(WHITESPACE_REGEX).filter(Boolean);
+  if (parts.length !== 5) {
+    return 'Cron expression must have 5 fields (minute hour day month weekday)';
+  }
+
+  for (let i = 0; i < parts.length; i += 1) {
+    const error = validateCronField(parts[i], CRON_RANGES[i]);
+    if (error) {
+      return error;
+    }
+  }
+
+  return null;
+}
+
+export function cronMatches(date: Date, expression: string): boolean {
+  const parts = expression.trim().split(WHITESPACE_REGEX).filter(Boolean);
+  if (parts.length !== 5) {
+    return false;
+  }
+
+  const minute = date.getMinutes();
+  const hour = date.getHours();
+  const dayOfMonth = date.getDate();
+  const month = date.getMonth() + 1;
+  const dayOfWeek = date.getDay();
+
+  const minuteMatch = matchCronField(parts[0], minute, CRON_RANGES[0]);
+  const hourMatch = matchCronField(parts[1], hour, CRON_RANGES[1]);
+  const monthMatch = matchCronField(parts[3], month, CRON_RANGES[3]);
+  const dayOfMonthMatch = matchCronField(parts[2], dayOfMonth, CRON_RANGES[2]);
+  const dayOfWeekMatch = matchCronField(parts[4], dayOfWeek, CRON_RANGES[4]);
+
+  const domWildcard = parts[2] === '*';
+  const dowWildcard = parts[4] === '*';
+  const dayMatch =
+    (domWildcard && dowWildcard) ||
+    (domWildcard && dayOfWeekMatch) ||
+    (dowWildcard && dayOfMonthMatch) ||
+    (dayOfMonthMatch && dayOfWeekMatch);
+
+  return minuteMatch && hourMatch && monthMatch && dayMatch;
+}
+
+export function getNextRun(
+  expression: string,
+  fromDate: Date = new Date(),
+  maxIterations = 60 * 24 * 31
+): Date | null {
+  if (validateCronExpression(expression)) {
+    return null;
+  }
+
+  const start = new Date(fromDate.getTime());
+  start.setSeconds(0, 0);
+  start.setMinutes(start.getMinutes() + 1);
+
+  const candidate = new Date(start.getTime());
+
+  for (let i = 0; i < maxIterations; i += 1) {
+    if (cronMatches(candidate, expression)) {
+      return new Date(candidate.getTime());
+    }
+    candidate.setMinutes(candidate.getMinutes() + 1);
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a reusable cron engine and command runner utilities to schedule local tasks
- extend the global settings modal with tree navigation plus automation and GitHub project management sections
- build dedicated automation and project settings UIs with supporting styles and persistence

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d47c81e16c8333b95172f1770640a1