### PR TITLE
Add AI model galleries and provider settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
   useCallback,
+  useMemo,
   Suspense,
   lazy,
 } from 'react';
@@ -40,6 +41,18 @@ import {
   VideoProviderId,
 } from './utils/videoProviders';
 import { clearVideoCache } from './utils/videoCache';
+import {
+  MODEL_PROVIDER_DEFINITIONS,
+  loadStoredModelProviderConfigs,
+  fetchModelGallery as fetchModelProviderGallery,
+  addInstalledModel,
+  removeInstalledModel,
+  setActiveModel,
+  setProviderInstallPath,
+  getInstalledModelsIndex,
+  persistModelProviderConfigs,
+} from './utils/aiModelProviders';
+import { AiModelProviderId, ModelInfo, ModelProviderConfig } from './types/models';
 import { CronJob, CronJobRunResult } from './types/automation';
 import { ProjectConfig, ProjectValidationResult } from './types/projects';
 import { runCommand, CommandRunResult } from './utils/commandRunner';
@@ -66,6 +79,7 @@ const App: React.FC = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const engineRef = useRef<AudioVisualizerEngine | null>(null);
   const broadcastRef = useRef<BroadcastChannel | null>(null);
+  const initialModelGalleryLoad = useRef(false);
   const [isInitialized, setIsInitialized] = useState(false);
   const [availablePresets, setAvailablePresets] = useState<LoadedPreset[]>([]);
   const [fps, setFps] = useState(60);
@@ -123,6 +137,30 @@ const App: React.FC = () => {
     }
     return defaultVideoProviderSettings;
   });
+
+  const [modelProviderConfigs, setModelProviderConfigs] = useState<Record<AiModelProviderId, ModelProviderConfig>>(() => {
+    return loadStoredModelProviderConfigs();
+  });
+  const [modelGalleryProvider, setModelGalleryProvider] = useState<AiModelProviderId>(() => {
+    const first = MODEL_PROVIDER_DEFINITIONS.find((provider) => provider.supportsGallery);
+    return (first ? first.id : 'huggingface') as AiModelProviderId;
+  });
+  const [modelGalleryQuery, setModelGalleryQuery] = useState('jarvis');
+  const [modelGalleryItems, setModelGalleryItems] = useState<ModelInfo[]>([]);
+  const [isLoadingModels, setIsLoadingModels] = useState(false);
+  const [modelGalleryError, setModelGalleryError] = useState<string | null>(null);
+  const [activeModelKey, setActiveModelKey] = useState<string | null>(() => {
+    try {
+      return localStorage.getItem('activeJarvisModelKey');
+    } catch {
+      return null;
+    }
+  });
+
+  const installedModelsIndex = useMemo(
+    () => getInstalledModelsIndex(modelProviderConfigs),
+    [modelProviderConfigs]
+  );
 
   const [videoGallery, setVideoGallery] = useState<VideoResource[]>(() => {
     try {
@@ -411,6 +449,105 @@ const App: React.FC = () => {
     }
   }, [refreshVideoGallery]);
 
+  const refreshModelGallery = useCallback(
+    async (provider: AiModelProviderId, search: string) => {
+      setIsLoadingModels(true);
+      setModelGalleryError(null);
+      try {
+        const items = await fetchModelProviderGallery({
+          provider,
+          query: search.trim() ? search.trim() : undefined,
+          limit: 24,
+        });
+        setModelGalleryItems(items);
+      } catch (error) {
+        console.error('Model gallery request failed', error);
+        setModelGalleryError(
+          error instanceof Error
+            ? error.message
+            : 'No se pudo cargar la galería de modelos'
+        );
+      } finally {
+        setIsLoadingModels(false);
+      }
+    },
+    []
+  );
+
+  const handleModelProviderChange = useCallback(
+    (provider: AiModelProviderId) => {
+      setModelGalleryProvider(provider);
+      refreshModelGallery(provider, modelGalleryQuery);
+    },
+    [modelGalleryQuery, refreshModelGallery]
+  );
+
+  const handleModelQueryChange = useCallback((value: string) => {
+    setModelGalleryQuery(value);
+  }, []);
+
+  const handleModelRefresh = useCallback(() => {
+    refreshModelGallery(modelGalleryProvider, modelGalleryQuery);
+  }, [modelGalleryProvider, modelGalleryQuery, refreshModelGallery]);
+
+  const handleModelInstall = useCallback(
+    (model: ModelInfo) => {
+      setModelProviderConfigs(prev => addInstalledModel(prev, model));
+      setStatus(`${model.name} instalado desde ${model.provider}`);
+    },
+    []
+  );
+
+  const handleModelActivate = useCallback(
+    (provider: AiModelProviderId, modelId: string) => {
+      setModelProviderConfigs(prev => setActiveModel(prev, provider, modelId));
+      const key = `${provider}:${modelId}`;
+      setActiveModelKey(key);
+      try {
+        localStorage.setItem('activeJarvisModelKey', key);
+      } catch (error) {
+        console.warn('Unable to persist active model key', error);
+      }
+      setStatus(`Modelo ${modelId} activo en Jarvis`);
+    },
+    []
+  );
+
+  const handleModelActivateRequest = useCallback(
+    (model: ModelInfo) => {
+      handleModelActivate(model.provider, model.id);
+    },
+    [handleModelActivate]
+  );
+
+  const handleModelRemove = useCallback(
+    (provider: AiModelProviderId, modelId: string) => {
+      setModelProviderConfigs(prev => removeInstalledModel(prev, provider, modelId));
+      const key = `${provider}:${modelId}`;
+      if (activeModelKey === key) {
+        setActiveModelKey(null);
+        try {
+          localStorage.removeItem('activeJarvisModelKey');
+        } catch (error) {
+          console.warn('Unable to clear active model key', error);
+        }
+      }
+      setStatus(`Modelo ${modelId} eliminado`);
+    },
+    [activeModelKey]
+  );
+
+  const handleModelInstallPathChange = useCallback(
+    (provider: AiModelProviderId, path: string) => {
+      setModelProviderConfigs(prev => {
+        const next = setProviderInstallPath(prev, provider, path);
+        persistModelProviderConfigs(next);
+        return next;
+      });
+    },
+    []
+  );
+
   const handleVideoSettingsChange = useCallback(
     (updates: Partial<VideoPlaybackSettings>) => {
       if (!selectedVideoLayer) return;
@@ -631,6 +768,35 @@ const App: React.FC = () => {
   useEffect(() => {
     refreshVideoGallery();
   }, [refreshVideoGallery]);
+
+  useEffect(() => {
+    if (initialModelGalleryLoad.current) {
+      return;
+    }
+    initialModelGalleryLoad.current = true;
+    refreshModelGallery(modelGalleryProvider, modelGalleryQuery);
+  }, [modelGalleryProvider, modelGalleryQuery, refreshModelGallery]);
+
+  useEffect(() => {
+    const activeFromConfig =
+      (Object.entries(modelProviderConfigs) as [AiModelProviderId, ModelProviderConfig][])
+        .map(([provider, config]) =>
+          config.activeModelId ? `${provider}:${config.activeModelId}` : null
+        )
+        .find((key): key is string => Boolean(key)) || null;
+    if (activeFromConfig !== activeModelKey) {
+      setActiveModelKey(activeFromConfig);
+      try {
+        if (activeFromConfig) {
+          localStorage.setItem('activeJarvisModelKey', activeFromConfig);
+        } else {
+          localStorage.removeItem('activeJarvisModelKey');
+        }
+      } catch (error) {
+        console.warn('Unable to sync active model key', error);
+      }
+    }
+  }, [modelProviderConfigs, activeModelKey]);
 
   useEffect(() => {
     if (!videoProviderSettings.refreshMinutes) return;
@@ -1981,10 +2147,15 @@ const App: React.FC = () => {
         onProjectSync={handleProjectSync}
         onProjectClone={handleProjectClone}
         onProjectValidate={handleProjectValidate}
-        />
-      </Suspense>
+        modelProviderConfigs={modelProviderConfigs}
+        activeModelKey={activeModelKey}
+        onModelInstallPathChange={handleModelInstallPathChange}
+        onModelActivate={handleModelActivate}
+        onModelRemove={handleModelRemove}
+      />
+    </Suspense>
 
-      {/* Modal de galeria de presets */}
+    {/* Modal de galeria de presets */}
       <Suspense fallback={null}>
         <ResourcesModal
           isOpen={isResourcesOpen}
@@ -2017,6 +2188,19 @@ const App: React.FC = () => {
           onRemoveVideoFromLayer={handleRemoveVideoFromLayer}
           onRefreshVideos={() => refreshVideoGallery(true)}
           isRefreshingVideos={isRefreshingVideos}
+          modelProviders={MODEL_PROVIDER_DEFINITIONS}
+          modelGalleryItems={modelGalleryItems}
+          installedModelsIndex={installedModelsIndex}
+          modelGalleryProvider={modelGalleryProvider}
+          modelGalleryQuery={modelGalleryQuery}
+          activeModelKey={activeModelKey}
+          onModelProviderChange={handleModelProviderChange}
+          onModelQueryChange={handleModelQueryChange}
+          onModelRefresh={handleModelRefresh}
+          onModelInstall={handleModelInstall}
+          onModelActivate={handleModelActivateRequest}
+          isLoadingModels={isLoadingModels}
+          modelGalleryError={modelGalleryError}
         />
       </Suspense>
     </div>

--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -12,6 +12,9 @@ import { AutomationSettings } from './settings/AutomationSettings';
 import { ProjectSettings } from './settings/ProjectSettings';
 import { VideoProviderSettings as VideoProviderSettingsSection } from './settings/VideoProviderSettings';
 import { VideoProviderId } from '../utils/videoProviders';
+import ModelProviderSettings from './settings/ModelProviderSettings';
+import { MODEL_PROVIDER_DEFINITIONS } from '../utils/aiModelProviders';
+import { AiModelProviderId, ModelProviderConfig } from '../types/models';
 import { CronJob } from '../types/automation';
 import { ProjectConfig, ProjectValidationResult } from '../types/projects';
 import { CommandRunResult } from '../utils/commandRunner';
@@ -115,6 +118,11 @@ interface GlobalSettingsModalProps {
   onProjectSync: (projectId: string) => Promise<CommandRunResult>;
   onProjectClone: (project: ProjectConfig) => Promise<CommandRunResult>;
   onProjectValidate: (project: ProjectConfig) => Promise<ProjectValidationResult>;
+  modelProviderConfigs: Record<AiModelProviderId, ModelProviderConfig>;
+  activeModelKey: string | null;
+  onModelInstallPathChange: (provider: AiModelProviderId, path: string) => void;
+  onModelActivate: (provider: AiModelProviderId, modelId: string) => void;
+  onModelRemove: (provider: AiModelProviderId, modelId: string) => void;
 }
 
 const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
@@ -193,6 +201,11 @@ const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
   onProjectSync,
   onProjectClone,
   onProjectValidate,
+  modelProviderConfigs,
+  activeModelKey,
+  onModelInstallPathChange,
+  onModelActivate,
+  onModelRemove,
 }) => {
   const [activeTab, setActiveTab] = useState('audio');
 
@@ -239,6 +252,19 @@ const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
             tabId: 'fullscreen',
           },
           { id: 'visual', label: 'Visual tweaks', icon: '🌈', tabId: 'visual' },
+        ],
+      },
+      {
+        id: 'ai-group',
+        label: 'AI & Models',
+        icon: '🧠',
+        children: [
+          {
+            id: 'models',
+            label: 'Model providers',
+            icon: '🤖',
+            tabId: 'models',
+          },
         ],
       },
       {
@@ -411,6 +437,17 @@ const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
                 onRefreshMinutesChange={onVideoRefreshMinutesChange}
                 onQueryChange={onVideoQueryChange}
                 onClearCache={onVideoCacheClear}
+              />
+            )}
+
+            {activeTab === 'models' && (
+              <ModelProviderSettings
+                providers={MODEL_PROVIDER_DEFINITIONS}
+                configs={modelProviderConfigs}
+                activeModelKey={activeModelKey}
+                onInstallPathChange={onModelInstallPathChange}
+                onActivateModel={onModelActivate}
+                onRemoveModel={onModelRemove}
               />
             )}
 

--- a/src/components/ResourcesModal.css
+++ b/src/components/ResourcesModal.css
@@ -597,6 +597,20 @@
   overflow-y: auto;
 }
 
+.gallery-controls-panel--wide {
+  flex: 1;
+  max-width: none;
+  margin-left: 0;
+  border-left: none;
+  background: transparent;
+  padding: 0;
+}
+
+.gallery-controls-panel--wide .model-gallery {
+  min-height: 100%;
+  background: transparent;
+}
+
 .preset-gallery-placeholder {
   display: flex;
   align-items: center;

--- a/src/components/models/ModelGallery.css
+++ b/src/components/models/ModelGallery.css
@@ -1,0 +1,342 @@
+.model-gallery {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  min-height: 100%;
+}
+
+.model-gallery__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.model-gallery__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.model-gallery__tab {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid transparent;
+  border-radius: 999px;
+  color: #e0e0e0;
+  padding: 6px 14px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.model-gallery__tab:hover,
+.model-gallery__tab.active {
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.model-gallery__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.model-gallery__actions input[type='search'] {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 6px 10px;
+  color: #fff;
+  width: 220px;
+  transition: border-color 0.2s ease;
+}
+
+.model-gallery__actions input[type='search']:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.model-gallery__refresh {
+  background: linear-gradient(135deg, #ffb74d, #ff7043);
+  border: none;
+  border-radius: 8px;
+  color: #1b1b1b;
+  font-weight: 600;
+  padding: 7px 14px;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.model-gallery__refresh:hover {
+  transform: translateY(-1px);
+}
+
+.model-gallery__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-left: 4px solid rgba(255, 255, 255, 0.25);
+  background: rgba(0, 0, 0, 0.35);
+  padding: 16px;
+  border-radius: 12px;
+}
+
+.model-gallery__summary h3 {
+  margin: 0 0 4px;
+  color: #fff;
+}
+
+.model-gallery__summary p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 13px;
+}
+
+.model-gallery__summary a {
+  color: #ffcc80;
+  font-size: 13px;
+  text-decoration: none;
+  transition: opacity 0.2s ease;
+}
+
+.model-gallery__summary a:hover {
+  opacity: 0.8;
+}
+
+.model-gallery__grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  width: 100%;
+}
+
+.model-card {
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 340px;
+  position: relative;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.model-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.model-card__thumbnail {
+  height: 160px;
+  background: rgba(255, 255, 255, 0.04);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.model-card__thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.model-card__placeholder {
+  font-size: 48px;
+  color: rgba(255, 255, 255, 0.4);
+  font-weight: 700;
+}
+
+.model-card__meta {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+}
+
+.model-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.model-card__provider {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.model-card__stat {
+  font-variant-numeric: tabular-nums;
+}
+
+.model-card h4 {
+  margin: 0;
+  font-size: 16px;
+  color: #fff;
+  line-height: 1.3;
+}
+
+.model-card__description {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 13px;
+  line-height: 1.5;
+  max-height: 70px;
+  overflow: hidden;
+}
+
+.model-card__details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.model-card__details div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.model-card__details dt {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.5);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.model-card__details dd {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 12px;
+}
+
+.model-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.model-card__tags li {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.model-card__actions {
+  padding: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.model-card__button {
+  width: 100%;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, #ffa726, #fb8c00);
+  color: #1a1a1a;
+  transition: transform 0.2s ease;
+}
+
+.model-card__button:hover {
+  transform: translateY(-1px);
+}
+
+.model-card__button--active {
+  background: linear-gradient(135deg, #4caf50, #2e7d32);
+  color: #fff;
+}
+
+.model-card__cta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.model-card__installed {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.55);
+  text-align: center;
+}
+
+.model-gallery__empty,
+.model-gallery__error {
+  padding: 40px 20px;
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.35);
+  text-align: center;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.model-gallery__error span {
+  display: block;
+  margin-top: 8px;
+}
+
+.model-gallery__retry {
+  margin-top: 16px;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+
+.model-card--skeleton {
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.model-card--skeleton .model-card__thumbnail,
+.model-card--skeleton .model-card__title,
+.model-card--skeleton .model-card__info,
+.model-card--skeleton .model-card__tags {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 0.9;
+  }
+  100% {
+    opacity: 0.5;
+  }
+}
+
+@media (max-width: 720px) {
+  .model-gallery__summary {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .model-gallery__actions {
+    width: 100%;
+  }
+
+  .model-gallery__actions input[type='search'] {
+    flex: 1;
+    width: auto;
+  }
+}

--- a/src/components/models/ModelGallery.tsx
+++ b/src/components/models/ModelGallery.tsx
@@ -1,0 +1,242 @@
+import React from 'react';
+import {
+  AiModelProviderId,
+  InstalledModel,
+  ModelInfo,
+  ModelProviderDefinition,
+} from '../../types/models';
+import { formatBytes } from '../../utils/aiModelProviders';
+import './ModelGallery.css';
+
+interface ModelGalleryProps {
+  providers: ModelProviderDefinition[];
+  provider: AiModelProviderId;
+  models: ModelInfo[];
+  installedIndex: Record<string, InstalledModel>;
+  activeModelKey?: string | null;
+  query: string;
+  isLoading?: boolean;
+  error?: string | null;
+  onProviderChange: (provider: AiModelProviderId) => void;
+  onQueryChange: (value: string) => void;
+  onRefresh: () => void;
+  onInstall: (model: ModelInfo) => void;
+  onActivate: (model: ModelInfo) => void;
+}
+
+const ModelGallery: React.FC<ModelGalleryProps> = ({
+  providers,
+  provider,
+  models,
+  installedIndex,
+  activeModelKey,
+  query,
+  isLoading = false,
+  error,
+  onProviderChange,
+  onQueryChange,
+  onRefresh,
+  onInstall,
+  onActivate,
+}) => {
+  const providerDefinition = providers.find((item) => item.id === provider);
+
+  const renderSkeleton = () => (
+    <div className="model-gallery__grid">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div key={index} className="model-card model-card--skeleton">
+          <div className="model-card__thumbnail" />
+          <div className="model-card__meta">
+            <div className="model-card__title" />
+            <div className="model-card__info" />
+            <div className="model-card__tags" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
+  const renderManualContent = () => (
+    <div className="model-gallery__empty">
+      <h4>Galería no disponible</h4>
+      <p>
+        Este proveedor es únicamente para modelos instalados manualmente. Usa la configuración avanzada
+        para registrar modelos descargados desde otras fuentes.
+      </p>
+    </div>
+  );
+
+  const renderGalleryContent = () => {
+    if (isLoading) {
+      return renderSkeleton();
+    }
+
+    if (error) {
+      return (
+        <div className="model-gallery__error">
+          <strong>No se pudo cargar la galería.</strong>
+          <span>{error}</span>
+          <button type="button" onClick={onRefresh} className="model-gallery__retry">
+            Reintentar
+          </button>
+        </div>
+      );
+    }
+
+    if (!models.length) {
+      return (
+        <div className="model-gallery__empty">
+          <h4>No hay resultados</h4>
+          <p>Prueba con otro término de búsqueda o revisa más tarde.</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="model-gallery__grid">
+        {models.map((model) => {
+          const installed = installedIndex[`${model.provider}:${model.id}`];
+          const isActive = activeModelKey === `${model.provider}:${model.id}`;
+          const primaryFile = model.files?.[0];
+          return (
+            <article key={`${model.provider}-${model.id}`} className="model-card">
+              <div className="model-card__thumbnail">
+                {model.thumbnail ? (
+                  <img src={model.thumbnail} alt={model.name} />
+                ) : (
+                  <span className="model-card__placeholder">{model.name.charAt(0).toUpperCase()}</span>
+                )}
+              </div>
+              <div className="model-card__meta">
+                <div className="model-card__header">
+                  <span className={`model-card__provider model-card__provider--${model.provider}`}>
+                    {providerDefinition?.name ?? model.provider}
+                  </span>
+                  {model.downloads ? (
+                    <span className="model-card__stat">⬇ {model.downloads.toLocaleString()}</span>
+                  ) : null}
+                </div>
+                <h4 title={model.name}>{model.name}</h4>
+                {model.description ? (
+                  <p className="model-card__description">{model.description}</p>
+                ) : null}
+                <dl className="model-card__details">
+                  {model.version ? (
+                    <div>
+                      <dt>Versión</dt>
+                      <dd>{model.version}</dd>
+                    </div>
+                  ) : null}
+                  {model.author ? (
+                    <div>
+                      <dt>Autor</dt>
+                      <dd>{model.author}</dd>
+                    </div>
+                  ) : null}
+                  {model.updatedAt ? (
+                    <div>
+                      <dt>Actualizado</dt>
+                      <dd>{new Date(model.updatedAt).toLocaleDateString()}</dd>
+                    </div>
+                  ) : null}
+                  {primaryFile ? (
+                    <div>
+                      <dt>Formato</dt>
+                      <dd>{primaryFile.format || primaryFile.name.split('.').pop()}</dd>
+                    </div>
+                  ) : null}
+                  <div>
+                    <dt>Tamaño</dt>
+                    <dd>{formatBytes(model.sizeBytes)}</dd>
+                  </div>
+                </dl>
+                {model.tags?.length ? (
+                  <ul className="model-card__tags">
+                    {model.tags.slice(0, 5).map((tag) => (
+                      <li key={tag}>#{tag}</li>
+                    ))}
+                  </ul>
+                ) : null}
+              </div>
+              <div className="model-card__actions">
+                {!installed ? (
+                  <button
+                    type="button"
+                    className="model-card__button"
+                    onClick={() => onInstall(model)}
+                  >
+                    Instalar modelo
+                  </button>
+                ) : (
+                  <div className="model-card__cta">
+                    <button
+                      type="button"
+                      className={`model-card__button ${isActive ? 'model-card__button--active' : ''}`}
+                      onClick={() => onActivate(model)}
+                    >
+                      {isActive ? 'Activo en Jarvis' : 'Activar para Jarvis'}
+                    </button>
+                    <span className="model-card__installed">Instalado el {new Date(installed.installedAt).toLocaleDateString()}</span>
+                  </div>
+                )}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <section className="model-gallery">
+      <header className="model-gallery__header">
+        <div className="model-gallery__tabs">
+          {providers.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className={`model-gallery__tab ${item.id === provider ? 'active' : ''}`}
+              onClick={() => onProviderChange(item.id)}
+            >
+              {item.name}
+            </button>
+          ))}
+        </div>
+        {providerDefinition?.supportsGallery ? (
+          <div className="model-gallery__actions">
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => onQueryChange(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  onRefresh();
+                }
+              }}
+              placeholder="Buscar modelos..."
+            />
+            <button type="button" onClick={onRefresh} className="model-gallery__refresh">
+              Actualizar
+            </button>
+          </div>
+        ) : null}
+      </header>
+
+      {providerDefinition ? (
+        <div className="model-gallery__summary" style={{ borderColor: providerDefinition.accentColor }}>
+          <div>
+            <h3>{providerDefinition.name}</h3>
+            <p>{providerDefinition.description}</p>
+          </div>
+          <a href={providerDefinition.docsUrl} target="_blank" rel="noreferrer">
+            Ver documentación ↗
+          </a>
+        </div>
+      ) : null}
+
+      {providerDefinition?.supportsGallery ? renderGalleryContent() : renderManualContent()}
+    </section>
+  );
+};
+
+export default ModelGallery;

--- a/src/components/settings/ModelProviderSettings.css
+++ b/src/components/settings/ModelProviderSettings.css
@@ -1,0 +1,252 @@
+.model-provider-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.provider-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.provider-card {
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.provider-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 18px;
+  border-left: 4px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.provider-card__header h4 {
+  margin: 0 0 6px;
+  color: #fff;
+}
+
+.provider-card__header p {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.provider-card__header a {
+  color: #ffcc80;
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.provider-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px;
+}
+
+.provider-card__path-input {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.provider-card__path-input input {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 8px 10px;
+  color: #fff;
+}
+
+.provider-card__path-input input:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.provider-card__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(120px, 1fr));
+  gap: 12px;
+}
+
+.provider-card__stats div {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.provider-card__stats strong {
+  font-size: 18px;
+  color: #fff;
+}
+
+.provider-card__stats span {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.provider-card__hint {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.65);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 10px 12px;
+  border-radius: 10px;
+}
+
+.provider-card__models {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.provider-card__model {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 14px;
+  background: rgba(0, 0, 0, 0.25);
+}
+
+.provider-card__model-info {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.provider-card__model-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.provider-card__model-header h4 {
+  margin: 0;
+  color: #fff;
+  font-size: 15px;
+}
+
+.provider-card__badge {
+  background: rgba(76, 175, 80, 0.18);
+  color: #81c784;
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.provider-card__model-info dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 8px;
+}
+
+.provider-card__model-info dt {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.5);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.provider-card__model-info dd {
+  margin: 0;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.85);
+  word-break: break-all;
+}
+
+.provider-card__path {
+  display: block;
+  max-height: 34px;
+  overflow: hidden;
+}
+
+.provider-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.provider-card__tags li {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.provider-card__model-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.provider-card__model-actions button {
+  flex: 1;
+  min-width: 120px;
+  border: none;
+  border-radius: 10px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-weight: 600;
+  background: linear-gradient(135deg, #ffa726, #fb8c00);
+  color: #1a1a1a;
+  transition: transform 0.2s ease;
+}
+
+.provider-card__model-actions button:hover {
+  transform: translateY(-1px);
+}
+
+.provider-card__model-actions button.secondary {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+}
+
+.provider-card__model-actions button.danger {
+  background: linear-gradient(135deg, #ef5350, #c62828);
+  color: #fff;
+}
+
+.provider-card__empty {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.6);
+  padding: 14px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  text-align: center;
+}
+
+@media (max-width: 720px) {
+  .provider-card__stats {
+    grid-template-columns: 1fr;
+  }
+
+  .provider-card__model-actions button {
+    flex: 1 1 100%;
+  }
+}

--- a/src/components/settings/ModelProviderSettings.tsx
+++ b/src/components/settings/ModelProviderSettings.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import {
+  AiModelProviderId,
+  InstalledModel,
+  ModelProviderConfig,
+  ModelProviderDefinition,
+} from '../../types/models';
+import { formatBytes } from '../../utils/aiModelProviders';
+import './ModelProviderSettings.css';
+
+interface ModelProviderSettingsProps {
+  providers: ModelProviderDefinition[];
+  configs: Record<AiModelProviderId, ModelProviderConfig>;
+  activeModelKey?: string | null;
+  onInstallPathChange: (provider: AiModelProviderId, path: string) => void;
+  onActivateModel: (provider: AiModelProviderId, modelId: string) => void;
+  onRemoveModel: (provider: AiModelProviderId, modelId: string) => void;
+}
+
+const formatDate = (value: string) => {
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+};
+
+const ModelProviderSettings: React.FC<ModelProviderSettingsProps> = ({
+  providers,
+  configs,
+  activeModelKey,
+  onInstallPathChange,
+  onActivateModel,
+  onRemoveModel,
+}) => {
+  const renderInstalledModel = (
+    provider: AiModelProviderId,
+    model: InstalledModel,
+    isActive: boolean
+  ) => (
+    <li key={`${provider}-${model.id}`} className="provider-card__model">
+      <div className="provider-card__model-info">
+        <div className="provider-card__model-header">
+          <h4>{model.name}</h4>
+          {isActive ? <span className="provider-card__badge">Activo en Jarvis</span> : null}
+        </div>
+        <dl>
+          <div>
+            <dt>Proveedor</dt>
+            <dd>{provider}</dd>
+          </div>
+          <div>
+            <dt>Tamaño</dt>
+            <dd>{formatBytes(model.sizeOnDisk || model.sizeBytes)}</dd>
+          </div>
+          <div>
+            <dt>Instalado</dt>
+            <dd>{formatDate(model.installedAt)}</dd>
+          </div>
+          <div>
+            <dt>Ubicación</dt>
+            <dd className="provider-card__path" title={model.installedPath}>{model.installedPath}</dd>
+          </div>
+        </dl>
+        {model.tags?.length ? (
+          <ul className="provider-card__tags">
+            {model.tags.slice(0, 6).map((tag) => (
+              <li key={tag}>#{tag}</li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+      <div className="provider-card__model-actions">
+        {!isActive ? (
+          <button type="button" onClick={() => onActivateModel(provider, model.id)}>
+            Activar para Jarvis
+          </button>
+        ) : (
+          <button type="button" className="secondary" onClick={() => onActivateModel(provider, model.id)}>
+            Reasignar
+          </button>
+        )}
+        <button
+          type="button"
+          className="danger"
+          onClick={() => onRemoveModel(provider, model.id)}
+        >
+          Eliminar
+        </button>
+      </div>
+    </li>
+  );
+
+  return (
+    <section className="settings-section model-provider-settings">
+      <h3>🧠 Proveedores de modelos IA</h3>
+      <p className="setting-description">
+        Define dónde se descargan los modelos, consulta qué tienes instalado y activa el modelo en producción
+        para Jarvis.
+      </p>
+
+      <div className="provider-grid">
+        {providers.map((provider) => {
+          const config = configs[provider.id];
+          const installedModels = config?.models || [];
+          const activeKey = config?.activeModelId ? `${provider.id}:${config.activeModelId}` : null;
+          return (
+            <article key={provider.id} className="provider-card">
+              <header className="provider-card__header" style={{ borderColor: provider.accentColor }}>
+                <div>
+                  <h4>{provider.name}</h4>
+                  <p>{provider.description}</p>
+                </div>
+                <a href={provider.docsUrl} target="_blank" rel="noreferrer">
+                  Docs ↗
+                </a>
+              </header>
+
+              <div className="provider-card__body">
+                <label className="provider-card__path-input">
+                  <span>Ruta de instalación</span>
+                  <input
+                    type="text"
+                    value={config?.installPath || ''}
+                    onChange={(event) => onInstallPathChange(provider.id, event.target.value)}
+                    placeholder={provider.defaultInstallPath}
+                  />
+                </label>
+
+                <div className="provider-card__stats">
+                  <div>
+                    <strong>{installedModels.length}</strong>
+                    <span>Modelos instalados</span>
+                  </div>
+                  <div>
+                    <strong>{formatBytes(installedModels.reduce((total, item) => total + (item.sizeOnDisk || item.sizeBytes || 0), 0))}</strong>
+                    <span>Espacio ocupado</span>
+                  </div>
+                </div>
+
+                {provider.supportsGallery ? (
+                  <div className="provider-card__hint">
+                    Descarga directamente desde la galería para mantener los metadatos sincronizados.
+                  </div>
+                ) : (
+                  <div className="provider-card__hint">
+                    Registra aquí modelos instalados manualmente o importados desde otras fuentes.
+                  </div>
+                )}
+
+                {installedModels.length ? (
+                  <ul className="provider-card__models">
+                    {installedModels.map((model) =>
+                      renderInstalledModel(provider.id, model, activeModelKey === `${provider.id}:${model.id}`)
+                    )}
+                  </ul>
+                ) : (
+                  <div className="provider-card__empty">Todavía no hay modelos registrados para este proveedor.</div>
+                )}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default ModelProviderSettings;

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,0 +1,50 @@
+export type AiModelProviderId = 'huggingface' | 'civitai' | 'manual';
+
+export interface ModelFileInfo {
+  id: string;
+  name: string;
+  sizeBytes?: number;
+  downloadUrl: string;
+  primary?: boolean;
+  format?: string;
+  sha256?: string;
+}
+
+export interface ModelInfo {
+  id: string;
+  name: string;
+  description?: string;
+  provider: AiModelProviderId;
+  tags: string[];
+  downloads?: number;
+  updatedAt?: string;
+  version?: string;
+  author?: string;
+  license?: string;
+  sizeBytes?: number;
+  thumbnail?: string;
+  files: ModelFileInfo[];
+}
+
+export interface InstalledModel extends ModelInfo {
+  installedAt: string;
+  installedPath: string;
+  sizeOnDisk?: number;
+}
+
+export interface ModelProviderDefinition {
+  id: AiModelProviderId;
+  name: string;
+  description: string;
+  accentColor: string;
+  docsUrl: string;
+  defaultInstallPath: string;
+  supportsGallery: boolean;
+  requiresApiKey: boolean;
+}
+
+export interface ModelProviderConfig {
+  installPath: string;
+  models: InstalledModel[];
+  activeModelId?: string | null;
+}

--- a/src/utils/aiModelProviders.ts
+++ b/src/utils/aiModelProviders.ts
@@ -1,0 +1,433 @@
+import {
+  AiModelProviderId,
+  InstalledModel,
+  ModelFileInfo,
+  ModelInfo,
+  ModelProviderConfig,
+  ModelProviderDefinition,
+} from '../types/models';
+
+const STORAGE_KEY = 'aiModelProviderConfigs';
+
+const DEFAULT_INSTALL_ROOT = '~/JungleLab/models';
+
+export const MODEL_PROVIDER_DEFINITIONS: ModelProviderDefinition[] = [
+  {
+    id: 'huggingface',
+    name: 'Hugging Face',
+    description: 'Repositorio de modelos open-source con soporte para múltiples tareas.',
+    accentColor: '#ff7b00',
+    docsUrl: 'https://huggingface.co/docs/api-inference/index',
+    defaultInstallPath: `${DEFAULT_INSTALL_ROOT}/huggingface`,
+    supportsGallery: true,
+    requiresApiKey: false,
+  },
+  {
+    id: 'civitai',
+    name: 'Civitai',
+    description: 'Modelos y LORAs creados por la comunidad para Stable Diffusion.',
+    accentColor: '#5b6cff',
+    docsUrl: 'https://docs.civitai.com/api-reference',
+    defaultInstallPath: `${DEFAULT_INSTALL_ROOT}/civitai`,
+    supportsGallery: true,
+    requiresApiKey: false,
+  },
+  {
+    id: 'manual',
+    name: 'Manual / Local',
+    description: 'Modelos instalados manualmente o importados desde otras fuentes.',
+    accentColor: '#26a69a',
+    docsUrl: 'https://docs.jarvis.local/model-import',
+    defaultInstallPath: `${DEFAULT_INSTALL_ROOT}/manual`,
+    supportsGallery: false,
+    requiresApiKey: false,
+  },
+];
+
+const PROVIDER_MAP: Record<AiModelProviderId, ModelProviderDefinition> = MODEL_PROVIDER_DEFINITIONS.reduce(
+  (map, provider) => ({ ...map, [provider.id]: provider }),
+  {} as Record<AiModelProviderId, ModelProviderDefinition>
+);
+
+const ensureConfig = (
+  configs: Partial<Record<AiModelProviderId, ModelProviderConfig>> | null,
+  provider: AiModelProviderId
+): ModelProviderConfig => {
+  const fallback: ModelProviderConfig = {
+    installPath: PROVIDER_MAP[provider].defaultInstallPath,
+    models: [],
+    activeModelId: null,
+  };
+  if (!configs) {
+    return fallback;
+  }
+  const existing = configs[provider];
+  if (!existing) {
+    return fallback;
+  }
+  return {
+    installPath: existing.installPath || PROVIDER_MAP[provider].defaultInstallPath,
+    models: Array.isArray(existing.models) ? existing.models : [],
+    activeModelId: existing.activeModelId ?? null,
+  };
+};
+
+const sanitizePath = (value: string): string => {
+  if (!value) return '';
+  return value.replace(/\\\\/g, '/');
+};
+
+const sanitizeModelName = (value: string): string => {
+  return value
+    .replace(/[<>:"|?*]/g, '_')
+    .replace(/[\\/]/g, '_')
+    .trim();
+};
+
+const computeSizeBytes = (model: ModelInfo | InstalledModel): number => {
+  if (model.sizeBytes && model.sizeBytes > 0) {
+    return model.sizeBytes;
+  }
+  if (model.files?.length) {
+    return model.files.reduce((total, file) => total + (file.sizeBytes || 0), 0);
+  }
+  return 0;
+};
+
+const buildInstalledModel = (
+  model: ModelInfo,
+  installPath: string
+): InstalledModel => {
+  const sizeBytes = computeSizeBytes(model);
+  const sanitizedPath = sanitizePath(installPath || PROVIDER_MAP[model.provider].defaultInstallPath);
+  const normalizedRoot = sanitizedPath.replace(/\\\\/g, '/').replace(/\/+$/, '');
+  const safeName = sanitizeModelName(model.id || model.name);
+  const fullPath = normalizedRoot ? `${normalizedRoot}/${safeName}` : safeName;
+  return {
+    ...model,
+    installedAt: new Date().toISOString(),
+    installedPath: fullPath,
+    sizeOnDisk: sizeBytes || undefined,
+    sizeBytes: sizeBytes || undefined,
+  };
+};
+
+export const loadStoredModelProviderConfigs = (): Record<AiModelProviderId, ModelProviderConfig> => {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      throw new Error('localStorage unavailable');
+    }
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return MODEL_PROVIDER_DEFINITIONS.reduce((acc, provider) => {
+        acc[provider.id] = ensureConfig({}, provider.id);
+        return acc;
+      }, {} as Record<AiModelProviderId, ModelProviderConfig>);
+    }
+    const parsed = JSON.parse(raw);
+    return MODEL_PROVIDER_DEFINITIONS.reduce((acc, provider) => {
+      acc[provider.id] = ensureConfig(parsed, provider.id);
+      return acc;
+    }, {} as Record<AiModelProviderId, ModelProviderConfig>);
+  } catch {
+    return MODEL_PROVIDER_DEFINITIONS.reduce((acc, provider) => {
+      acc[provider.id] = ensureConfig({}, provider.id);
+      return acc;
+    }, {} as Record<AiModelProviderId, ModelProviderConfig>);
+  }
+};
+
+export const persistModelProviderConfigs = (
+  configs: Record<AiModelProviderId, ModelProviderConfig>
+) => {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(configs));
+  } catch (err) {
+    console.warn('Unable to persist model provider configs', err);
+  }
+};
+
+export const setProviderInstallPath = (
+  configs: Record<AiModelProviderId, ModelProviderConfig>,
+  provider: AiModelProviderId,
+  path: string
+): Record<AiModelProviderId, ModelProviderConfig> => {
+  const next: Record<AiModelProviderId, ModelProviderConfig> = { ...configs };
+  const config = ensureConfig(configs, provider);
+  next[provider] = {
+    ...config,
+    installPath: sanitizePath(path) || PROVIDER_MAP[provider].defaultInstallPath,
+  };
+  return next;
+};
+
+export const addInstalledModel = (
+  configs: Record<AiModelProviderId, ModelProviderConfig>,
+  model: ModelInfo
+): Record<AiModelProviderId, ModelProviderConfig> => {
+  const provider = model.provider;
+  const config = ensureConfig(configs, provider);
+  const installed = buildInstalledModel(model, config.installPath);
+  const existingIndex = config.models.findIndex((item) => item.id === installed.id);
+  const nextModels = existingIndex >= 0
+    ? config.models.map((item, index) => (index === existingIndex ? { ...installed, installedAt: item.installedAt } : item))
+    : [...config.models, installed];
+  const next: Record<AiModelProviderId, ModelProviderConfig> = {
+    ...configs,
+    [provider]: {
+      ...config,
+      models: nextModels,
+    },
+  };
+  persistModelProviderConfigs(next);
+  return next;
+};
+
+export const removeInstalledModel = (
+  configs: Record<AiModelProviderId, ModelProviderConfig>,
+  provider: AiModelProviderId,
+  modelId: string
+): Record<AiModelProviderId, ModelProviderConfig> => {
+  const config = ensureConfig(configs, provider);
+  const nextModels = config.models.filter((model) => model.id !== modelId);
+  const nextActive = config.activeModelId === modelId ? null : config.activeModelId ?? null;
+  const next: Record<AiModelProviderId, ModelProviderConfig> = {
+    ...configs,
+    [provider]: {
+      ...config,
+      models: nextModels,
+      activeModelId: nextActive,
+    },
+  };
+  persistModelProviderConfigs(next);
+  return next;
+};
+
+export const setActiveModel = (
+  configs: Record<AiModelProviderId, ModelProviderConfig>,
+  provider: AiModelProviderId,
+  modelId: string | null
+): Record<AiModelProviderId, ModelProviderConfig> => {
+  const config = ensureConfig(configs, provider);
+  const existing = config.models.find((model) => model.id === modelId);
+  const next: Record<AiModelProviderId, ModelProviderConfig> = {
+    ...configs,
+    [provider]: {
+      ...config,
+      activeModelId: existing ? modelId : null,
+    },
+  };
+  persistModelProviderConfigs(next);
+  return next;
+};
+
+export const getInstalledModelsIndex = (
+  configs: Record<AiModelProviderId, ModelProviderConfig>
+): Record<string, InstalledModel> => {
+  const index: Record<string, InstalledModel> = {};
+  (Object.keys(configs) as AiModelProviderId[]).forEach((provider) => {
+    const config = ensureConfig(configs, provider);
+    config.models.forEach((model) => {
+      index[`${provider}:${model.id}`] = model;
+    });
+  });
+  return index;
+};
+
+type FetchOptions = {
+  provider: AiModelProviderId;
+  query?: string;
+  limit?: number;
+  signal?: AbortSignal;
+};
+
+const parseJsonResponse = async <T>(response: Response): Promise<T> => {
+  const contentType = response.headers.get('content-type') || '';
+  const textBody = await response.text();
+  if (!response.ok) {
+    throw new Error(textBody || `Request failed with status ${response.status}`);
+  }
+  if (!contentType.includes('application/json')) {
+    try {
+      return JSON.parse(textBody) as T;
+    } catch {
+      throw new Error('El proveedor devolvió una respuesta no válida (JSON)');
+    }
+  }
+  try {
+    return JSON.parse(textBody) as T;
+  } catch (error) {
+    throw new Error('Error al parsear la respuesta JSON del proveedor');
+  }
+};
+
+interface HuggingFaceResponseItem {
+  modelId: string;
+  id?: string;
+  name?: string;
+  author?: string;
+  likes?: number;
+  downloads?: number;
+  tags?: string[];
+  pipeline_tag?: string;
+  library_name?: string;
+  lastModified?: string;
+  createdAt?: string;
+  siblings?: { rfilename: string; size?: number }[];
+  cardData?: {
+    summary?: string;
+    license?: string;
+    thumbnail?: string;
+  };
+}
+
+interface CivitaiResponseItem {
+  id: number;
+  name: string;
+  description?: string;
+  tags?: string[];
+  stats?: {
+    downloadCount?: number;
+  };
+  modelVersions?: Array<{
+    id: number;
+    name: string;
+    baseModel?: string;
+    updatedAt?: string;
+    trainedWords?: string[];
+    files?: Array<{
+      id: number;
+      name: string;
+      sizeKB?: number;
+      type?: string;
+      primary?: boolean;
+      downloadUrl: string;
+      hashes?: {
+        SHA256?: string;
+      };
+    }>;
+    images?: Array<{
+      url: string;
+    }>;
+  }>;
+  creator?: {
+    username?: string;
+  };
+}
+
+const fetchFromHuggingFace = async (
+  options: FetchOptions
+): Promise<ModelInfo[]> => {
+  const url = new URL('https://huggingface.co/api/models');
+  if (options.query) {
+    url.searchParams.set('search', options.query);
+  }
+  if (options.limit) {
+    url.searchParams.set('limit', String(options.limit));
+  }
+  url.searchParams.set('sort', 'downloads');
+  const response = await fetch(url.toString(), {
+    signal: options.signal,
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+  const data = await parseJsonResponse<HuggingFaceResponseItem[]>(response);
+  return data.map<ModelInfo>((item) => {
+    const files: ModelFileInfo[] = (item.siblings || []).map((file) => ({
+      id: file.rfilename,
+      name: file.rfilename,
+      sizeBytes: file.size,
+      downloadUrl: `https://huggingface.co/${item.modelId}/resolve/main/${file.rfilename}`,
+      format: file.rfilename.split('.').pop(),
+    }));
+    const sizeBytes = files.reduce((total, file) => total + (file.sizeBytes || 0), 0) || undefined;
+    return {
+      id: item.modelId,
+      name: item.name || item.modelId.split('/').pop() || item.modelId,
+      description: item.cardData?.summary,
+      provider: 'huggingface',
+      tags: item.tags || (item.pipeline_tag ? [item.pipeline_tag] : []),
+      downloads: item.downloads,
+      updatedAt: item.lastModified || item.createdAt,
+      author: item.author,
+      license: item.cardData?.license,
+      sizeBytes,
+      thumbnail: item.cardData?.thumbnail,
+      version: item.library_name,
+      files,
+    };
+  });
+};
+
+const fetchFromCivitai = async (
+  options: FetchOptions
+): Promise<ModelInfo[]> => {
+  const url = new URL('https://civitai.com/api/v1/models');
+  if (options.query) {
+    url.searchParams.set('query', options.query);
+  }
+  url.searchParams.set('limit', String(options.limit ?? 24));
+  const response = await fetch(url.toString(), {
+    signal: options.signal,
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+  const data = await parseJsonResponse<{ items: CivitaiResponseItem[] }>(response);
+  return (data.items || []).map<ModelInfo>((item) => {
+    const primaryVersion = item.modelVersions?.[0];
+    const files: ModelFileInfo[] = (primaryVersion?.files || []).map((file) => ({
+      id: String(file.id),
+      name: file.name,
+      sizeBytes: typeof file.sizeKB === 'number' ? file.sizeKB * 1024 : undefined,
+      downloadUrl: file.downloadUrl,
+      primary: file.primary,
+      format: file.type,
+      sha256: file.hashes?.SHA256,
+    }));
+    const thumbnail = primaryVersion?.images?.[0]?.url;
+    const sizeBytes = files.reduce((total, file) => total + (file.sizeBytes || 0), 0) || undefined;
+    return {
+      id: String(item.id),
+      name: item.name,
+      description: item.description,
+      provider: 'civitai',
+      tags: item.tags || [],
+      downloads: item.stats?.downloadCount,
+      updatedAt: primaryVersion?.updatedAt,
+      author: item.creator?.username,
+      sizeBytes,
+      version: primaryVersion?.name,
+      thumbnail,
+      files,
+    };
+  });
+};
+
+export const fetchModelGallery = async (
+  options: FetchOptions
+): Promise<ModelInfo[]> => {
+  if (options.provider === 'manual') {
+    return [];
+  }
+  if (options.provider === 'huggingface') {
+    return fetchFromHuggingFace(options);
+  }
+  if (options.provider === 'civitai') {
+    return fetchFromCivitai(options);
+  }
+  return [];
+};
+
+export const formatBytes = (bytes?: number): string => {
+  if (!bytes || bytes <= 0) return '—';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const idx = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, idx);
+  return `${value.toFixed(value >= 10 || idx === 0 ? 0 : 1)} ${units[idx]}`;
+};
+


### PR DESCRIPTION
## Summary
- add a reusable AI model gallery with consistent card layout, search, and install/activate actions across providers
- provide a dedicated model provider settings panel showing install paths, installed models, disk usage, and Jarvis activation controls
- introduce shared model provider utilities for Hugging Face, Civitai, and manual installs with resilient download metadata parsing and persistence

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d6aad62bd4833384dbd6b28b975a9a